### PR TITLE
Improve cache usage code example

### DIFF
--- a/Documentation/CachingFramework/Developer/Index.rst
+++ b/Documentation/CachingFramework/Developer/Index.rst
@@ -76,15 +76,16 @@ Here is some example code::
 
        protected function getCachedMagic() {
            $cacheIdentifier = $this->calculateCacheIdentifier();
+           $cache = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('myext_mycache');
 
            // If $entry is null, it hasn't been cached. Calculate the value and store it in the cache:
-           if (($entry = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('myext_mycache')->get($cacheIdentifier)) === FALSE) {
+           if (($entry = $cache->get($cacheIdentifier)) === FALSE) {
                $entry = $this->calculateMagic();
 
                // [calculate lifetime and assigned tags]
 
                // Save value in cache
-               GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('myext_mycache')->set($cacheIdentifier, $entry, $tags, $lifetime);
+               $cache->set($cacheIdentifier, $entry, $tags, $lifetime);
            }
            return $entry;
        }


### PR DESCRIPTION
The code shown as an example for the usage of the cache has some errors in it. I didn't want to overdo it but just remove the duplicate code by extracting the cache frontend to a variable.