### PR TITLE
BUGFIX: Fix wrong MetaTag API examples

### DIFF
--- a/Documentation/ApiOverview/MetaTagApi/Index.rst
+++ b/Documentation/ApiOverview/MetaTagApi/Index.rst
@@ -12,7 +12,7 @@ In order to have the possibility to set metatags in a flexible (but regulated wa
 The API uses :php:`MetaTagManagers` to manage the tags for a "family" of meta tags. The core e.g. ships an
 OpenGraph MetaTagManager that is responsible for all OpenGraph tags.
 In addition to the MetaTagManagers included in the core, you can also register your own
-:php:`MetaTagManager` in the :php:`MetaTagManagerRegistry`.
+:php:`MetaTagManager` in the :php:`\TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry`.
 
 .. _metatagapi-usage:
 
@@ -24,7 +24,10 @@ You can use that manager to add your meta tag; see the example below for the :ht
 
 .. code-block:: php
 
-    $metaTagManager = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance()->getManagerForProperty('og:title');
+    use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+    $metaTagManager = GeneralUtility::makeInstance(MetaTagManagerRegistry::class)->getManagerForProperty('og:title');
     $metaTagManager->addProperty('og:title', 'This is the OG title from a controller');
 
 This code will result in a :html:`<meta property="og:title" content="This is the OG title from a controller" />` tag in frontend.
@@ -33,21 +36,30 @@ If you need to specify sub-properties, e.g. :html:`og:image:width`, you can use 
 
 .. code-block:: php
 
-    $metaTagManager = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance()->getManagerForProperty('og:image');
+    use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+    $metaTagManager = GeneralUtility::makeInstance(MetaTagManagerRegistry::class)->getManagerForProperty('og:image');
     $metaTagManager->addProperty('og:image', '/path/to/image.jpg', ['width' => 400, 'height' => 400]);
 
 You can also remove a specific property:
 
 .. code-block:: php
 
-    $metaTagManager = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance()->getManagerForProperty('og:title');
+    use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+    $metaTagManager = GeneralUtility::makeInstance(MetaTagManagerRegistry::class)->getManagerForProperty('og:title');
     $metaTagManager->removeProperty('og:title');
 
 Or remove all previously set meta tags of a specific manager:
 
 .. code-block:: php
 
-    $metaTagManager = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance()->getManagerForProperty('og:title');
+    use TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+    $metaTagManager = GeneralUtility::makeInstance(MetaTagManagerRegistry::class)->getManagerForProperty('og:title');
     $metaTagManager->removeAllProperties();
 
 .. _metatagapi-create-your-own:
@@ -63,7 +75,7 @@ To use the manager, you must register it in :php:`ext_localconf.php`:
 
 .. code-block:: php
 
-    $metaTagManagerRegistry = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance();
+    $metaTagManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::class);
     $metaTagManagerRegistry->registerManager(
         'custom',
         \Some\CustomExtension\MetaTag\CustomMetaTagManager::class
@@ -75,7 +87,7 @@ want to implement your own :php:`OpenGraphMetaTagManager`, you can use the follo
 
 .. code-block:: php
 
-    $metaTagManagerRegistry = \TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::getInstance();
+    $metaTagManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\MetaTag\MetaTagManagerRegistry::class);
     $metaTagManagerRegistry->registerManager(
         'myOwnOpenGraphManager',
         \Some\CustomExtension\MetaTag\MyOpenGraphMetaTagManager::class,


### PR DESCRIPTION
There is no getInstance method, therefore GeneralUtility::makeInstance
might be a better choice.