### PR TITLE
Change makeInstance example

### DIFF
--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -143,11 +143,23 @@ So a test class in :file:`EXT:foo_bar_baz/Tests/Unit/Bla/` will have as namespac
 Creating instances
 ------------------
 
-When creating instances using :code:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()`
-the leading backslash must be omitted and all other backslashes escaped, even when using
-single quotes. Thus the following code is correct::
+The following example shows how you can create instances with :code:`GeneralUtility::makeInstance`:
 
-   $contentObject = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+
+
+
+   $contentObject = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+
+Or, with the use of :code:`use`, which makes the code more readable:
+
+   use TYPO3\CMS\Core\Utility\GeneralUtility;
+   use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+   
+   class ...
+   
+   ...
+   
+      $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
 
 There is no need to use :code:`require()` or :code:`include()` statements. All classes that follow

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -138,33 +138,30 @@ So a test class in :file:`EXT:foo_bar_baz/Tests/Unit/Bla/` will have as namespac
 :code:`\Vendor\FooBarBaz\Tests\Unit\Bla`.
 
 
+
 .. _namespaces-instances:
 
 Creating instances
 ------------------
 
-The following example shows how you can create instances with :code:`GeneralUtility::makeInstance`:
-
-
-
+The following example shows how you can create instances with :code:`GeneralUtility::makeInstance`::
 
    $contentObject = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
 
-Or, with the use of :code:`use`, which makes the code more readable:
+Or, with the use of :code:`use`, which makes the code more readable::
 
    use TYPO3\CMS\Core\Utility\GeneralUtility;
    use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
    
-   class ...
-   
-   ...
-   
-      $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+::
 
+   $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+
+include and required
+--------------------
 
 There is no need to use :code:`require()` or :code:`include()` statements. All classes that follow
 namespace conventions will automatically be located and included by the autoloader.
-
 
 .. _namespaces-references:
 


### PR DESCRIPTION
- Fix error in class path for makeInstance (leading slash was missing)
- Added example with "use" as is common practice in TYPO3 core

See issue #157