### PR TITLE
Add working link for Swiftmailer in general

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -228,7 +228,7 @@ available methods,
 
 .. seealso::
 
-   - `Swiftmailer: General <http://swiftmailer.org/docs/>`__
+   - `Swiftmailer: General <http://swiftmailer.org/docs/index.html>`__
 
    - `Swiftmailer: Content, attachments, basic headers
      <http://swiftmailer.org/docs/messages>`__


### PR DESCRIPTION
http://swiftmailer.org/docs/ is a 404