### PR TITLE
add file ext_tables.php

### DIFF
--- a/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
+++ b/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
@@ -19,7 +19,7 @@ global array. The keys in this array are class names and the values are the abso
 paths to these class. The class must have a :code:`proc()` method.
 
 Here is some code from the "examples" extension, to register the "pierror"
-plugin with the wizard. First of all, the class is declared:: in the file :file:`ext_tables.php`
+plugin with the wizard. First of all, the class is declared in :file:`ext_tables.php`::
 
    // Add "pierror" plugin to new element wizard
    if (TYPO3_MODE == 'BE') {

--- a/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
+++ b/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
@@ -19,7 +19,7 @@ global array. The keys in this array are class names and the values are the abso
 paths to these class. The class must have a :code:`proc()` method.
 
 Here is some code from the "examples" extension, to register the "pierror"
-plugin with the wizard. First of all, the class is declared::
+plugin with the wizard. First of all, the class is declared:: in the file :file:`ext_tables.php`
 
    // Add "pierror" plugin to new element wizard
    if (TYPO3_MODE == 'BE') {


### PR DESCRIPTION
It is important to know exactly where the PHP code has to be inserted:

$TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['tx_examples_pierror_wizicon'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'pierror/class.tx_examples_pierror_wizicon.php';