### PR TITLE
Improve readability of code blocks and add namespaces

### DIFF
--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -57,7 +57,6 @@ It is possible to add another array as third argument to specify how single valu
 if `date` or `numbers` or similar should be inserted. The example below quotes the first value to an integer
 and the second one to a string::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Connection;
@@ -90,7 +89,6 @@ bulkInsert()
 ^^^^^^^^^^^^
 
 `INSERT` multiple rows at once. An example from the test suite::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -126,7 +124,6 @@ update()
 
 Create and execute an `UPDATE` statement. The example from `FAL's` `ResourceStorage` sets a storage to offline::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Connection;
@@ -156,7 +153,6 @@ delete()
 
 Execute a `DELETE` query using `equal` conditions in `WHERE`, example from `BackendUtility` to mark
 rows as no longer locked by a user::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -188,7 +184,6 @@ truncate()
 Empty a table, removing all rows. Usually much quicker than a :php:`->delete()` of all rows. This typically
 resets "auto increment primary keys" to zero. Use with care::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // TRUNCATE `cache_treelist`
@@ -202,10 +197,6 @@ count()
 
 A `COUNT` query. Again, this methods becomes handy if very simple `COUNT` statements are to be executed, the example
 returns tha number of active rows from table `tt_content` that have their `bodytext` field set to `klaus`::
-
-
-.. code-block:: php
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -254,7 +245,6 @@ Creates and executes a simple `SELECT` query based on `equal` conditions. Its us
 :ref:`RestrictionBuilder <database-restriction-builder>` kicks in and key/value pairs are automatically
 quoted::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `entry_key`, `entry_value` FROM `sys_registry` WHERE `entry_namespace` = 'my_extension'
@@ -286,7 +276,6 @@ lastInsertId()
 ^^^^^^^^^^^^^^
 
 Returns the `uid` of the last :php:`->insert()` statement. Useful if this id needs to be used afterwards directly::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -320,7 +309,6 @@ query, and to create a `QueryBuilder` for a more complex query from this connect
 usefulness is limited however and no good example within the core can be found at the time of this writing.
 
 The method can be helpful in loops to save some precious code characters, too::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -34,6 +34,9 @@ insert()
 
 Creates and executes an `INSERT INTO` statement. A (slightly simplified) example from the `Registry` API::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // INSERT INTO `sys_registry` (`entry_namespace`, `entry_key`, `entry_value`) VALUES ('aoeu', 'aoeu', 's:3:\"bar\";')
    GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('sys_registry')
@@ -54,6 +57,10 @@ It is possible to add another array as third argument to specify how single valu
 if `date` or `numbers` or similar should be inserted. The example below quotes the first value to an integer
 and the second one to a string::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
    // INSERT INTO `sys_log` (`userid`, `details`) VALUES (42, 'klaus')
    GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('sys_log')
