### PR TITLE
Wrong path for custom site property

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/ExtendingSiteConfig.rst
+++ b/Documentation/ApiOverview/SiteHandling/ExtendingSiteConfig.rst
@@ -61,7 +61,7 @@ an input field for a Google API key. However it is **not possible to extend with
 database driven select fields, Flex Form handling and similar.
 
 The example below shows the experimental feature adding a field to site in an extensions file
-:file:`Configuration/SiteConfiguration/Overrides/sites.php`. Note the helper methods of class
+:file:`Configuration/SiteConfiguration/sites.php`. Note the helper methods of class
 :php:`TYPO3\CMS\core\Utility\ExtensionManagementUtility` can not be used.
 
 .. code-block:: php


### PR DESCRIPTION
Site custom fields need to reside in Configuration/SiteConfiguration directly instead of Configuration/SiteConfiguration/Overrides according to practical tests and implementation details at src/public/typo3/sysext/backend/Classes/Configuration/SiteTcaConfiguration.php:51.