### PR TITLE
Add a hint for Galera Cluster users

### DIFF
--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -67,6 +67,11 @@ Example of a CREATE TABLE statement for logTable:
    );
 
 
+.. warning::
+
+   If you are using a MariaDB Galera Cluster you should definitely add a primary key field
+   to the database definition, since it is required by Galera (this can be a normal `uid` field as known from other tables):
+   `MariaDB Galera Cluster - Known Limitations <https://mariadb.com/kb/en/mariadb/mariadb-galera-cluster-known-limitations/>`__.
 
 .. _logging-writers-file:
 


### PR DESCRIPTION
MariaDB Galera Cluster is used more often in for TYPO3 but there are a few snares one easily runs into.
Adds a hint for MariaDB Galera Cluster users that they have to add a PK field manually so they will be on the safe side.