### PR TITLE
TASK: Always use GLOBALS['TYPO3_CONF_VARS']

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
@@ -22,7 +22,7 @@ and can be overridden in :file:`LocalConfiguration.php`.
 
 If specific settings should be applied to the configuration, they should be added to :file:`LocalConfiguration.php`.
 All settings in :file:`LocalConfiguration.php` will be merged with :file:`DefaultConfiguration.php`. The easiest way to see
-the final cache configuration is to use the TYPO3 Backend module Admin Tools > Configuration > $TYPO3_CONF_VARS.
+the final cache configuration is to use the TYPO3 Backend module Admin Tools > Configuration > :php:`$GLOBALS['TYPO3_CONF_VARS']`.
 
 Example for a configuration of redis cache backend on redis database number 42 instead of the default
 database backend with compression for the pages cache:

--- a/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
+++ b/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
@@ -23,7 +23,7 @@ Pooling
 ^^^^^^^
 
 TYPO3 can handle multiple connections to different database endpoints at the same time. This
-can be configured on a per-table basis in :php:`$TYPO3_CONF_VARS`. It allows running tables
+can be configured on a per-table basis in :php:`$GLOBALS['TYPO3_CONF_VARS']`. It allows running tables
 on different databases, without an extension developer taking care of that.
 
 The `ConnectionPool` implements this feature: It looks up a configured table-to-database

--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
@@ -7,7 +7,7 @@ Configuration
 =============
 
 All configuration options related to error and exception handling are
-part of :php:`$TYPO3_CONF_VARS[SYS]`:
+part of :php:`$GLOBALS['TYPO3_CONF_VARS'][SYS]`:
 
 .. t3-field-list-table::
  :header-rows: 1
@@ -53,7 +53,7 @@ part of :php:`$TYPO3_CONF_VARS[SYS]`:
          Backend are only displayed if the error and exception handling is in
          "debug-mode", which is the case when the configured
          "debugExceptionHandler" is registered as exception handler (see:
-         :php:`$TYPO3_CONF_VARS[SYS][displayErrors]`).
+         :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']`).
 
          Errors which are registered as "exceptionalErrors" will be turned into
          exceptions (to be handled by the configured exceptionHandler).
@@ -78,7 +78,7 @@ part of :php:`$TYPO3_CONF_VARS[SYS]`:
          handler.
 
          Default: :php:`E_ALL ^ E_NOTICE ^ E_WARNING ^ E_USER\_ERROR ^ E_USER\_NOTICE ^ E_USER\_WARNING`
-         (4341) and "0" if :php:`$TYPO3_CONF_VARS[SYS][displayErrors] = 0`.
+         (4341) and "0" if :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 0`.
 
          Refer to the PHP documentation for more details on this value.
 
@@ -99,8 +99,8 @@ part of :php:`$TYPO3_CONF_VARS[SYS]`:
          .. note::
 
             The configured productionExceptionHandler is used if
-            :php:`$TYPO3_CONF_VARS[SYS][displayErrors]` is set to "0" or to "-1"
-            and :php:`$TYPO3_CONF_VARS[SYS][devIPmask]` doesn't match.
+            :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']` is set to "0" or to "-1"
+            and :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']` doesn't match.
 
 
  - :Key:
@@ -120,9 +120,9 @@ part of :php:`$TYPO3_CONF_VARS[SYS]`:
          .. note::
 
             The configured debugExceptionHandler is used if
-            :php:`$TYPO3_CONF_VARS[SYS][displayErrors]` is set to "1" or
-            if :php:`$TYPO3_CONF_VARS[SYS][displayErrors]` is "-1" or "2" and
-            the :php:`$TYPO3_CONF_VARS[SYS][devIPmask]` matches.
+            :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']` is set to "1" or
+            if :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']` is "-1" or "2" and
+            the :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']` matches.
 
 
  - :Key:

--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Extending/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Extending/Index.rst
@@ -11,9 +11,9 @@ If you want to register your own error or exception handler, simply
 include the class and insert its name into "productionExceptionHandler",
 "debugExceptionHandler" or "errorHandler"::
 
