### PR TITLE
Update chapter FAL examples

### DIFF
--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -30,6 +30,14 @@ or its combined identifier:
    $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
    $file = $resourceFactory->getFileObjectFromCombinedIdentifier('1:/foo.txt');
 
+The syntax of argument 1 for getFileObjectFromCombinedIdentifier is
+
+.. code-block:: none
+
+   `[[storage uid]:]<file identifier>
+
+The storage uid is optional. If it is not specified, the default storage 
+(virtual storage with uid=0) is used. 
 
 .. _fal-using-fal-examples-file-folder-copy-file:
 
@@ -72,6 +80,11 @@ Storage:
          'final_file_name.foo'
    );
 
+The default storage uses :file:`fileadmin` unless you have configured this 
+differently, as explained in :ref:`fal-concepts-storages-drivers`. 
+
+So, for this example, the resulting file path would typically be
+:file:`<document-root>/fileadmin/tmp/temporary_file_name.foo`
 
 .. _fal-using-fal-examples-file-folder-create-reference:
 
@@ -85,8 +98,8 @@ In the backend context
 ''''''''''''''''''''''
 
 In the backend or command-line context, it is possible to create
-file references using the normal :php:`\TYPO3\CMS\Core\DataHandling\DataHandler`
-processes.
+file references using the :ref:`DataHandler <datahandler-basics>`
+processes (:php:`\TYPO3\CMS\Core\DataHandling\DataHandler`).
 
 Assuming you have the "uid" of both the File and whatever other item
 you want to create a relation to, the following code will create
@@ -103,22 +116,22 @@ the "sys\_file\_reference" entry and the relation to the other item
      );
      // Assemble DataHandler data
      $newId = 'NEW1234';
-     $data = array();
-     $data['sys_file_reference'][$newId] = array(
+     $data = [];
+     $data['sys_file_reference'][$newId] = [
              'table_local' => 'sys_file',
              'uid_local' => $fileObject->getUid(),
              'tablenames' => 'tt_content',
              'uid_foreign' => $contentElement['uid'],
-             'fieldname' => 'image',
+             'fieldname' => 'assets',
              'pid' => $contentElement['pid']
-     );
-     $data['tt_content'][$contentElement['uid']] = array(
-             'image' => $newId
-     );
+     ];
+     $data['tt_content'][$contentElement['uid']] = [
+             'assets' => $newId
+     ];
      // Get an instance of the DataHandler and process the data
      /** @var DataHandler $dataHandler */
      $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-     $dataHandler->start($data, array());
+     $dataHandler->start($data, []);
      $dataHandler->process_datamap();
      // Error or success reporting
      if (count($dataHandler->errorLog) === 0) {
@@ -131,15 +144,18 @@ the "sys\_file\_reference" entry and the relation to the other item
 The above example comes from the "examples" extension
 (reference: https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples/blob/master/Classes/Controller/ModuleController.php).
 
+Here, the :php:`'fieldname'` :php:`'assets'` is used instead of 
+:php:`image`. Content elements of ctype 'textmedia' use the field 'assets'.
+
 For another table than "tt\_content", you need to define
 the "pid" explicitly when creating the relation:
 
 .. code-block:: php
 
-   $data['tt_address'][$address['uid']] = array(
+   $data['tt_address'][$address['uid']] = [
        'pid' => $address['pid'],
        'image' => 'NEW1234' // changed automatically
-   );
+   ];
 
 
 .. _fal-using-fal-examples-file-folder-create-reference-frontend:
@@ -151,8 +167,8 @@ In a frontend context, the :php:`\TYPO3\CMS\Core\DataHandling\DataHandler`
 class cannot be used and there is no specific API to create a File Reference.
 You are on your own.
 
-The simplest solution is to simply create a database entry into
-table "sys\_file\_reference" by using directly the database connection
+The simplest solution is to create a database entry into
+table "sys\_file\_reference" by using the database connection
 class provided by TYPO3 CMS.
 
 A cleaner solution using Extbase requires far more work. An example

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -34,10 +34,10 @@ The syntax of argument 1 for getFileObjectFromCombinedIdentifier is
 
 .. code-block:: none
 
-   `[[storage uid]:]<file identifier>
+   [[storage uid]:]<file identifier>
 
-The storage uid is optional. If it is not specified, the default storage 
-(virtual storage with uid=0) is used. 
+The storage uid is optional. If it is not specified, the default storage
+(virtual storage with uid=0) is used.
 
 .. _fal-using-fal-examples-file-folder-copy-file:
 
@@ -75,16 +75,16 @@ Storage:
    $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
    $storage = $resourceFactory->getDefaultStorage();
    $newFile = $storage->addFile(
-         '/tmp/temporary_file_name.foo',
+         '/tmp/temporary_file_name.ext',
          $storage->getRootLevelFolder(),
-         'final_file_name.foo'
+         'final_file_name.ext'
    );
 
-The default storage uses :file:`fileadmin` unless you have configured this 
-differently, as explained in :ref:`fal-concepts-storages-drivers`. 
+The default storage uses :file:`fileadmin` unless this was configured
+differently, as explained in :ref:`fal-concepts-storages-drivers`.
 
 So, for this example, the resulting file path would typically be
-:file:`<document-root>/fileadmin/tmp/temporary_file_name.foo`
+:file:`<document-root>/fileadmin/tmp/temporary_file_name.ext`
 
 .. _fal-using-fal-examples-file-folder-create-reference:
 
@@ -144,7 +144,7 @@ the "sys\_file\_reference" entry and the relation to the other item
 The above example comes from the "examples" extension
 (reference: https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples/blob/master/Classes/Controller/ModuleController.php).
 
-Here, the :php:`'fieldname'` :php:`'assets'` is used instead of 
+Here, the :php:`'fieldname'` :php:`'assets'` is used instead of
 :php:`image`. Content elements of ctype 'textmedia' use the field 'assets'.
 
 For another table than "tt\_content", you need to define


### PR DESCRIPTION
- Add link to DataHandler
- Add (short) information about default storage and link to section 
  where this is explained in more detail
- Add (short) explanation of combined "storage:identifier" syntax
- change fieldname from 'image' to 'assets' (for 'textmedia')