### PR TITLE
Changes description of Plugins

### DIFF
--- a/Documentation/ExtensionArchitecture/Introduction/Index.rst
+++ b/Documentation/ExtensionArchitecture/Introduction/Index.rst
@@ -16,9 +16,7 @@ Manager (EM) inside TYPO3 and the online TYPO3 Extension Repository
 additions to TYPO3. The main types are:
 
 - **Plugins** which play a role on the website itself, e.g. a discussion
-  board, guestbook, shop, etc. It is normally enclosed in a PHP class
-  and invoked through a USER or USER\_INT cObject from TypoScript. A
-  plugin is an extension in the frontend.
+  board, guestbook, shop, etc. Therefore plugins are content elements, that can be placed on a page like a text element or an image.
 
 - **Modules** are backend applications which have their own entry in the
   main menu. They require a backend login and work inside the framework


### PR DESCRIPTION
The old plugin description seem to match for pi base, but not for extbase. 
I pilfered the description from https://docs.typo3.org/typo3cms/ExtbaseFluidBook/4-FirstExtension/7-configuring-the-plugin.html