### PR TITLE
Remove stripslashes_values from dataHandler examples

### DIFF
--- a/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
@@ -49,7 +49,6 @@ submission.
    :linenos:
 
    $tce = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
-   $tce->stripslashes_values = 0;
    $tce->start($data, array());
    $tce->process_datamap();
 
@@ -69,7 +68,6 @@ commands.
    :linenos:
 
    $tce = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
-   $tce->stripslashes_values = 0;
    $tce->start(array(), $cmd);
    $tce->process_cmdmap();
 
@@ -142,7 +140,6 @@ all pages is cleared in line 7.
    :linenos:
 
    $tce = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
-   $tce->stripslashes_values = 0;
    $tce->reverseOrder = 1;
    $tce->start($data, array());
    $tce->process_datamap();
@@ -170,7 +167,6 @@ should not set this argument since you want TCE to use the global
    :linenos:
 
    $tce = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
-   $tce->stripslashes_values = 0;
    $tce->start($data, $cmd, $alternative_BE_USER);
    $tce->process_datamap();
    $tce->process_cmdmap();


### PR DESCRIPTION
Datahandler stripslashes_values property has been deprecated in 7.2 and removed in 8.7
See: https://docs.typo3.org/typo3cms/extensions/core/7.6/Changelog/7.2/Deprecation-65381-DataHandlerStripslashesValuesProperty.html