@@ -84,6 +91,11 @@ bulkInsert()
 
 `INSERT` multiple rows at once. An example from the test suite::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+      ->getConnectionForTable('aTestTable')
    $connection->bulkInsert(
       'aTestTable',
       [
@@ -114,6 +126,10 @@ update()
 
 Create and execute an `UPDATE` statement. The example from `FAL's` `ResourceStorage` sets a storage to offline::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
    // UPDATE `sys_file_storage` SET `is_online` = 0 WHERE `uid` = '42'
    GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('sys_file_storage')
@@ -141,6 +157,10 @@ delete()
 Execute a `DELETE` query using `equal` conditions in `WHERE`, example from `BackendUtility` to mark
 rows as no longer locked by a user::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
    // DELETE FROM `sys_lockedrecords` WHERE `userid` = 42
    GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('sys_lockedrecords')
@@ -168,6 +188,9 @@ truncate()
 Empty a table, removing all rows. Usually much quicker than a :php:`->delete()` of all rows. This typically
 resets "auto increment primary keys" to zero. Use with care::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // TRUNCATE `cache_treelist`
    GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('cache_treelist')
@@ -180,6 +203,12 @@ count()
 A `COUNT` query. Again, this methods becomes handy if very simple `COUNT` statements are to be executed, the example
 returns tha number of active rows from table `tt_content` that have their `bodytext` field set to `klaus`::
 
+
+.. code-block:: php
+
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT COUNT(*)
    // FROM `tt_content`
    // WHERE
@@ -225,6 +254,9 @@ Creates and executes a simple `SELECT` query based on `equal` conditions. Its us
 :ref:`RestrictionBuilder <database-restriction-builder>` kicks in and key/value pairs are automatically
 quoted::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `entry_key`, `entry_value` FROM `sys_registry` WHERE `entry_namespace` = 'my_extension'
    $resultRows = GeneralUtility::makeInstance(ConnectionPool::class)
       ->getConnectionForTable('sys_registry')
@@ -255,6 +287,11 @@ lastInsertId()
 
 Returns the `uid` of the last :php:`->insert()` statement. Useful if this id needs to be used afterwards directly::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
+   $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);
    $databaseConnectionForPages = $connectionPool->getConnectionForTable('myTable');
    $databaseConnectionForPages->insert(
       'myTable',
@@ -284,6 +321,9 @@ usefulness is limited however and no good example within the core can be found a
 
 The method can be helpful in loops to save some precious code characters, too::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($myTable);
    foreach ($someList as $aListValue) {
       $myResult = $connection->createQueryBuilder

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -34,7 +34,6 @@ insert()
 
 Creates and executes an `INSERT INTO` statement. A (slightly simplified) example from the `Registry` API::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // INSERT INTO `sys_registry` (`entry_namespace`, `entry_key`, `entry_value`) VALUES ('aoeu', 'aoeu', 's:3:\"bar\";')

--- a/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
+++ b/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
@@ -8,6 +8,9 @@ ConnectionPool
 TYPO3's interface to execute queries via `doctrine-dbal` typically starts by asking
 the `ConnectionPool` for a `QueryBuilder` or a `Connection` object, handing over the table name to be queried::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Get a query builder for a table
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tx_myext_comments');
    // or

--- a/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
+++ b/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
@@ -8,7 +8,6 @@ ConnectionPool
 TYPO3's interface to execute queries via `doctrine-dbal` typically starts by asking
 the `ConnectionPool` for a `QueryBuilder` or a `Connection` object, handing over the table name to be queried::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Get a query builder for a table

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -18,13 +18,10 @@ to ensure queries are being build based on the requirements of the database plat
 
 An instance of the `ExpressionBuilder` is retrieved from the `QueryBuilder` object::
 
-
    $expressionBuilder = $queryBuilder->expr();
-
 
 It is good practice to not assign an instance of the `ExpressionBuilder` to a variable but
 to use it within the code flow of the `QueryBuilder` context directly::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -38,7 +35,6 @@ to use it within the code flow of the `QueryBuilder` context directly::
       )
       ->execute()
       ->fetchAll();
-
 
 .. warning::
 
@@ -60,7 +56,6 @@ take any number of argument which are all combined. It usually doesn't make much
 zero or only one argument, though.
 
 A core example to find a sys_domain record::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -199,7 +194,6 @@ the field name (or table name / alias with field name), second argument an optio
 
 Examples::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Calculate the average creation timestamp of all rows from tt_content
@@ -232,8 +226,7 @@ TRIM
 %%%%
 
 Using the TRIM expression makes sure fields get trimmed on database level.
-See the examples below to get a better idea of what can be done.
-
+See the examples below to get a better idea of what can be done::
 
     // use TYPO3\CMS\Core\Utility\GeneralUtility;
     // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -260,8 +253,7 @@ LENGTH
 %%%%%%
 
 The LENGTH string function can be used to return the length of a string in bytes, method
-signature is fieldName with optional alias :php:`->length(string $fieldName, string $alias = null)`
-
+signature is fieldName with optional alias :php:`->length(string $fieldName, string $alias = null)`::
 
     // use TYPO3\CMS\Core\Utility\GeneralUtility;
     // use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -18,12 +18,16 @@ to ensure queries are being build based on the requirements of the database plat
 
 An instance of the `ExpressionBuilder` is retrieved from the `QueryBuilder` object::
 
+
    $expressionBuilder = $queryBuilder->expr();
 
 
 It is good practice to not assign an instance of the `ExpressionBuilder` to a variable but
 to use it within the code flow of the `QueryBuilder` context directly::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $rows = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content')
       ->select('uid', 'header', 'bodytext')
       ->from('tt_content')
@@ -57,6 +61,9 @@ zero or only one argument, though.
 
 A core example to find a sys_domain record::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // WHERE
    //     (`sys_domain`.`pid` = `pages`.`uid`)
    //     AND (
@@ -64,6 +71,7 @@ A core example to find a sys_domain record::
    //        OR
    //        (`sys_domain`.`domainName` = 'example.com/')
    //     )
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder->where(
       $queryBuilder->expr()->eq('sys_domain.pid', $queryBuilder->createNamedParameter('pages.uid', \PDO::PARAM_INT)),
       $queryBuilder->expr()->orX(
@@ -123,6 +131,7 @@ Remarks and warnings:
 
 Examples::
 
+
    // `bodytext` = 'foo' - string comparison
    ->eq('bodytext', $queryBuilder->createNamedParameter('foo'))
 
@@ -150,6 +159,7 @@ Examples::
       $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards('klaus') . '%')
    )
 
+   // use TYPO3\CMS\Core\Database\Connection;
    // `uid` IN (42, 0, 44) - properly sanitized, mind the intExplode and PARAM_INT_ARRAY
    ->in(
       'uid',
@@ -159,6 +169,7 @@ Examples::
       )
    )
 
+   // use TYPO3\CMS\Core\Database\Connection;
    // `CType` IN ('media', 'multimedia') - properly sanitized, mind the PARAM_STR_ARRAY
    ->in(
       'CType',
@@ -188,8 +199,12 @@ the field name (or table name / alias with field name), second argument an optio
 
 Examples::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Calculate the average creation timestamp of all rows from tt_content
    // SELECT AVG(`crdate`) AS `averagecreation` FROM `tt_content`
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $result = $queryBuilder
       ->addSelectLiteral(
          $queryBuilder->expr()->avg('crdate', 'averagecreation')
@@ -219,8 +234,11 @@ TRIM
 Using the TRIM expression makes sure fields get trimmed on database level.
 See the examples below to get a better idea of what can be done.
 
-.. code-block:: php
 
+    // use TYPO3\CMS\Core\Utility\GeneralUtility;
+    // use TYPO3\CMS\Core\Database\ConnectionPool;
+    // use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
     $queryBuilder->expr()->comparison(
         $queryBuilder->expr()->trim($fieldName),
         ExpressionBuilder::EQ,
@@ -237,15 +255,18 @@ The call to :php:`$queryBuilder->expr()-trim()` can be one of the following:
   results in :code:`TRIM(TRAILING "x" FROM "tableName"."fieldName")`
 * :php:`trim('fieldName', AbstractPlatform::TRIM_BOTH, 'x')`
   results in :code:`TRIM(BOTH "x" FROM "tableName"."fieldName")`
-  
+
 LENGTH
 %%%%%%
 
 The LENGTH string function can be used to return the length of a string in bytes, method
 signature is fieldName with optional alias :php:`->length(string $fieldName, string $alias = null)`
 
-.. code-block:: php
 
+    // use TYPO3\CMS\Core\Utility\GeneralUtility;
+    // use TYPO3\CMS\Core\Database\ConnectionPool;
+    // use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
     $queryBuilder->expr()->comparison(
         $queryBuilder->expr()->length($fieldName),
         ExpressionBuilder::GT,

--- a/Documentation/ApiOverview/Database/Migration/Index.rst
+++ b/Documentation/ApiOverview/Database/Migration/Index.rst
@@ -22,7 +22,6 @@ and simple approach to verify this is to note down and compare the queries at th
 layer. In $GLOBALS['TYPO3_DB'], the final query statement is usually retrieved by removing the
 `exec_` part from the method name, in `doctrine` method :php:`QueryBuilder->getSQL()` can be used::
 
-
    // Inital code:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('*', 'index_fulltext', 'phash=' . (int)$phash);
 
@@ -56,7 +55,6 @@ table's `TCA`. The method call *should* be removed during migration. If there is
 method involved in the old call like `enableFields()`, the migrated code typically removes all
 doctrine default restrictions and just adds the `DeletedRestriction` again::
 
-
    // Before:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
       'uid, TSconfig',
@@ -85,7 +83,6 @@ doctrine default restrictions and just adds the `DeletedRestriction` again::
 `BackendUtility::versioningPlaceholderClause('pages')` is typically substituted with the
 `BackendWorkspaceRestriction`. Example very similar to the above one::
 
-
    // Before:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(
       'uid, TSconfig',
@@ -95,7 +92,6 @@ doctrine default restrictions and just adds the `DeletedRestriction` again::
          . BackendUtility::versioningPlaceholderClause('pages'),
       'pages.uid'
    );
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -118,7 +114,6 @@ doctrine default restrictions and just adds the `DeletedRestriction` again::
 :php:`BackendUtility::BEenableFields()` in combination with :php:`BackendUtility::deleteClause()` adds the same
 calls as the `DefaultRestrictionContainer`. No further configuration needed::
 
-
    // Before:
    $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
       'title, content, crdate',
@@ -127,7 +122,6 @@ calls as the `DefaultRestrictionContainer`. No further configuration needed::
          . BackendUtility::BEenableFields($systemNewsTable)
          . BackendUtility::deleteClause($systemNewsTable)
    );
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -142,7 +136,6 @@ calls as the `DefaultRestrictionContainer`. No further configuration needed::
 
 :php:`cObj->enableFields()` in frontend context is typically directly substituted with
 `FrontendRestrictionContainer`::
-
 
    // Before:
    $GLOBALS['TYPO3_DB']->exec_SELECTquery(
@@ -169,8 +162,7 @@ From ->exec_UDATEquery() to ->update()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Most often, the easiest way to migrate a `$GLOBALS['TYPO3_DB']->exec_UDATEquery()` is to use
-:php:`$connection->update()`:
-
+:php:`$connection->update()`::
 
     // Before:
     $database->exec_UPDATEquery(
@@ -197,7 +189,6 @@ Result set iteration
 The `exec_*` calls return a resource object that is typically iterated over using :php:`sql_fetch_assoc()`.
 This is typically changed to :php:`->fetch()` on the `Statement` object::
 
-
    // Before:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(...);
    while ($row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
@@ -217,7 +208,6 @@ sql_insert_id()
 It is sometimes needed to fetch the new `uid` of a just added record to further work with that row.
 In `TYPO3_DB` this was done with a call to :php:`->sql_insert_id()` after a :php:`->exec_INSERTquery()` call
 on the same resource. :php:`->lastInsertId()` can be used instead::
-
 
    // Before:
    $GLOBALS['TYPO3_DB']->exec_INSERTquery(
@@ -248,7 +238,6 @@ fullQuoteStr()
 ^^^^^^^^^^^^^^
 
 :php:`->fullQuoteStr()` is rather straight changed to a :php:`->createNamedParameter()`, typical case::
-
 
    // Before:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -11,7 +11,6 @@ The `QueryBuilder` is a rather huge class that takes care of the main query deal
 An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing
 over the table. Never instantiate and initialize the `QueryBuilder` directly via :php:`makeInstance()`! ::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
@@ -44,7 +43,6 @@ The `QueryBuilder` comes with a happy little list of small methods:
 
 Most methods of the `QueryBuilder` return `$this` and can be chained::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Connection;
@@ -76,20 +74,17 @@ Select all fields::
 :php:`->select()` and a number of other methods of the `QueryBuilder` are `variadic <https://en.wikipedia.org/wiki/Variadic_function>`__
 and can handle any number of arguments. For :php:`->select()`, every argument is interpreted as a single field name to select::
 
-
    // SELECT `uid`, `pid`, `aField`
    $queryBuilder->select('uid', 'pid', 'aField');
 
 
 Argument unpacking can be used if the list of fields is available as array already::
 
-
    $fields = ['uid', 'pid', 'aField', 'anotherField'];
    $queryBuilder->select(...$fields);
 
 
 :php:`->select()` supports `AS` and quotes identifiers automatically. This can become especially handy in join() operations::
-
 
    // SELECT `tt_content`.`bodytext` AS `t1`.`text`
    $queryBuilder->select('tt_content.bodytext AS t1.text')
@@ -105,7 +100,6 @@ constraints, :php:`->andWhere()` appends additional constraints.
 
 A useful combination of :php:`->select()` and :php:`->addSelect()` can be::
 
-
    $queryBuilder->select(...$defaultList);
    if ($needAdditionalFields) {
       $queryBuilder->addSelect(...$additionalFields);
@@ -114,7 +108,6 @@ A useful combination of :php:`->select()` and :php:`->addSelect()` can be::
 Calling :php:`->execute()` on a :php:`->select()` query returns a `Statement` object. To receive single rows a :php:`->fetch()`
 loop on that object is used, or :php:`->fetchAll()` to return a single array with all rows. A typical code flow
 of a `SELECT` query looks like::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -147,7 +140,6 @@ count()
 =======
 
 Create a `COUNT` query, a typical usage::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -190,7 +182,6 @@ delete()
 
 Create a `DELETE FROM` query. The method requires the table name to drop data from. Classic usage::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // DELETE FROM `tt_content` WHERE `bodytext` = 'klaus'
@@ -230,7 +221,6 @@ update() and set()
 
 Create an `UPDATE` query. Typical usage::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // UPDATE `tt_content` SET `bodytext` = 'peter' WHERE `bodytext` = 'klaus'
@@ -248,7 +238,6 @@ Create an `UPDATE` query. Typical usage::
 :php:`->update()` requires the table to update as first argument and a table alias as optional second argument.
 The table alias can then be used in :php:`->set()` and :php:`->where()` expressions::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // UPDATE `tt_content` `t` SET `t`.`bodytext` = 'peter' WHERE `u`.`bodytext` = 'klaus'
@@ -261,14 +250,12 @@ The table alias can then be used in :php:`->set()` and :php:`->where()` expressi
       ->set('u.bodytext', 'peter')
       ->execute();
 
-
 :php:`->set()` requires a field name as first argument and automatically quotes it internally. The second mandatory
 argument is the value a field should be set to, the value is automatically transformed to a named parameter
 of a prepared statement. This way, :php:`->set()` key/value pairs are automatically SQL injection save by default.
 
 If a field should be set to the value of another field from the row, the quoting needs to be turned off and
 :php:`->quoteIdentifier()` has to be used::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -281,7 +268,6 @@ If a field should be set to the value of another field from the row, the quoting
       )
       ->set('bodytext', $queryBuilder->quoteIdentifier('header'), false)
       ->execute();
-
 
 Remarks:
 
@@ -305,7 +291,6 @@ insert() and values()
 =====================
 
 Create an `INSERT` query. Typical usage::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -342,7 +327,6 @@ from()
 and the table name is typically the same as what was given to :php:`->getQueryBuilderForTable()`. If the query joins
 multiple tables, the argument should be the name of the first table within the :php:`->join()` chain::
 
-
    // FROM `myTable`
    $queryBuilder->from('myTable');
 
@@ -361,7 +345,6 @@ where(), andWhere() and orWhere()
 
 The three methods are used to create `WHERE` restrictions for `SELECT`, `COUNT`, `UPDATE` and `DELETE` query types.
 Each argument is typically an `ExpressionBuilder` object that will be cast to a string on :php:`->execute()`::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -395,7 +378,6 @@ Note the parenthesis of the above example: :php:`->andWhere()` encapsulates both
 with an additional restriction.
 
 Argument unpacking can become handy with these methods::
-
 
    $whereExpressions = [
       $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus')),
@@ -436,7 +418,6 @@ Joining multiple tables in a :php:`->select()` or :php:`->count()` query is done
 are supported by calling the methods more than once. All methods require four arguments: The name of the left side
 table (or its alias), the name of the right side table, an alias for the right side table name and the join
 restriction as fourth argument::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -497,7 +478,6 @@ Notes to the above example:
 
 A more complex example with two joins. The first join points to the first table again using an alias to resolve
 a language overlay scenario. The second join uses the alias name of the first join target as left side::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -567,7 +547,6 @@ orderBy() and addOrderBy()
 Add `ORDER BY` to a :php:`->select()` statement. Both :php:`->orderBy()` and :php:`->addOrderBy()` require a field name as first
 argument::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `sys_language` ORDER BY `sorting` ASC
@@ -606,7 +585,6 @@ groupBy() and addGroupBy()
 
 Add `GROUP BY` to a :php:`->select()` statement. Each argument to the methods is a single identifier::
 
-
    // GROUP BY `pages_language_overlay`.`sys_language_uid`, `sys_language`.`uid`
    ->groupBy('pages_language_overlay.sys_language_uid', 'sys_language.uid');
 
@@ -629,7 +607,6 @@ setMaxResults() and setFirstResult()
 Add `LIMIT` to restrict number of records and `OFFSET` for pagination query parts. Both methods should be
 called only once per statement::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `sys_language` LIMIT 2 OFFSET 4
@@ -640,7 +617,6 @@ called only once per statement::
       ->setMaxResults(2)
       ->setFirstResult(4)
       ->execute();
-
 
 Remarks:
 
@@ -657,7 +633,6 @@ add()
 
 Method :php:`->add()` appends to or replaces a single, generic query part. It can be used as a low level call
 if more specific calls don't give enough freedom to express parts of statments::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -683,7 +658,6 @@ getSQL()
 
 Method :php:`->getSQL()` returns the created query statement as string. It is incredibly useful during development
 to verify the final statement is executed just as a developer expects it::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -714,7 +688,6 @@ getParameters()
 ===============
 
 Method :php:`->getParameters()` returns the values for the prepared statement placeholders in an array. It is incredibly useful during development to verify the final statement is executed just as a developer expects it::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -756,7 +729,6 @@ expr()
 Return an instance of the `ExpressionBuilder`. This object is used to create complex `WHERE` query parts and `JOIN`
 expressions::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `uid` FROM `tt_content` WHERE (`uid` > 42)
@@ -787,7 +759,6 @@ createNamedParameter()
 Create a placeholder for a prepared statement field value. **Always** use that when dealing with user input in
 expressions to make the statement SQL injection safe::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `tt_content` WHERE (`bodytext` = 'kl\'aus')
@@ -807,7 +778,6 @@ and would break the query if not channeled through :php:`->createNamedParameter(
 the value SQL injection safe.
 
 Not convinced? Suppose the code would look like this::
-
 
    // NEVER EVER DO THIS!
    $_POST['searchword'] = "'foo' UNION SELECT username FROM be_users";
@@ -848,7 +818,6 @@ Rules:
   or :php:`GeneralUtility::quoteJSvalue()`, too. Sanitizing should be directly obvious at the very place where it is
   important::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // DO
@@ -882,7 +851,6 @@ quoteIdentifier() and quoteIdentifiers()
 :php:`->quoteIdentifier()` must be used if not a value is handled, but a field name. The quoting is different in those
 cases and typically ends up with backticks ````` instead of ticks ``'``::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Connection;
@@ -898,7 +866,6 @@ cases and typically ends up with backticks ````` instead of ticks ``'``::
 
 
 The method quotes single field names or combinations of table names or table aliases with field names::
-
 
    // Single field name: `bodytext`
    ->quoteIdentifier('bodytext');
@@ -931,7 +898,6 @@ escapeLikeWildcards()
 
 Helper method to quote `%` characters within a search string. This is helpful in :php:`->like()` and :php:`->notLike()`
 expressions::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -11,6 +11,9 @@ The `QueryBuilder` is a rather huge class that takes care of the main query deal
 An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing
 over the table. Never instantiate and initialize the `QueryBuilder` directly via :php:`makeInstance()`! ::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
 
 
@@ -41,6 +44,11 @@ The `QueryBuilder` comes with a happy little list of small methods:
 
 Most methods of the `QueryBuilder` return `$this` and can be chained::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages')->createQueryBuilder();
    $queryBuilder->select('uid')->from('pages');
 
 .. note::
@@ -60,6 +68,7 @@ Create a `SELECT` query.
 
 Select all fields::
 
+
    // SELECT *
    $queryBuilder->select('*')
 
@@ -67,17 +76,20 @@ Select all fields::
 :php:`->select()` and a number of other methods of the `QueryBuilder` are `variadic <https://en.wikipedia.org/wiki/Variadic_function>`__
 and can handle any number of arguments. For :php:`->select()`, every argument is interpreted as a single field name to select::
 
+
    // SELECT `uid`, `pid`, `aField`
    $queryBuilder->select('uid', 'pid', 'aField');
 
 
 Argument unpacking can be used if the list of fields is available as array already::
 
+
    $fields = ['uid', 'pid', 'aField', 'anotherField'];
    $queryBuilder->select(...$fields);
 
 
 :php:`->select()` supports `AS` and quotes identifiers automatically. This can become especially handy in join() operations::
+
 
    // SELECT `tt_content`.`bodytext` AS `t1`.`text`
    $queryBuilder->select('tt_content.bodytext AS t1.text')
@@ -93,6 +105,7 @@ constraints, :php:`->andWhere()` appends additional constraints.
 
 A useful combination of :php:`->select()` and :php:`->addSelect()` can be::
 
+
    $queryBuilder->select(...$defaultList);
    if ($needAdditionalFields) {
       $queryBuilder->addSelect(...$additionalFields);
@@ -102,6 +115,9 @@ Calling :php:`->execute()` on a :php:`->select()` query returns a `Statement` ob
 loop on that object is used, or :php:`->fetchAll()` to return a single array with all rows. A typical code flow
 of a `SELECT` query looks like::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $statement = $queryBuilder
       ->select('uid', 'header', 'bodytext')
@@ -132,10 +148,14 @@ count()
 
 Create a `COUNT` query, a typical usage::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT COUNT(`uid`) FROM `tt_content` WHERE (`bodytext` = 'klaus')
    //     AND ((`tt_content`.`deleted` = 0) AND (`tt_content`.`hidden` = 0)
    //     AND (`tt_content`.`starttime` <= 1475580240)
    //     AND ((`tt_content`.`endtime` = 0) OR (`tt_content`.`endtime` > 1475580240)))
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $count = $queryBuilder
       ->count('uid')
       ->from('tt_content')
@@ -170,7 +190,11 @@ delete()
 
 Create a `DELETE FROM` query. The method requires the table name to drop data from. Classic usage::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // DELETE FROM `tt_content` WHERE `bodytext` = 'klaus'
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $affectedRows = $queryBuilder
       ->delete('tt_content')
       ->where(
@@ -206,8 +230,12 @@ update() and set()
 
 Create an `UPDATE` query. Typical usage::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // UPDATE `tt_content` SET `bodytext` = 'peter' WHERE `bodytext` = 'klaus'
-   queryBuilder
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
+   $queryBuilder
       ->update('tt_content')
       ->where(
          $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus')
@@ -219,7 +247,11 @@ Create an `UPDATE` query. Typical usage::
 :php:`->update()` requires the table to update as first argument and a table alias as optional second argument.
 The table alias can then be used in :php:`->set()` and :php:`->where()` expressions::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // UPDATE `tt_content` `t` SET `t`.`bodytext` = 'peter' WHERE `u`.`bodytext` = 'klaus'
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder
       ->update('tt_content', 'u')
       ->where(
@@ -236,7 +268,11 @@ of a prepared statement. This way, :php:`->set()` key/value pairs are automatica
 If a field should be set to the value of another field from the row, the quoting needs to be turned off and
 :php:`->quoteIdentifier()` has to be used::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // UPDATE `tt_content` SET `bodytext` = `header` WHERE `bodytext` = 'klaus'
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder
       ->update('tt_content')
       ->where(
@@ -269,6 +305,10 @@ insert() and values()
 
 Create an `INSERT` query. Typical usage::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $affectedRows = $queryBuilder
       ->insert('tt_content')
       ->values([
@@ -301,6 +341,7 @@ from()
 and the table name is typically the same as what was given to :php:`->getQueryBuilderForTable()`. If the query joins
 multiple tables, the argument should be the name of the first table within the :php:`->join()` chain::
 
+
    // FROM `myTable`
    $queryBuilder->from('myTable');
 
@@ -320,6 +361,9 @@ where(), andWhere() and orWhere()
 The three methods are used to create `WHERE` restrictions for `SELECT`, `COUNT`, `UPDATE` and `DELETE` query types.
 Each argument is typically an `ExpressionBuilder` object that will be cast to a string on :php:`->execute()`::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `uid`, `header`, `bodytext`
    // FROM `tt_content`
    // WHERE
@@ -329,6 +373,7 @@ Each argument is typically an `ExpressionBuilder` object that will be cast to a 
    //    )
    //    AND (`pid` = 42)
    //    AND ... RestrictionBuilder TCA restrictions ...
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $statement = $queryBuilder
       ->select('uid', 'header', 'bodytext')
       ->from('tt_content')
@@ -349,6 +394,7 @@ Note the parenthesis of the above example: :php:`->andWhere()` encapsulates both
 with an additional restriction.
 
 Argument unpacking can become handy with these methods::
+
 
    $whereExpressions = [
       $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus')),
@@ -390,6 +436,9 @@ are supported by calling the methods more than once. All methods require four ar
 table (or its alias), the name of the right side table, an alias for the right side table name and the join
 restriction as fourth argument::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `sys_language`.`uid`, `sys_language`.`title`
    // FROM `sys_language`
    // INNER JOIN `pages_language_overlay` `overlay`
@@ -448,6 +497,9 @@ Notes to the above example:
 A more complex example with two joins. The first join points to the first table again using an alias to resolve
 a language overlay scenario. The second join uses the alias name of the first join target as left side::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `tt_content_orig`.`sys_language_uid`
    // FROM `tt_content`
    // INNER JOIN `tt_content` `tt_content_orig` ON `tt_content`.`t3_origuid` = `tt_content_orig`.`uid`
@@ -514,6 +566,9 @@ orderBy() and addOrderBy()
 Add `ORDER BY` to a :php:`->select()` statement. Both :php:`->orderBy()` and :php:`->addOrderBy()` require a field name as first
 argument::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `sys_language` ORDER BY `sorting` ASC
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
    $queryBuilder->getRestrictions()->removeAll();
@@ -540,7 +595,7 @@ Remarks:
 * To create a chain of orders, use :php:`->orderBy()` and then multiple :php:`->addOrderBy()` calls. Calling
   :php:`->orderBy('header')->addOrderBy('bodytext')->addOrderBy('uid', 'DESC')` creates
   ``ORDER BY `header` ASC, `bodytext` ASC, `uid` DESC``
-  
+
 * To add more complex sorting, you can use :php:`->add('orderBy', 'FIELD(eventtype, 0, 4, 1, 2, 3)', true)`,
   remember to quote properly
 
@@ -549,6 +604,7 @@ groupBy() and addGroupBy()
 ==========================
 
 Add `GROUP BY` to a :php:`->select()` statement. Each argument to the methods is a single identifier::
+
 
    // GROUP BY `pages_language_overlay`.`sys_language_uid`, `sys_language`.`uid`
    ->groupBy('pages_language_overlay.sys_language_uid', 'sys_language.uid');
@@ -572,7 +628,11 @@ setMaxResults() and setFirstResult()
 Add `LIMIT` to restrict number of records and `OFFSET` for pagination query parts. Both methods should be
 called only once per statement::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `sys_language` LIMIT 2 OFFSET 4
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
    $queryBuilder
       ->select('*')
       ->from('sys_language')
@@ -597,6 +657,9 @@ add()
 Method :php:`->add()` appends to or replaces a single, generic query part. It can be used as a low level call
 if more specific calls don't give enough freedom to express parts of statments::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
    $queryBuilder->select('*')->from('sys_language');
    $queryBuilder->add('orderBy', 'FIELD(eventtype, 0, 4, 1, 2, 3)');
@@ -620,6 +683,9 @@ getSQL()
 Method :php:`->getSQL()` returns the created query statement as string. It is incredibly useful during development
 to verify the final statement is executed just as a developer expects it::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
    $queryBuilder->select('*')->from('sys_language');
    debug($queryBuilder->getSQL());
@@ -648,6 +714,9 @@ getParameters()
 
 Method :php:`->getParameters()` returns the values for the prepared statement placeholders in an array. It is incredibly useful during development to verify the final statement is executed just as a developer expects it::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('sys_language');
    $queryBuilder->select('*')->from('sys_language');
    debug($queryBuilder->getParameters());
@@ -686,7 +755,11 @@ expr()
 Return an instance of the `ExpressionBuilder`. This object is used to create complex `WHERE` query parts and `JOIN`
 expressions::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT `uid` FROM `tt_content` WHERE (`uid` > 42)
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder
       ->select('uid')
       ->from('tt_content')
@@ -713,6 +786,9 @@ createNamedParameter()
 Create a placeholder for a prepared statement field value. **Always** use that when dealing with user input in
 expressions to make the statement SQL injection safe::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // SELECT * FROM `tt_content` WHERE (`bodytext` = 'kl\'aus')
    $searchWord = "kl'aus"; // $searchWord = GeneralUtility::_GP('searchword');
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
@@ -730,6 +806,7 @@ and would break the query if not channeled through :php:`->createNamedParameter(
 the value SQL injection safe.
 
 Not convinced? Suppose the code would look like this::
+
 
    // NEVER EVER DO THIS!
    $_POST['searchword'] = "'foo' UNION SELECT username FROM be_users";
@@ -770,6 +847,9 @@ Rules:
   or :php:`GeneralUtility::quoteJSvalue()`, too. Sanitizing should be directly obvious at the very place where it is
   important::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // DO
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder->getRestrictions()->removeAll();
@@ -801,6 +881,10 @@ quoteIdentifier() and quoteIdentifiers()
 :php:`->quoteIdentifier()` must be used if not a value is handled, but a field name. The quoting is different in those
 cases and typically ends up with backticks ````` instead of ticks ``'``::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
    // SELECT `uid` FROM `tt_content` WHERE (`header` = `bodytext`)
    // Return list of rows where header and bodytext values are identical
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
@@ -813,6 +897,7 @@ cases and typically ends up with backticks ````` instead of ticks ``'``::
 
 
 The method quotes single field names or combinations of table names or table aliases with field names::
+
 
    // Single field name: `bodytext`
    ->quoteIdentifier('bodytext');
@@ -846,8 +931,13 @@ escapeLikeWildcards()
 Helper method to quote `%` characters within a search string. This is helpful in :php:`->like()` and :php:`->notLike()`
 expressions::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Connection;
    // SELECT `uid` FROM `tt_content` WHERE (`bodytext` LIKE '%kl\\%aus%')
    $searchWord = 'kl%aus';
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder
       ->select('uid')
       ->from('tt_content')

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -156,7 +156,6 @@ However, many backend modules still want to show disabled records and remove the
 restrictions to allow administration of those records for an editor. A typical setup from within a
 backend module::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction
@@ -182,7 +181,6 @@ An alternative to the recommended way of first removing all restrictions and the
 ones again (using :php:`->removeAll()`, then :php:`->add()`) is to kick specific restrictions with a call to
 :php:`->removeByType()`::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction
@@ -198,7 +196,6 @@ ones again (using :php:`->removeAll()`, then :php:`->add()`) is to kick specific
 In the frontend it is often needed to swap the `DefaultRestrictionContainer` with the
 `FrontendRestrictionContainer`::
 
-
    // use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer
    // Kick default restrictions and add list of default frontend restrictions
    $queryBuilder->setRestrictions(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
@@ -207,7 +204,6 @@ In the frontend it is often needed to swap the `DefaultRestrictionContainer` wit
 Note that :php:`->setRestrictions()` resets any previously specified restrictions. Any class instance implementing
 `QueryRestrictionContainerInterface` can be given to :php:`->setRestrictions()`. This allows extensions to
 deliver and use an own set of restrictions for own query statements if needed.
-
 
 .. tip::
 

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -156,6 +156,10 @@ However, many backend modules still want to show disabled records and remove the
 restrictions to allow administration of those records for an editor. A typical setup from within a
 backend module::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction
    // SELECT `uid`, `bodytext` FROM `tt_content` WHERE (`pid` = 42) AND (`tt_content`.`deleted` = 0)
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    // Remove all restrictions but add DeletedRestriction again
@@ -178,7 +182,13 @@ An alternative to the recommended way of first removing all restrictions and the
 ones again (using :php:`->removeAll()`, then :php:`->add()`) is to kick specific restrictions with a call to
 :php:`->removeByType()`::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   // use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction
+   // use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction
    // Remove starttime and endtime, but keep hidden and deleted
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder
       ->getRestrictions()
       ->removeByType(StartTimeRestriction::class)
@@ -188,6 +198,8 @@ ones again (using :php:`->removeAll()`, then :php:`->add()`) is to kick specific
 In the frontend it is often needed to swap the `DefaultRestrictionContainer` with the
 `FrontendRestrictionContainer`::
 
+
+   // use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer
    // Kick default restrictions and add list of default frontend restrictions
    $queryBuilder->setRestrictions(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
 

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -119,8 +119,7 @@ not properly implementing prepared statements fall back to a direct execution of
 
 There is an API to make real use of prepared statements that becomes handy if the same query is executed
 with different arguments over and over again. The example below prepares a statement to the `pages` table
-and executes it twice with different arguments:
-
+and executes it twice with different arguments::
 
     // use TYPO3\CMS\Core\Utility\GeneralUtility;
     // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -140,6 +139,7 @@ and executes it twice with different arguments:
 
 Looking at a mysql debug log:
 
+.. code-block:: sql
 
     Prepare SELECT `uid` FROM `pages` WHERE `uid` = ?
     Execute SELECT `uid` FROM `pages` WHERE `uid` = '24'

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -37,6 +37,9 @@ fetch()
 
 Fetch next row from a result statement. Usually used in while() loops. Typical example::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Fetch all records from tt_content on page 42
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $statement = $queryBuilder
@@ -60,6 +63,9 @@ Returns an array containing all of the result set rows by implementing the same 
 Using that method saves some precious code characters but is more memory intensive if the result set is large
 with lots of rows and lot of data since big arrays are carried around in `PHP`::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Fetch all records from tt_content on page 42
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $rows = $queryBuilder
@@ -77,6 +83,9 @@ Returns a single column from the next row of a result set, other columns from th
 This method is especially handy for :php:`QueryBuilder->count()` queries. The :php:`Connection->count()` implementation
 does exactly that to return the number of rows directly::
 
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Get the number of tt_content records on pid 42 into variable $numberOfRecords
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $numberOfRecords = $queryBuilder
@@ -112,8 +121,9 @@ There is an API to make real use of prepared statements that becomes handy if th
 with different arguments over and over again. The example below prepares a statement to the `pages` table
 and executes it twice with different arguments:
 
-.. code-block:: php
 
+    // use TYPO3\CMS\Core\Utility\GeneralUtility;
+    // use TYPO3\CMS\Core\Database\ConnectionPool;
     $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages');
     $queryBuilder = $connection->createQueryBuilder();
     $queryBuilder->getRestrictions()->removeAll();
@@ -130,7 +140,6 @@ and executes it twice with different arguments:
 
 Looking at a mysql debug log:
 
-.. code-block:: php
 
     Prepare SELECT `uid` FROM `pages` WHERE `uid` = ?
     Execute SELECT `uid` FROM `pages` WHERE `uid` = '24'

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -37,7 +37,6 @@ fetch()
 
 Fetch next row from a result statement. Usually used in while() loops. Typical example::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Fetch all records from tt_content on page 42
@@ -63,7 +62,6 @@ Returns an array containing all of the result set rows by implementing the same 
 Using that method saves some precious code characters but is more memory intensive if the result set is large
 with lots of rows and lot of data since big arrays are carried around in `PHP`::
 
-
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    // Fetch all records from tt_content on page 42
@@ -82,7 +80,6 @@ fetchColumn()
 Returns a single column from the next row of a result set, other columns from that result row are discarded.
 This method is especially handy for :php:`QueryBuilder->count()` queries. The :php:`Connection->count()` implementation
 does exactly that to return the number of rows directly::
-
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;


### PR DESCRIPTION
The additional `.. code-block:: php` are simply deco and cleanup, so
that all PHP code blocks have the same formatting through the whole
document.

In the same way as in 82a9e08652bfd8964374df70ae1a1df3bdbf6d95, I added
several lines about the namespace of the actual classes used in the
examples for better readability.