### PR TITLE
Wrong calculation for E_RECOVERABLE_ERROR | E_USER_DEPRECATED

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
@@ -306,7 +306,7 @@ Typical in TYPO3 for production:
 .. code-block:: none
 
 
-   20408                      SYS/exceptionalErrors   = E_RECOVERABLE_ERROR | E_USER_DEPRECATED
+   20480                      SYS/exceptionalErrors   = E_RECOVERABLE_ERROR | E_USER_DEPRECATED
 
 
 Typical in TYPO3 for development:


### PR DESCRIPTION
Wrong calculation or typo corrected:
4096 (`E_RECOVERABLE_ERROR`) + 16384 (`E_USER_DEPRECATED`) = 20480