-   $TYPO3_CONF_VARS['SYS']['errorHandler'] = 'myOwnErrorHandler';
-   $TYPO3_CONF_VARS['SYS']['debugExceptionHandler'] = 'myOwnDebugExceptionHandler';
-   $TYPO3_CONF_VARS['SYS']['productionExceptionHandler'] = 'myOwnProductionExceptionHandler';
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler'] = 'myOwnErrorHandler';
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler'] = 'myOwnDebugExceptionHandler';
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler'] = 'myOwnProductionExceptionHandler';
 
 
 An error or exception handler class must register an error (exception)
@@ -25,13 +25,17 @@ extend it with your own functionality, simply derive your class from the
 error and exception handling classes shipped with TYPO3 and register
 this class as error (exception) handler::
 
-   class tx_postExceptionsOnTwitter extends \TYPO3\CMS\Core\Error\DebugExceptionHandler {
-       function echoExceptionWeb(Exception $exception) {
+   class tx_postExceptionsOnTwitter extends \TYPO3\CMS\Core\Error\DebugExceptionHandler
+   {
+       public function echoExceptionWeb(Exception $exception)
+       {
            $this->postExceptionsOnTwitter($exception);
        }
-       function postExceptionsOnTwitter($exception) {
+
+       public function postExceptionsOnTwitter($exception)
+       {
            // do it ;-)
        }
    }
-   $TYPO3_CONF_VARS['SYS']['debugExceptionHandler'] = 'tx_postExceptionsOnTwitter';
-   $TYPO3_CONF_VARS['SYS']['productionExceptionHandler'] = 'tx_postExceptionsOnTwitter';
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler'] = 'tx_postExceptionsOnTwitter';
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler'] = 'tx_postExceptionsOnTwitter';

--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -11,7 +11,7 @@ TYPO3 provides an API class for creating so-called 'Feature Toggles'. Feature to
 new implementations of features next to their legacy version. By using a feature toggle, the integrator or site admin
 can decide when to switch to the new feature.
 
-The API checks against a system-wide option array within :php:`$TYPO3_CONF_VARS['SYS']['features']` which an integrator
+The API checks against a system-wide option array within :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']` which an integrator
 or admin can set in the :file:`LocalConfiguration.php` file.
 Both TYPO3 Core and Extensions can provide alternative functionality for a certain feature.
 

--- a/Documentation/ApiOverview/JavaScript/Ajax/Presentation/Index.rst
+++ b/Documentation/ApiOverview/JavaScript/Ajax/Presentation/Index.rst
@@ -50,8 +50,8 @@ supports usage of 'Ext.Direct')).
 Server-side programming
 """""""""""""""""""""""
 
-If you look into "typo3/ajax.php", it is only a small dispatcher
-script. It checks for an ajaxID in the :code:`$TYPO3_CONF_VARS['BE']['AJAX']`
+If you look into :file:`typo3/ajax.php`, it is only a small dispatcher
+script. It checks for an ajaxID in the :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['AJAX']`
 array and tries to execute the function pointer. The function has two
 parameters, where the first (an array) is not used yet. The second
 parameter is the TYPO3 AJAX Object (located in

--- a/Documentation/ApiOverview/SoftReferences/Index.rst
+++ b/Documentation/ApiOverview/SoftReferences/Index.rst
@@ -179,7 +179,7 @@ User-defined soft reference parsers
 
 Soft References can also be user-defined. It is easy to set them up by
 simply adding new keys in
-:code:`$TYPO3_CONF_VARS['SC_OPTIONS']['GLOBAL']['softRefParser']`. Use key
+:code:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['softRefParser']`. Use key
 names based on the extension you put it in, e.g. :code:`tx_myextensionkey`.
 
 The class containing the soft reference parser must have a function

--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -21,7 +21,7 @@ every request. They should therefore be optimized for speed.
 
   These are the typical functions that extension authors should place within :file:`ext_localconf.php`
 
-  * Registering hooks or any simple array assignments to :php:`$TYPO3_CONF_VARS` options
+  * Registering hooks or any simple array assignments to :php:`$GLOBALS['TYPO3_CONF_VARS']` options
   * Registering additional Request Handlers within the Bootstrap
   * Adding any PageTSconfig or Default TypoScript via :php:`ExtensionManagementUtility` APIs
   * Registering Extbase Command Controllers


### PR DESCRIPTION
Do no longer provide examples where TYPO3_CONF_VARS is accessed without
$GLOBALS prefix.

Accordingly to #15 of security guide.