### PR TITLE
[TASK] Remove loose reference to TYPO3 4.5

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -113,7 +113,7 @@ mbox
 How to create and send mails
 ============================
 
-This shows how to generate and send a mail in TYPO3 (starting with 4.5)::
+This shows how to generate and send a mail in TYPO3::
 
    // Create the message
    $mail = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Mail\\MailMessage');


### PR DESCRIPTION
This possibly misleading reference was mentioned on slack. People could misunderstand the reference "that's the way since 4.5" as being able to use the code literally without changes even on 4.5. Since the file header already informs about the introduction of the Mail API, just drop it here.