### PR TITLE
[TASK] Propose existing ext for reading db-logs

### DIFF
--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -47,7 +47,7 @@ logTable  no         Database table  :code:`sys_log`
    The Admin Tools > Log module is not adapted to the records written by the
    :code:`DatabaseWriter` into the :code:`sys_log` table. If you write such records
    there, you will not be able to see them using that module. A tool for viewing
-   such records in the TYPO3 backend is currently missing.
+   such records in the TYPO3 backend can be found here: https://github.com/vertexvaar/VerteXVaaR.Logs.
 
 
 .. _logging-writers-file:


### PR DESCRIPTION
Add a hyperlink to an extension that is able to read logs written by the DatabaseWriter.