### PR TITLE
fixed typo "andSelect()" in Heading to "addSelect()"

### DIFF
--- a/Documentation/Database/QueryBuilder/Index.rst
+++ b/Documentation/Database/QueryBuilder/Index.rst
@@ -52,7 +52,7 @@ Most methods of the `QueryBuilder` return `$this` and can be chained::
 
 .. _database-query-builder-select:
 
-select() and andSelect()
+select() and addSelect()
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Create a `SELECT` query.


### PR DESCRIPTION
The correct method name is "addSelect" as in description text stated.