### PR TITLE
Add an example for the namespace syntax of a hook.

### DIFF
--- a/Documentation/ApiOverview/Hooks/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Hooks/Configuration/Index.rst
@@ -95,8 +95,17 @@ extension keys. ::
 - **function\_reference :** A function reference using the syntax of
   :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()` as a function
   or :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()` as a class name
-  depending on implementation of the hook. A namespace function has the quoted string format :php:`'Foo\\Bar\\MyClassName->myUserFunction'`. A namespace class name can be in the FQCN quoted string format :php:`'Foo\\Bar\\MyClassName'`, which must not have a leading backslash, or in the unquoted form :php:`\Foo\Bar\MyClassName::class` (>= PHP 5.5). 
-  The called function name is determined by the hook itself.
+  depending on implementation of the hook.
+  
+  A namespace function has the quoted string format :php:`'Foo\\Bar\\MyClassName->myUserFunction'`
+  or a format using an unquoted class name :php:`\Foo\Bar\MyClassName::class . '->myUserFunction'`.
+  The latter is available since PHP 5.5.
+  
+  A namespace class name can be in the FQCN quoted string format :php:`'Foo\\Bar\\MyClassName'`,
+  or in the unquoted form :php:`\Foo\Bar\MyClassName::class`. The called function name
+  is determined by the hook itself.
+  
+  Leading backslashes for class names are not allowed and lead to an error.
 
 The above syntax is how a hook is typically defined but it might
 differ and it might not be a hook at all, but just configuration.

--- a/Documentation/ApiOverview/Hooks/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Hooks/Configuration/Index.rst
@@ -95,7 +95,7 @@ extension keys. ::
 - **function\_reference :** A function reference using the syntax of
   :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()` as a function
   or :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()` as a class name
-  depending on implementation of the hook. A namespace function has the quoted string format :php:`'Foo\\Bar\\MyClassName->myUserFunction'`. A namespace class name can be in the quoted string format :php:`'Foo\\Bar\\MyClassName'` or in the unquoted form :php:`\Foo\Bar\MyClassName::class` (>= PHP 5.5). 
+  depending on implementation of the hook. A namespace function has the quoted string format :php:`'Foo\\Bar\\MyClassName->myUserFunction'`. A namespace class name can be in the FQCN quoted string format :php:`'Foo\\Bar\\MyClassName'`, which must not have a leading backslash, or in the unquoted form :php:`\Foo\Bar\MyClassName::class` (>= PHP 5.5). 
   The called function name is determined by the hook itself.
 
 The above syntax is how a hook is typically defined but it might

--- a/Documentation/ApiOverview/Hooks/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Hooks/Configuration/Index.rst
@@ -93,9 +93,10 @@ extension keys. ::
   array and uses only the value (function reference)
 
 - **function\_reference :** A function reference using the syntax of
-  :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()`
-  or :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()`
-  depending on implementation of the hook.
+  :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()` as a function
+  or :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()` as a class name
+  depending on implementation of the hook. A namespace function has the quoted string format :php:`'Foo\\Bar\\MyClassName->myUserFunction'`. A namespace class name can be in the quoted string format :php:`'Foo\\Bar\\MyClassName'` or in the unquoted form :php:`\Foo\Bar\MyClassName::class` (>= PHP 5.5). 
+  The called function name is determined by the hook itself.
 
 The above syntax is how a hook is typically defined but it might
 differ and it might not be a hook at all, but just configuration.


### PR DESCRIPTION
This exception must be avoided. But the documentation is missing.

Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1420281366: $className "\MyDomain\MyExtension\Hooks\PageCacheHook" must not start with a backslash. | InvalidArgumentException thrown in file /home/mydomein/public_html/typo3_src-8.7.16/typo3/sysext/core/Classes/Utility/GeneralUtility.php in line 3937