### PR TITLE
[TASK] Logging example: Change filename

### DIFF
--- a/Documentation/ApiOverview/Logging/Index.rst
+++ b/Documentation/ApiOverview/Logging/Index.rst
@@ -57,8 +57,11 @@ and pass the severity level:
       'This is an utter failure!'
    );
 
+TYPO3 has the :ref:`FileWriter <filewriter>` enabled by default,
+so all log entries are written to a file. If the filename is not set,
+then the file will contain a hash like :code:`typo3temp/logs/typo3_<hash>.log`,
+eg: :file:`typo3temp/logs/typo3_7ac500bce5.log`.
 
-By default the log entries are written to file :file:`typo3temp/logs/typo3.log`.
 A sample output looks like this::
 
    Fri, 08 Mar 2013 09:45:00 +0100 [INFO] request="5139a50bee3a1" component="TYPO3.Examples.Controller.DefaultController": Everything went fine.


### PR DESCRIPTION
The default filename is not »typo3temp/logs/typo3.log« anymore,
see Breaking Change https://docs.typo3.org/typo3cms/extensions/core/Changelog/7.4/Breaking-52705-DefaultLogConfigurationIsChanged.html

Explain hash schema instead.