### PR TITLE
[TASK] Explain filename in FileWriter

### DIFF
--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -86,12 +86,15 @@ appended with a hash, that depends on the encryption key.
 If :code:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['generateApacheHtaccess']` is set,
 an :file:`.htaccess` file is added to the directory.
 It protects your log files from being accessed from the web.
+If the log file is not set, then TYPO3 will use a filename containing a random hash,
+like :code:`typo3temp/logs/typo3_7ac500bce5.log`.
 
-=======  =========  ================  ===========================================
+=======  =========  ================  ===============================================
 Option   Mandatory  Description       Default
-=======  =========  ================  ===========================================
-logFile  no         Path to log file  :file:`typo3temp/logs/typo3_7ac500bce5.log`
-=======  =========  ================  ===========================================
+=======  =========  ================  ===============================================
+logFile  no         Path to log file  :code:`typo3temp/logs/typo3_<hash>.log`, 
+                                      eg: :file:`typo3temp/logs/typo3_7ac500bce5.log`
+=======  =========  ================  ===============================================
 
 
 .. _logging-writers-php:


### PR DESCRIPTION
Explain usage of the random hash in the default filename
(see https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.4/Breaking-52705-DefaultLogConfigurationIsChanged.html)