### PR TITLE
[BUGFIX] Fix page/user TSconfig directory rendering

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -275,11 +275,11 @@ Classes/ViewHelpers
   Helper classes used in the views.
 
 Configuration/TsConfig/Page
-  Page TSconfig, see `TSconfig Reference <https://docs.typo3.org/typo3cms/TSconfigReference/PageTsconfig/>`_.
+  Page TSconfig, see :ref:`chapter 'Page TSconfig' in the TSconfig Reference <t3tsconfig:PageTSconfig>`.
   Files should have the file extension :file:`.tsconfig`.
   
 Configuration/TsConfig/User
-  User TSconfig, see `TSconfig Reference <https://docs.typo3.org/typo3cms/TSconfigReference/UserTsconfig/>`_.
+  User TSconfig, see :ref:`chapter 'User TSconfig' in the TSconfig Reference <t3tsconfig:UserTSconfig>`.
   Files should have the file extension :file:`.tsconfig`.
 
 Configuration/TypoScript

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -275,8 +275,11 @@ Classes/ViewHelpers
   Helper classes used in the views.
 
 Configuration/TsConfig/Page
+  Page TSconfig, see `TSconfig Reference <https://docs.typo3.org/typo3cms/TSconfigReference/PageTsconfig/>`_.
+  Files should have the file extension :file:`.tsconfig`.
+  
 Configuration/TsConfig/User
-  Page and User TSconfig, see `TSconfig Reference <https://docs.typo3.org/typo3cms/TSconfigReference/>`_.
+  User TSconfig, see `TSconfig Reference <https://docs.typo3.org/typo3cms/TSconfigReference/UserTsconfig/>`_.
   Files should have the file extension :file:`.tsconfig`.
 
 Configuration/TypoScript


### PR DESCRIPTION
Right now these are rendered like this:

![image](https://user-images.githubusercontent.com/5037116/29126255-1b41475a-7d1e-11e7-9416-f99db285c61e.png)

Hopefully splitting them fixes the rendering.