### PR TITLE
"Configuration\TCA\*.php"

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -123,4 +123,4 @@ The following example contains the complete code::
     })();
 
 In most cases, the file :file:`ext_tables.php` is no longer needed, since most of
-the code can be placed in :file:`Configuration\TCA\*.php` files.
+the code can be placed in :file:`Configuration\\TCA\\*.php` files.

--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -123,4 +123,4 @@ The following example contains the complete code::
     })();
 
 In most cases, the file :file:`ext_tables.php` is no longer needed, since most of
-the code can be placed in :file:`Configuration\\TCA\\*.php` files.
+the code can be placed in :file:`Configuration/TCA/*.php` files.


### PR DESCRIPTION
The file name is shown as "ConfigurationTCA*.php" on the documentation website.
The backslash must be escaped inside of the string.

https://docs.python.org/2.0/ref/strings.html