### PR TITLE
Delete removed displayErrors value

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
@@ -31,11 +31,6 @@ part of :php:`$TYPO3_CONF_VARS[SYS]`:
          - 1 = Display error messages with the registered error handler,the
            configured :php:`debugExceptionHandler` is used as exception handler
 
-         - 2 = Display errors only if client matches
-           :php:`$TYPO3_CONF_VARS[SYS][devIPmask]`. If devIPmask matches the users IP
-           address the configured "debugExceptionHandler" is used for exceptions,
-           if not "productionExceptionHandler" will be used.
-
          - -1 = Default setting. With this option, you can override the PHP
            setting :php:`display_errors`. If :php:`devIPmask` matches the users IP address
            the configured :php:`debugExceptionHandler` is used for exceptions, if not


### PR DESCRIPTION
displayErrors=2 has been removed. 
https://docs.typo3.org/typo3cms/extensions/core/8.7/singlehtml/Index.html#breaking-72572-remove-more-deprecated-miscellaneous-functions-and-options