### PR TITLE
Add CGL for other file types

### DIFF
--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -19,10 +19,61 @@ This chapter defines how TYPO3 code, files and directories should be
 outlined and formatted. It gives some thoughts on general coding
 flavors the core tries to follow.
 
-Following PSR standards
+.. _cgl-general-recommendations:
+
+General recommendations
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-TYPO3 codebase follows  `PSR-1 <http://www.php-fig.org/psr/psr-1/>`__ and `PSR-2 <http://www.php-fig.org/psr/psr-2/>`__ standards for code formatting.
+As a general rule, use your IDE to enforce the correct code
+style for you. For Phpstorm, which is widely used within
+the TYPO3 community, you can find some hints in the
+:ref:`Contribution Guide <t3contribute:phpstorm-setup-cgl>`
+
+.. _cgl-standards:
+
+General standards
+^^^^^^^^^^^^^^^^
+
+.. _cgl-standards-psr:
+
+PSR standards for PHP
+"""""""""""""""""""""
+
+PHP files in the TYPO3 codebase follow
+`PSR-1 <http://www.php-fig.org/psr/psr-1/>`__ and
+`PSR-2 <http://www.php-fig.org/psr/psr-2/>`__ standards for code
+formatting.
+
+
+AirBnB ruleset for JavaScript
+"""""""""""""""""""""""""""""
+
+The rules suggested in the
+`Airbnb JavaScript Style Guide <https://github.com/airbnb/javascript>`__
+should be used throughout the TYPO3 CMS core for JavaScript files.
+
+Excel Micro rules for TypeScript
+""""""""""""""""""""""""""""""""
+
+`Excel Micro TypeScript Style Guide for TypeScript
+<https://github.com/excelmicro/typescript>`__ should be used
+throughout the TYPO3 CMS core for TypeScript files.
+
+Rules for Language XLIFF files
+""""""""""""""""""""""""""""""
+
+Tabs are used for indentation within Language files (.xlf).
+
+Language files are located in the directory
+:file:`Resources/Private/Language`,
+
+Rules for Documentation ReST files
+""""""""""""""""""""""""""""""""""
+
+Don't use tabs, use spaces. Use 3 spaces to indent.
+
+
+.. Todo: Other files: .sql, .scss, css, json ...
 
 
 .. _cgl-quality-assurance:
@@ -30,8 +81,9 @@ TYPO3 codebase follows  `PSR-1 <http://www.php-fig.org/psr/psr-1/>`__ and `PSR-2
 The CGL as a means of quality assurance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Our programmers know the CGL and are encouraged to inform authors,
-should their code not comply with the guidelines.
+In the TYPO3 CMS codebase, our programmers know the CGL and are
+encouraged to inform authors, should their code not comply
+with the guidelines.
 
 Apart from that, adhering to the CGL is not voluntary: The CGL are also
 enforced by structural means: Automated tests are run by the continuous

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/AccessingTheDatabase.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/AccessingTheDatabase.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _cgl-database-access:
 

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/ClassNamesOfUserFiles.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/ClassNamesOfUserFiles.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-namespaces-class-names:

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/HandlingDeprecations.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/HandlingDeprecations.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-deprecation:

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/Index.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _cgl-best-practices:
 

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/Localization.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/Localization.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-localization:

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/Singletons.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/Singletons.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _cgl-singletons:
 

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/StaticMethods.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/StaticMethods.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-static-methods:

--- a/Documentation/CodingGuidelines/Php/CodingBestPractices/UnitTests.rst
+++ b/Documentation/CodingGuidelines/Php/CodingBestPractices/UnitTests.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _cgl-unit-tests:
 

--- a/Documentation/CodingGuidelines/Php/Index.rst
+++ b/Documentation/CodingGuidelines/Php/Index.rst
@@ -1,10 +1,10 @@
-.. include:: ../Includes.txt
+.. include:: ../../Includes.txt
 
-.. _cgl:
+.. _cgl-php:
 
-=================
-Coding Guidelines
-=================
+=========================
+Coding Guidelines for PHP
+=========================
 
 This chapter contains description of the formal requirements or standards
 regarding coding that you should adhere to when you develop TYPO3
@@ -14,5 +14,6 @@ extensions or core parts.
    :maxdepth: 3
    :titlesonly:
 
-   Introduction
-   Php/Index
+   PhpFileFormatting/Index
+   PhpArchitecture/Index
+   CodingBestPractices/Index

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/GeneralLinks.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/GeneralLinks.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-general-links:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/Index.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-php-architecture:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Index.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: ../../../../Includes.txt
 
 
 .. _cgl-modeling-cross-cutting-concerns:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Services.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Services.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: ../../../../Includes.txt
 
 
 .. _cgl-services:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/StaticMethods.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/StaticMethods.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: ../../../../Includes.txt
 
 
 .. _cgl-model-static-methods:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Traits.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/ModelingCrossCuttingConcerns/Traits.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: ../../../../Includes.txt
 
 
 .. _cgl-traits:

--- a/Documentation/CodingGuidelines/Php/PhpArchitecture/WorkingWithExceptions.rst
+++ b/Documentation/CodingGuidelines/Php/PhpArchitecture/WorkingWithExceptions.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-working-with-exceptions:

--- a/Documentation/CodingGuidelines/Php/PhpFileFormatting/FileStructure.rst
+++ b/Documentation/CodingGuidelines/Php/PhpFileFormatting/FileStructure.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-file-structure:

--- a/Documentation/CodingGuidelines/Php/PhpFileFormatting/GeneralRequirementsForPhpFiles.rst
+++ b/Documentation/CodingGuidelines/Php/PhpFileFormatting/GeneralRequirementsForPhpFiles.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-general-requirements-for-php-files:

--- a/Documentation/CodingGuidelines/Php/PhpFileFormatting/Index.rst
+++ b/Documentation/CodingGuidelines/Php/PhpFileFormatting/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 .. _cgl-php-file-formatting:
 

--- a/Documentation/CodingGuidelines/Php/PhpFileFormatting/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/Php/PhpFileFormatting/PhpSyntaxFormatting.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-php-syntax-formatting:

--- a/Documentation/CodingGuidelines/Php/PhpFileFormatting/UsingPhpdoc.rst
+++ b/Documentation/CodingGuidelines/Php/PhpFileFormatting/UsingPhpdoc.rst
@@ -1,4 +1,4 @@
-.. include:: ../../Includes.txt
+.. include:: ../../../Includes.txt
 
 
 .. _cgl-using-phpdoc:


### PR DESCRIPTION
- Until now, the CGL section only included info about PHP.
  Add sections for some other file types to introduction
- Add a link in introduction to description on setting
  up Phpstorm for CGL in contribution guide

See issue: #218