### PR TITLE
[TASK] Refresh naming conventions

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -170,7 +170,7 @@ Create a `DELETE FROM` query. The method requires the table name to drop data fr
    $affectedRows = $queryBuilder
       ->delete('tt_content')
       ->where(
-         $queryBuilder->expr()->eq('bodytext', $this->createNamedParameter('klaus'))
+         $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus'))
       )
       ->execute();
 

--- a/Documentation/ApiOverview/JavaScript/Index.rst
+++ b/Documentation/ApiOverview/JavaScript/Index.rst
@@ -9,7 +9,7 @@
 JavaScript in TYPO3
 ===================
 
-Some thid-party JavaScript libraries are packaged with the TYPO3 source code.
+Some third-party JavaScript libraries are packaged with the TYPO3 source code.
 The TYPO3 backend itself relies on quite a lot of JavaScript to do its job.
 The topic of this chapter is to present how to use JavaScript properly
 with TYPO3, in particular in the backend. It presents the most important

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -151,7 +151,7 @@ single quotes. Thus the following code is correct::
 
 
 There is no need to use :code:`require()` or :code:`include()` statements. All classes that follow
-namespace conventions will automatically located and included by the autoloader.
+namespace conventions will automatically be located and included by the autoloader.
 
 
 .. _namespaces-references:

--- a/Documentation/ExtensionArchitecture/ExtendingTca/Examples/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Examples/Index.rst
@@ -173,7 +173,7 @@ The result is the following:
 
 .. note::
 
-   Obviously this new field will no magically exclude a content element
+   Obviously this new field will now magically exclude a content element
    from being printed. For it to have any effect, it must be used during
    the rendering by modifying the TypoScript used to render the
    "tt\_content" table. Although this is outside the scope of this

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -36,7 +36,7 @@ use for specific functionality. For example, if a svg logo of your extension
 is placed at :file:`Resources/Public/Icons/Extension.svg`, the extension manager
 will show that image.
 
-Nearly none of the are required, but for example you can not have a TYPO3
+Nearly none of these are required, but for example you can not have a TYPO3
 extension recognized by TYPO3 without the :file:`ext_emconf.php` file etc. You
 can read more details like that in the table below.
 

--- a/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
+++ b/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
@@ -79,7 +79,7 @@ Abbreviations
    
 
 Public extensions
-   1. Public extensions are available from the TER.
+   1. Public extensions are available from the TER_ or via Packagist_, private extensions are not published to the TER or Packagist.
    
    2. The *extkey* is made up of alphanumeric characters and underscores only
       and should start with a letter.
@@ -91,45 +91,17 @@ Public extensions
       
    4. Database tablenames look like 'tx\_' + *extkey* (without underscores) + '\_specification'.
    
-      **Examples:** tx\_coolshop\_products, tx\_coolshop\_categories, tx\_coolshop\_more\_categories 
+      **Examples:** tx\_coolshop\_products, tx\_coolshop\_categories, tx\_coolshop\_more\_categories, tx\_coolshop\_domain\_model\_tag
 
-Private extensions
-   1. Private extensions are not uploaded to the TER.
-   
-   2. The *extkey* is made up of alphanumeric characters and underscores only
-      and starts with the string 'user\_'.
-   
-      **Example:** user\_my\_shop
-
-   3. Database tablenames look like *extkey* + '\_specification'.
-   
-      **Examples:** user\_my\_shop\_products, user\_my\_shop\_categories
-
-Public backend modules
+Backend modules
    1. The *modkey* is made up of alphanumeric characters only. It does not
       contain underscores and starts with a letter.
    
       **Example:** coolshop
 
-   2. ((correct?))   
-      Database tablenames look like 'tx' (no underscore) + *modkey* + '\_specification'.
-   
-      **Examples:** txcoolshop\_products, txcoolshop\_categories, txcoolshop\_more\_categories
-
-Private backend modules
-   1. The *modkey* is made up of alphanumeric characters only. It does not
-      contain underscores and starts with a letter.
-  
-      **Example:** uMyCoolShop
-
-   2. ((correct?))
-      Database tablenames look like 'u' (no underscore) + *modkey* (no underscores) + '\_specification'.
-   
-      **Examples:** uMyCoolShop\_products, uMyCoolShop\_categories, uMyCoolShop\_more\_categories
-
 Frontend PHP classes
    For frontend PHP classes, follow the same conventions as for
-   database tables and field, but prepend class file names with `class`.
+   database tables and field.
 
 You may also want to refer to the TYPO3 Core Coding Guidelines for
 more on general naming conventions in TYPO3.
@@ -176,3 +148,6 @@ constant. However because modules are required to work from both
 :code:`typo3/sysext/`, :code:`typo3/ext/` *and* :code:`typo3conf/ext/` it is a policy that any
 path before "ext/" is omitted.
 
+
+.. _TER: https://extensions.typo3.org/
+.. _Packagist: https://packagist.org/

--- a/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
+++ b/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
@@ -76,32 +76,35 @@ Abbreviations
    | TER = TYPO3 extension repository
    | *extkey* = extension key
    | *modkey* = backend module key
-   
+
 
 Public extensions
-   1. Public extensions are available from the TER_ or via Packagist_, private extensions are not published to the TER or Packagist.
-   
+   1. Public extensions are available from the TER_ or via Packagist_. Private
+      extensions are not published to the TER or Packagist.
+
    2. The *extkey* is made up of alphanumeric characters and underscores only
       and should start with a letter.
-   
+
       **Example:** cool\_shop
 
    3. The *extkey* is valid if the TER accepts it. This makes sure that the
       name follows the rules and is unique.
-      
-   4. Database tablenames look like 'tx\_' + *extkey* (without underscores) + '\_specification'.
-   
-      **Examples:** tx\_coolshop\_products, tx\_coolshop\_categories, tx\_coolshop\_more\_categories, tx\_coolshop\_domain\_model\_tag
+
+   4. Database tablenames look like `tx_` + *extkey* (without underscores) +
+      `_specification`.
+
+      **Examples:** tx\_coolshop\_products, tx\_coolshop\_categories,
+      tx\_coolshop\_more\_categories, tx\_coolshop\_domain\_model\_tag.
 
 Backend modules
    1. The *modkey* is made up of alphanumeric characters only. It does not
       contain underscores and starts with a letter.
-   
+
       **Example:** coolshop
 
 Frontend PHP classes
-   For frontend PHP classes, follow the same conventions as for
-   database tables and field.
+   For frontend PHP classes, follow the same conventions as for database tables
+   and fields.
 
 You may also want to refer to the TYPO3 Core Coding Guidelines for
 more on general naming conventions in TYPO3.


### PR DESCRIPTION
- There's not much to say about private extensions aside from that they are not published.
- There is no such thing as private backend modules, only private extensions, see above.
- Prepending class filenames with "class." is outdated