### PR TITLE
Fix extension builder directory structure

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -297,7 +297,7 @@ Configuration/TCA/Overrides
 Documentation
   Contains the manual in reStructuredText format (:ref:`read more on the topic <extension-documentation>`).
 
-Resources/Private/Languages
+Resources/Private/Language
   XLIFF files for localized labels.
 
 Resources/Private/Layouts


### PR DESCRIPTION
Extension Builder creates Resources/Private/Language not Resources/Private/Languages.