### PR TITLE
Minor changes

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -15,11 +15,11 @@ Introduction
 Overview
 --------
 
-TYPO3 is known for its extensibility. However to really benefit from
-this power, a complete documentation is needed. "Core APIs" and its
+TYPO3 is known for its extensibility. To really benefit from
+this power, a complete documentation is needed: "Core APIs" and its
 companion, "Inside TYPO3", aim to provide such information to
 developers and administrators. Not all areas are covered with the same
-amount of details, but at least some pointers are provided.
+amount of detail, but at least some pointers are provided.
 
 "Inside TYPO3" contains the overall introduction to the architecture
 of the TYPO3 core. It also contains API descriptions to a certain
@@ -29,14 +29,14 @@ subjects more closely related to development.
 
 These documents do *not* contain any significant information about
 the frontend of TYPO3. Creating templates, setting up TypoScript
-objects etc. is not the scope of these documents; they are about the
+objects etc. is not the scope of these documents; they address the
 *backend* part of the core only.
 
 The TYPO3 Documentation Team hopes that these two documents, "Inside TYPO3" and
 "TYPO3 Core APIs", will form a complete picture of the TYPO3 Core
-architecture, the backend and be the reference of choice in your work
+architecture and the backend. They will hopefully be the reference of choice in your work
 with TYPO3. It took Kasper more than a year to get the first version
-published and we've tried to maintain it as best we could.
+published and we've tried to maintain it as best as we could.
 
 
 .. _what-s-new:


### PR DESCRIPTION
Minor changes in wording. 
The What's new section is irritating as it starts with "This version is updated for TYPO3 CMS 6.2." So I (and most likely other readers) wondered if this docu is up to date. I recommend to remove it.