### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -116,7 +116,7 @@ Here a code sample for attaching a file to mail:
 
    	// Create the attachment
    	// * Note that you can technically leave the content-type parameter out
-   $attachment = Swift_Attachment::fromPath('/path/to/image.jpg', 'image/jpeg');
+   $attachment = \Swift_Attachment::fromPath('/path/to/image.jpg', 'image/jpeg');
 
    	// (optional) setting the filename
    $attachment->setFilename('cool.jpg');


### PR DESCRIPTION
I don't know if this is "clean", but in TYPO3 CMS 6.2.3 I have to prepend a backslash, for extbase/fluid to be able to resolve the class Swift_Attachment…
