### PR TITLE
[TASK] Fix HTTP code example

### DIFF
--- a/Documentation/ApiOverview/Http/Index.rst
+++ b/Documentation/ApiOverview/Http/Index.rst
@@ -60,7 +60,7 @@ The `RequestFactory` class can be used like this:
    $response = $requestFactory->request($url, 'GET', $additionalOptions);
    // Get the content as a string on a successful request
    if ($response->getStatusCode() === 200) {
-      if ($response->getHeader('Content-Type') === 'text/html') {
+      if (strpos($response->getHeaderLine('Content-Type'), 'text/html') === 0) {
          $content = $response->getBody()->getContents();
       }
    }


### PR DESCRIPTION
`Psr\Http\Message\ResponseInterface::getHeader()` returns an array with the parsed header, thus we should use `Psr\Http\Message\ResponseInterface::getHeaderLine()` to get the full header.

As the `type/subtype` may be followed by a parameter (separated by `;`) we should check if the header line starts with the desired content type instead of matching it fully.

See: https://www.w3.org/Protocols/rfc1341/4_Content-Type.html