### PR TITLE
Replace wrong use of $this with $queryBuilder

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -170,7 +170,7 @@ Create a `DELETE FROM` query. The method requires the table name to drop data fr
    $affectedRows = $queryBuilder
       ->delete('tt_content')
       ->where(
-         $queryBuilder->expr()->eq('bodytext', $this->createNamedParameter('klaus'))
+         $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus'))
       )
       ->execute();
 


### PR DESCRIPTION
The example for delete uses $this->createNamedParameter instead of $queryBuilder->createNamedParameter.