### PR TITLE
Update link to log reader extension EXT:logs

### DIFF
--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -44,7 +44,7 @@ logTable  no         Database table  :code:`sys_log`
    there, you will not be able to see them using that module.
 
 *Tip:* There's a tool for viewing such records in the TYPO3 backend at
-`github.com/vertexvaar <https://github.com/vertexvaar/VerteXVaaR.Logs>`__.
+`github.com/vertexvaar/logs <https://github.com/vertexvaar/logs>`__.
 
 Example of a CREATE TABLE statement for logTable:
 


### PR DESCRIPTION
I renamed the repository on github to match the extensions name. There is a redirect from the old to the new address by github but we shouldn't rely on that.