### PR TITLE
Fix example for adding a message to the queue

### DIFF
--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -76,7 +76,8 @@ or render it on your own where ever you want.
 This example adds the flash message at the top of modules when
 rendering the next request::
 
-   $messageQueue = $objectManager->get('\TYPO3\CMS\Core\Messaging\FlashMessageQueue');
+   $flashMessageService = $this->objectManager->get(FlashMessageService::class);
+   $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
    $messageQueue->addMessage($message);
 
 The message is added to the queue and then the template class calls


### PR DESCRIPTION
You can't directly get the FlashMessageQueue by using the objectManager. You need to use the FlashMessageService.
Otherwise you will get an exception saying "not a correct info array of constructor dependencies was passed!" that is not helpful at all.