### PR TITLE
Replace wrong use of $this with $queryBuilder

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -168,7 +168,7 @@ Create a `DELETE FROM` query. The method requires the table name to drop data fr
    $affectedRows = $queryBuilder
       ->delete('tt_content')
       ->where(
-         $queryBuilder->expr()->eq('bodytext', $this->createNamedParameter('klaus'))
+         $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus'))
       )
       ->execute();
 
@@ -204,7 +204,7 @@ Create an `UPDATE` query. Typical usage::
    $queryBuilder
       ->update('tt_content')
       ->where(
-         $queryBuilder->expr()->eq('bodytext', $this->createNamedParameter('klaus')
+         $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus')
       )
       ->set('bodytext', 'peter')
       ->execute();


### PR DESCRIPTION
The examples for delete and update use $this->createNamedParameter instead of $queryBuilder->createNamedParameter.