### PR TITLE
Add a warning that static data should not be Extended

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -137,7 +137,7 @@ extensions with the name prefix "ext\_".
             mysqldump --password=[password] [database name] [tablename] --add-drop-table > ./ext_tables_static.sql
 
          :code:`--add-drop-table` will make sure to include a DROP TABLE
-         statement so any data is inserted in a fresh table. 
+         statement so any data is inserted in a fresh table.
 
          |
 
@@ -151,7 +151,7 @@ extensions with the name prefix "ext\_".
          .. warning::
          
             Static data is not meant to be extended by other extensions. On re-import 
-            all extended fields and data is lost due to DROP TABLE statements.
+            all extended fields and data is lost due to `DROP TABLE` statements.
             
 
  - :Filename: ext\_typoscript\_constants.txt

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -150,8 +150,8 @@ extensions with the name prefix "ext\_".
            
          .. warning::
          
-            Static data is not meant to be extended by other Extensions. On re-import 
-            all extended fields and data is lost.
+            Static data is not meant to be extended by other extensions. On re-import 
+            all extended fields and data is lost due to DROP TABLE statements.
             
 
  - :Filename: ext\_typoscript\_constants.txt

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -137,7 +137,7 @@ extensions with the name prefix "ext\_".
             mysqldump --password=[password] [database name] [tablename] --add-drop-table > ./ext_tables_static.sql
 
          :code:`--add-drop-table` will make sure to include a DROP TABLE
-         statement so any data is inserted in a fresh table.
+         statement so any data is inserted in a fresh table. 
 
          |
 
@@ -147,6 +147,12 @@ extensions with the name prefix "ext\_".
             The table structure of static tables needs to be in the
             ext\_tables.sql file as well - otherwise an installed static table
             will be reported as being in excess in the EM!
+           
+         .. warning::
+         
+            Static data is not meant to be extended by other Extensions. On re-import 
+            all extended fields and data is lost.
+            
 
  - :Filename: ext\_typoscript\_constants.txt
    :Description:


### PR DESCRIPTION
This warning makes clear that data Loss is expected if you extend static data tables