### PR TITLE
TASK: Replace tce_db file with record/commit route

### DIFF
--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -1,9 +1,6 @@
 .. include:: ../../../Includes.txt
 
-
-
 .. _tce-database-basics:
-
 .. _datahandler-basics:
 
 ========================================================
@@ -273,7 +270,7 @@ Command keywords and values
            - "setStage": Sets the stage of an element. *Special feature: The id-
              key in the array can be a comma list of ids in order to perform the
              stageChange over a number of records. Also, the internal variable
-             ->generalComment (also available through :file:`tce_db.php` as
+             ->generalComment (also available through `/record/commit route` as
              "&generalComment") can be used to set a default comment for all stage
              changes of an instance of tcemain.* Additional keys for this action
              is:

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -270,13 +270,12 @@ Command keywords and values
            - "setStage": Sets the stage of an element. *Special feature: The id-
              key in the array can be a comma list of ids in order to perform the
              stageChange over a number of records. Also, the internal variable
-             ->generalComment (also available through `/record/commit route` as
-             "&generalComment") can be used to set a default comment for all stage
-             changes of an instance of tcemain.* Additional keys for this action
-             is:
+             ->generalComment (also available through `/record/commit` route as
+             `&generalComment`) can be used to set a default comment for all stage
+             changes of an instance of the data handler.* Additional keys for this action
+             are:
 
-             - [stageId]: Values are: -1 (rejected), 0 (editing, default), 1
-               (review), 10 (publish)
+             - [stageId]: Values are: -1 (rejected), 0 (editing, default), 1 (review), 10 (publish)
 
              - [comment]: Comment string that goes into the log.
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/TceDb/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/TceDb/Index.rst
@@ -1,26 +1,13 @@
 .. include:: ../../../Includes.txt
 
-
-
-
-
-
 .. _tce-db-api:
+.. _record-commit-route:
 
-The "tce\_db.php" API
-^^^^^^^^^^^^^^^^^^^^^
+The "/record/commit" route
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This script is a gateway for POST forms to class
-:php:`\TYPO3\CMS\Core\DataHandling\DataHandler`. It
-has historically been *the* script to which data was posted when you
-wanted to update something in the database.
-
-Today it is used for editing by only a few scripts, actually only the
-"Quick Edit" module in "Web>Page" (frontend). The standard forms you
-find in TYPO3 are normally rendered and handled by :file:`alt_doc.php`
-which includes :code:`\TYPO3\CMS\Core\DataHandling\DataHandler` on its own.
-
-For commands it is still used from various locations.
+This route is a gateway for POST forms to class
+:php:`\TYPO3\CMS\Backend\Controller\SimpleDataHandlerController`.
 
 You can send data to this file either as GET or POST vars where POST
 takes precedence. The variable names you can use are:

--- a/Documentation/ApiOverview/Typo3CoreEngine/TceDb/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/TceDb/Index.rst
@@ -6,7 +6,7 @@
 The "/record/commit" route
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This route is a gateway for POST forms to class
+This route is a gateway for posting form data to the
 :php:`\TYPO3\CMS\Backend\Controller\SimpleDataHandlerController`.
 
 You can send data to this file either as GET or POST vars where POST


### PR DESCRIPTION
As the file was removed, the documentation is now updated to reflect
this change. Instead of calling the file the route is now used.

Resolves: #296