### PR TITLE
Add deprecation warning for Extbase command controllers

### DIFF
--- a/Documentation/ApiOverview/BackendModules/CliScripts/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/CliScripts/Index.rst
@@ -71,6 +71,10 @@ A detailed description and an example can be found at `the Symfony Command Docum
 Extbase command controllers
 """""""""""""""""""""""""""
 
+.. warning::
+
+   Extbase command controller is ist deprecated as of TYPO3 9.4. Consider only using the above version.
+
 .. note::
 
    If you do not need Extbase in your command it is recommended to directly use


### PR DESCRIPTION
Since TYPO3 9.4, the Extbase command controller is deprecated, as stated here:
https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.4/Deprecation-85977-ExtbaseCommandControllersAndCliAnnotation.html

This should be reflected in the documentation in order to avoid people working on new Commands and walking right into a wall when updating to TYPO3 10 and having their newly built command not working anymore (and thus creating useless frustration).

Sidenote: I'm not sure if the formatting for the warning is quite right since I couldn't find a proper example for it, I hope this can be edited on merge (or just give me an example and I'll implement it).