### PR TITLE
[TASK] Update wizard state storage

### DIFF
--- a/Documentation/ApiOverview/UpdateWizards/Creation/Index.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation/Index.rst
@@ -71,4 +71,4 @@ As soon as the wizard has completely finished, e.g. it detected that no update i
 necessary anymore, or that all updates were completed successfully, the wizard should
 be marked as done. To mark the wizard as done, call :php:`$this->markWizardAsDone`.
 
-The state is persisted in :file:`LocalConfiguration.php`.
+The state of completed wizards is persisted in the TYPO3 system registry.

--- a/Documentation/ApiOverview/UpdateWizards/Creation/Index.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation/Index.rst
@@ -71,4 +71,4 @@ As soon as the wizard has completely finished, e.g. it detected that no update i
 necessary anymore, or that all updates were completed successfully, the wizard should
 be marked as done. To mark the wizard as done, call :php:`$this->markWizardAsDone`.
 
-The state of completed wizards is persisted in the TYPO3 system registry.
+The state of completed wizards is persisted in the :ref:`TYPO3 system registry <registry>`.


### PR DESCRIPTION
Since TYPO3v8 wizard states are stored in the system registry.