### PR TITLE
Removed --add-drop-table because it breaks extensions

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -134,10 +134,10 @@ extensions with the name prefix "ext\_".
 
          .. code-block:: csh
 
-            mysqldump --password=[password] [database name] [tablename] --add-drop-table > ./ext_tables_static.sql
+            mysqldump --password=[password] [database name] [tablename] > ./ext_tables_static.sql
 
-         :code:`--add-drop-table` will make sure to include a DROP TABLE
-         statement so any data is inserted in a fresh table.
+         :code: you might want to add a `TRUNCATE TABLE [tablename]` to the exported data if you want to import them freshly
+         its NOT adviced to have DROP TABLE statements in this file because it breaks the ability of other extensions to extend your table
 
          |
 


### PR DESCRIPTION
DROP TABLE breaks the Possiblity of other Extensions to Extend the Tables of extension it was discussed here in length:

 https://typo3.slack.com/archives/C07NARQGY/p1510322140000343