### PR TITLE
FEATURE: Document environment and l10n path changes

### DIFF
--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -15,6 +15,8 @@ root. This setup however did not fully settle yet, and is not documented
 here in detail. So, if you look at "casual" TYPO3 installations, you will
 almost always find the directory structure as outlined below.
 
+Also see :ref:`Environment` for further information, especially how to retrieve
+the paths within PHP code.
 
 .. t3-field-list-table::
   :header-rows: 1
@@ -53,25 +55,24 @@ almost always find the directory structure as outlined below.
       for more information on how single extensions are structured.
 
 
-  - :Directory: :file:`typo3conf/`
+  - :Directory: :ref:`Environment-config-path` either :file:`typo3conf/` or :file:`config/`
     :Description:
-      TYPO3 configuration directory. This directory contains local extensions
-      in :file:`typo3conf/ext` folder. It may also contain a :file:`typo3conf/l10n`
-      directory that holds localisation files for frontend or backend languages
-      other than english.
+      TYPO3 configuration directory. This directory contains installation wide
+      configuration.
 
-      The most important file within :file:`typo3conf/` however is
-      :file:`LocalConfiguration.php`. This one contains local settings of the main
-      global PHP array :php:`$GLOBALS['TYPO3_CONF_VARS`], crucial settings like
-      database connect credentials are in here. The file is managed by the Install
-      Tool and the Extension Manager and the content should not be managed manually
-      since Extension Manager or Install Tool may override manually changed settings
-      again.
+      The most important file within this folder is
+      :file:`LocalConfiguration.php`. This one contains local settings of the
+      main global PHP array :php:`$GLOBALS['TYPO3_CONF_VARS`], crucial settings
+      like database connect credentials are in here. The file is managed by the
+      Install Tool and the Extension Manager and the content should not be
+      managed manually since Extension Manager or Install Tool may override
+      manually changed settings again.
 
-      The file :file:`LocalConfiguration.php` can be enriched by :file:`AdditionalConfiguration.php`
-      which is never touched by TYPO3 internal management tools. Be aware that having
-      settings within :file:`AdditionalConfiguration.php` may prevent the system from
-      doing automatic upgrades and should be used with care and only if you know what
+      The file :file:`LocalConfiguration.php` can be enriched by
+      :file:`AdditionalConfiguration.php` which is never touched by TYPO3
+      internal management tools. Be aware that having settings within
+      :file:`AdditionalConfiguration.php` may prevent the system from doing
+      automatic upgrades and should be used with care and only if you know what
       you are doing.
 
 
@@ -80,10 +81,10 @@ almost always find the directory structure as outlined below.
       Directory for local TYPO3 extensions. Each subdirectory contains one extension.
 
 
-  - :Directory: :file:`typo3conf/l10n`
+  - :Directory: :ref:`Environment-labels-path` either :file:`typo3conf/l10n` or :file:`var/labels`
     :Description:
-      Directory for extension localisations. The "Language" module of the TYPO3 Backend
-      manages this directory.
+      Directory for extension localisations. Contains all downloaded translation
+      files.
 
 
   - :Directory: :file:`typo3temp/`

--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -6,7 +6,7 @@
 Environment
 ===========
 
-Since version 9.x the TYPO3 CMS core includes an environment class.
+Since version 9.x the TYPO3 core includes an environment class.
 This class contains all environment specific information, e.g. paths within the
 filesystem. This implementation replaces previously used global variables and
 constants like :php:`PATH_site`.
@@ -17,74 +17,66 @@ class provides static methods to access the necessary information.
 Also for testing, the :php:`initialize()` method can be called to adjust the
 information.
 
+
 .. _Environment-project-path:
 
-project path
-------------
+getProjectPath()
+----------------
 
-The environment provides the path to the folder containing the
-:file:`composer.json`, or public web folder for non composer projects.
+The environment provides the path to the folder containing the :file:`composer.json`.
+For projects without Composer setup, this is equal to :ref:`Environment-public-path`.
 
-The path is available through :php:`getProjectPath()` method.
 
 .. _Environment-public-path:
 
-public path
------------
+getPublicPath()
+---------------
 
 The environment provides the path to the public web folder with
 :file:`index.php` for TYPO3 frontend. This was previously :php:`PATH_site`.
+For projects without Composer setup, this is equal to :ref:`Environment-project-path`.
 
-For non composer setups, this is equal to :ref:`Environment-project-path`.
-
-The path is available through :php:`getPublicPath()` method.
 
 .. _Environment-var-path:
 
