### PR TITLE
Add CGL for other file types

### DIFF
--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -50,16 +50,17 @@ General recommendations
 =======================
 
 .. important::
-   As a general rule, use your IDE / Editor to enforce the correct code style for you.
+
+   You are strongly advised to set up your editor and IDE properly so that the
+   standards get checked and enforced automatically!
 
 
 .. _cgl-introduction-php:
 
-
 PHP
 ===
 
-TYPO3 codebase follows the following standards for code formatting:
+TYPO3 codebase is following these standards for code formatting:
 
 * `PSR-1 <http://www.php-fig.org/psr/psr-1/>`__
 * `PSR-2 <http://www.php-fig.org/psr/psr-2/>`__
@@ -68,32 +69,31 @@ TYPO3 codebase follows the following standards for code formatting:
 JavaScript
 ==========
 
-The rules suggested in the
-`Airbnb JavaScript Style Guide <https://github.com/airbnb/javascript>`__
-should be used throughout the TYPO3 CMS core for JavaScript files.
+The rules suggested in the `Airbnb JavaScript Style Guide
+<https://github.com/airbnb/javascript>`__ should be used throughout the TYPO3
+CMS core for JavaScript files.
 
 TypeSript
 =========
 
 `Excel Micro TypeScript Style Guide for TypeScript
-<https://github.com/excelmicro/typescript>`__ should be used
-throughout the TYPO3 CMS core for TypeScript files.
+<https://github.com/excelmicro/typescript>`__ should be used throughout the
+TYPO3 CMS core for TypeScript files.
 
 
 XLIFF
 =====
 
 Tabs are used for indentation within Language files (.xlf).
-
-Language files are located in the directory
-:file:`Resources/Private/Language`,
+Language files are located in the directory :file:`Resources/Private/Language`.
 
 reST
 ====
 
-Don't use tabs, use spaces. Use 3 spaces to indent.
+Don't use tabs, use spaces. Use three spaces for one level of indentation.
+Compare with the :ref:`rules for formatting reST files
+<h2document:Formatting-reST-Source-Files>`.
 
+.. Todo: More types: sql, scss, css, json ...
 
-.. Todo: Other files: .sql, .scss, css, json ...
-
-
+   possibly explain .editorconfig file!?

--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -2,8 +2,9 @@
 
 .. _cgl-introduction:
 
+============
 Introduction
-------------
+============
 
 This chapter defines coding guidelines for the TYPO3 CMS project.
 Following these guidelines is mandatory for TYPO3 core developers and
@@ -19,16 +20,10 @@ This chapter defines how TYPO3 code, files and directories should be
 outlined and formatted. It gives some thoughts on general coding
 flavors the core tries to follow.
 
-Following PSR standards
-^^^^^^^^^^^^^^^^^^^^^^^
-
-TYPO3 codebase follows  `PSR-1 <http://www.php-fig.org/psr/psr-1/>`__ and `PSR-2 <http://www.php-fig.org/psr/psr-2/>`__ standards for code formatting.
-
-
 .. _cgl-quality-assurance:
 
 The CGL as a means of quality assurance
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=======================================
 
 Our programmers know the CGL and are encouraged to inform authors,
 should their code not comply with the guidelines.
@@ -46,4 +41,59 @@ be easily replayed locally: If the test setup votes negative on a
 core patch in the review system due to CGL violations, the patch
 can be easily fixed locally by calling :file:`./Build/Scripts/cglFixMyCommit.sh`
 and pushed another time. For details on core contributions, have a look at the
-:ref:`contribution workflow guide <t3contribute:TYPO3.Tutorial.ContributionWorkflow.Index>`.
+:ref:`TYPO3 Contribution Guide <t3contribute:start>`.
+
+
+.. _cgl-introduction-general-recommendations:
+
+General recommendations
+=======================
+
+.. important::
+   As a general rule, use your IDE / Editor to enforce the correct code style for you.
+
+
+.. _cgl-introduction-php:
+
+
+PHP
+===
+
+TYPO3 codebase follows the following standards for code formatting:
+
+* `PSR-1 <http://www.php-fig.org/psr/psr-1/>`__
+* `PSR-2 <http://www.php-fig.org/psr/psr-2/>`__
+
+
+JavaScript
+==========
+
+The rules suggested in the
+`Airbnb JavaScript Style Guide <https://github.com/airbnb/javascript>`__
+should be used throughout the TYPO3 CMS core for JavaScript files.
+
+TypeSript
+=========
+
+`Excel Micro TypeScript Style Guide for TypeScript
+<https://github.com/excelmicro/typescript>`__ should be used
+throughout the TYPO3 CMS core for TypeScript files.
+
+
+XLIFF
+=====
+
+Tabs are used for indentation within Language files (.xlf).
+
+Language files are located in the directory
+:file:`Resources/Private/Language`,
+
+reST
+====
+
+Don't use tabs, use spaces. Use 3 spaces to indent.
+
+
+.. Todo: Other files: .sql, .scss, css, json ...
+
+

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -1,24 +1,15 @@
-﻿
-.. This is 'Includes.txt'. It is included at the very top of each and
+﻿.. This is 'Includes.txt'. It is included at the very top of each and
    every ReST source file in THIS documentation project (= manual).
 
-.. role:: aspect(emphasis)
-
+.. role:: aspect (emphasis)
 .. role:: html(code)
-   :language: html
-
 .. role:: js(code)
-   :language: javascript
-
 .. role:: php(code)
-   :language: php
-
+.. role:: sep (strong)
 .. role:: typoscript(code)
-   :language: typoscript
 
 .. role:: ts(typoscript)
    :class: typoscript
-   :language: typoscript
 
-.. highlight:: php
 .. default-role:: code
+.. highlight:: php

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -53,16 +53,17 @@ use_opensearch       = https://docs.typo3.org/typo3cms/CoreApiReference
 
 ; in this manual we actually use (really?):
 
+h2document    = https://docs.typo3.org/typo3cms/HowToDocument/
 t3cgl         = https://docs.typo3.org/typo3cms/CodingGuidelinesReference/
 t3contribute  = https://docs.typo3.org/typo3cms/ContributionWorkflowGuide/
 t3extbasebook = https://docs.typo3.org/typo3cms/ExtbaseFluidBook/
 t3inside      = https://docs.typo3.org/typo3cms/InsideTypo3Reference/
-t3start       = https://docs.typo3.org/typo3cms/GettingStartedTutorial/
 t3skinning    = https://docs.typo3.org/typo3cms/SkinningReference/
+t3start       = https://docs.typo3.org/typo3cms/GettingStartedTutorial/
 t3tca         = https://docs.typo3.org/typo3cms/TCAReference/
+t3templating  = https://docs.typo3.org/typo3cms/TemplatingTutorial/
 t3tsconfig    = https://docs.typo3.org/typo3cms/TSconfigReference/
 t3tsref       = https://docs.typo3.org/typo3cms/TyposcriptReference/
-t3templating  = https://docs.typo3.org/typo3cms/TemplatingTutorial/
 
 
 [notify]
@@ -71,9 +72,7 @@ t3templating  = https://docs.typo3.org/typo3cms/TemplatingTutorial/
 # Specify a comma separated list of one or more email addresses. If one of them is
 # 'no', then notification is turned off for all.
 
-about_new_build =
-   francois.suter@typo3.org,
-   martin.bless@typo3.org
+about_new_build = no
 
 # # Example: Turn off notification
 # about_new_build = no


### PR DESCRIPTION
- Until now, the CGL section only included info about PHP.
  Add information for some other file types to introduction

See issue: #218