### PR TITLE
remove ** signs as the sentence is in code and will not be shown bold

### DIFF
--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -268,7 +268,7 @@ values in the :code:`$EM_CONF` array if needed.
                ]
             ],
             
-          Important: The prefix **must** end with a backslash.          
+         // Important: The prefix must end with a backslash.          
 
  - :Key:
          autoload-dev


### PR DESCRIPTION
the ** is used to make the "must" bold, but because the sentence in code block the bold statement is ignored.

the sentence should be either written outside the code block or the ** should be removed