-var path
---------
+getVarPath()
+------------
 
 The environment provides the path to :file:`var` folder. This folder contains
 data like logs, sessions, locks and cache files.
 
-The folder is, by default, :file:`typo3temp/var` for setups where the project
-path is equal to public path, e.g. "classic" installation without composer.
+For projects with Composer setup, the value is :php:`getProjectPath() . '/var'`,
+so it is outside of the web document root - not within :php:`getPublicPath()`.
 
-For setups where project path and public path are not equal, the default is
-:file:`$projectPath/var`. This way these files are not available to the public.
+Without Composer, the value is :php:`getPublicPath() . '/typo3temp/var'`, so within
+the web document root - a situation that is not optimal from a security point of view.
 
-The path is available through :php:`getVarPath()` method.
 
 .. _Environment-config-path:
 
-config path
------------
+getConfigPath()
+---------------
 
-The environment provides the path to :file:`typo3conf`. This folder contains all
-TYPO3 global configuration files and folders, e.g. :file:`LocalConfiguration.php`.
+The environment provides the path to :file:`typo3conf`. This folder contains TYPO3
+global configuration files and folders, e.g. :file:`LocalConfiguration.php`.
 
-The folder is, by default, :file:`typo3conf` for setups where the project
-path is equal to public path, e.g. "classic" installation without composer.
+For projects with Composer setup, the value is :php:`getProjectPath() . '/typo3conf'`,
+so it is outside of the web document root - not within :php:`getPublicPath()`.
 
-For setups where project path and public path are not equal, the default is
-:file:`$projectPath/config`. This way these files are not available to the
-public. See :ref:`Environment-project-path`.
+Without Composer, the value is :php:`getPublicPath() . '/typo3conf'`, so within
+the web document root - a situation that is not optimal from a security point of view.
 
-The path is available through :php:`getConfigPath()` method.
 
 .. _Environment-labels-path:
 
-labels path
------------
+getLabelsPath()
+---------------
 
 The environment provides the path to :file:`labels`, respective :file:`l10n`
 folder. This folder contains downloaded translation files.
 
-The folder is, by default, :file:`typo3temp/l10n` for setups where the project
-path is equal to public path, e.g. "classic" installation without composer.
+For projects with Composer setup, the value is :php:`getVarPath() . '/labels'`,
+so it is outside of the web document root - not within :php:`getPublicPath()`.
 
-For setups where project path and public path are not equal, the default is
-:file:`$varPath/labels`. This way these files are not available to the public.
-See :ref:`Environment-var-path`.
-
-The path is available through :php:`getLabelsPath()` method.
+Without Composer, the value is :php:`getPublicPath() . '/typo3conf/l10n'`, so within
+the web document root - a situation that is not optimal from a security point of view.

--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -1,0 +1,90 @@
+.. include:: ../../Includes.txt
+
+.. _Environment:
+
+===========
+Environment
+===========
+
+Since version 9.x the TYPO3 CMS core includes an environment class.
+This class contains all environment specific information, e.g. paths within the
+filesystem. This implementation replaces previously used global variables and
+constants like :php:`PATH_site`.
+
+The fully qualified class name is :php:`\TYPO3\CMS\Core\Core\Environment`. The
+class provides static methods to access the necessary information.
+
+Also for testing, the :php:`initialize()` method can be called to adjust the
+information.
+
+.. _Environment-project-path:
+
+project path
+------------
+
+The environment provides the path to the folder containing the
+:file:`composer.json`, or public web folder for non composer projects.
+
+The path is available through :php:`getProjectPath()` method.
+
+.. _Environment-public-path:
+
+public path
+-----------
+
+The environment provides the path to the public web folder with
+:file:`index.php` for TYPO3 frontend. This was previously :php:`PATH_site`.
+
+For non composer setups, this is equal to :ref:`Environment-project-path`.
+
+The path is available through :php:`getPublicPath()` method.
+
+.. _Environment-var-path:
+
+var path
+--------
+
+The environment provides the path to :file:`var` folder. This folder contains
+data like logs, sessions, locks and cache files.
+
+The folder is, by default, :file:`typo3temp/var` for setups where the project
+path is equal to public path, e.g. "classic" installation without composer.
+
+For setups where project path and public path are not equal, the default is
+:file:`$projectPath/var`. This way these files are not available to the public.
+
+The path is available through :php:`getVarPath()` method.
+
+.. _Environment-config-path:
+
+config path
+-----------
+
+The environment provides the path to :file:`typo3conf`. This folder contains all
+TYPO3 global configuration files and folders, e.g. :file:`LocalConfiguration.php`.
+
+The folder is, by default, :file:`typo3conf` for setups where the project
+path is equal to public path, e.g. "classic" installation without composer.
+
+For setups where project path and public path are not equal, the default is
+:file:`$projectPath/config`. This way these files are not available to the
+public. See :ref:`Environment-project-path`.
+
+The path is available through :php:`getConfigPath()` method.
+
+.. _Environment-labels-path:
+
+labels path
+-----------
+
+The environment provides the path to :file:`labels`, respective :file:`l10n`
+folder. This folder contains downloaded translation files.
+
+The folder is, by default, :file:`typo3temp/l10n` for setups where the project
+path is equal to public path, e.g. "classic" installation without composer.
+
+For setups where project path and public path are not equal, the default is
+:file:`$varPath/labels`. This way these files are not available to the public.
+See :ref:`Environment-var-path`.
+
+The path is available through :php:`getLabelsPath()` method.

--- a/Documentation/ApiOverview/Index.rst
+++ b/Documentation/ApiOverview/Index.rst
@@ -47,6 +47,7 @@ This chapter describes the most important elements of the API.
    Categories/Index
    Collections/Index
    Enumerations/Index
+   Environment/Index
    Http/Index
    Icon/Index
    Hooks/Index

--- a/Documentation/ApiOverview/Internationalization/ManagingTranslations.rst
+++ b/Documentation/ApiOverview/Internationalization/ManagingTranslations.rst
@@ -156,12 +156,12 @@ translated::
 In this case we define that "gsw_CH" (which is the `official code <http://www.localeplanet.com/icu/>`_ for
 "Schwiizertüütsch" - that is, "Swiss German") can fall back on "de_AT" (another custom translation) and then on "de".
 
-The translations have to be stored in the appopriate folder, in this case
-:ref:`Environment-labels-path`/:file:`gsw_CH`.
+The translations have to be stored in the appropriate labels path sub folder
+(:ref:`Environment-labels-path`), in this case :file:`/gsw_CH`.
 
 The very least you need is to translate the label containing the name of the
 language itself, so that it appears in the user preferences. In our example this
-would be in file :ref:`Environment-labels-path`/:file:`gsw_CH/setup/mod/gsw_CH.locallang.xlf`.
+would be in file :file:`/gsw_CH/setup/mod/gsw_CH.locallang.xlf`.
 
 .. code-block:: xml
 

--- a/Documentation/ApiOverview/Internationalization/ManagingTranslations.rst
+++ b/Documentation/ApiOverview/Internationalization/ManagingTranslations.rst
@@ -31,7 +31,7 @@ The interface of the Install Tool in **ADMIN TOOLS > Maintenance > Manage langua
 allows to manage the list of available languages to your users and can fetch and
 update language packs of TER and core extensions from the official translation server.
 The module is rather straight forward to use and should be pretty much self explanatory.
-Downloaded language packs are stored in :file:`typo3conf/l10n/[language code]`.
+Downloaded language packs are stored in :ref:`Environment-labels-path`.
 
 .. figure:: ../../Images/InternationalizationManageLanguagePacks.png
    :alt: The Languages module
@@ -123,7 +123,7 @@ and the result can be easily seen in the backend:
    - The files containing the custom labels must be located inside an extension. Other locations
      will not be considered.
 
-   - The original translation needs to exist in :file:`typo3temp/l10n/` or next to the base
+   - The original translation needs to exist in :ref:`Environment-labels-path` or next to the base
      translation file in extensions, for example in :file:`typo3conf/ext/myext/Resources/Private/Language/`.
 
 
@@ -157,11 +157,11 @@ In this case we define that "gsw_CH" (which is the `official code <http://www.lo
 "Schwiizertüütsch" - that is, "Swiss German") can fall back on "de_AT" (another custom translation) and then on "de".
 
 The translations have to be stored in the appopriate folder, in this case
-:file:`typo3conf/l10n/gsw_CH`.
+:ref:`Environment-labels-path`/:file:`gsw_CH`.
 
 The very least you need is to translate the label containing the name of the
-language itself, so that it appears in the user preferences. In our example
-this would be in file :file:`typo3conf/l10n/gsw_CH/setup/mod/gsw_CH.locallang.xlf`.
+language itself, so that it appears in the user preferences. In our example this
+would be in file :ref:`Environment-labels-path`/:file:`gsw_CH/setup/mod/gsw_CH.locallang.xlf`.
 
 .. code-block:: xml
 


### PR DESCRIPTION
* Add new section about Environment class and new paths.
* Adjust typo3conf/l10n occurrences to use new Environment class
  information.

Relates: #321