### PR TITLE
Avoid problems if sending via SMTP

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -61,6 +61,8 @@ Example::
   $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_encrypt'] = 'ssl'; // ssl, sslv3, tls
   $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_username'] = 'johndoe';
   $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_password'] = 'cooLSecret';
+  $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress'] = 'bounces@example.org';  // fetches all 'returning' emails 
+  
 
 
 .. _mail-configuration-sendmail:
@@ -209,12 +211,21 @@ Tool*::
 This is how you can use these defaults::
 
    $from = \TYPO3\CMS\Core\Utility\MailUtility::getSystemFrom();
+   
    $mail = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Mail\MailMessage::class);
    $mail->setFrom($from);
    // ...
    $mail->send();
 
-
+In case of problem  "Mails are not sent" in your extension, try to set a ReturnPath: start as before but add
+      
+   // you will get a valid Email Adress from  'defaultMailFromAddress' or if not set from PHP settings or from system. 
+   // if result is not a valid email, the final result will be  no-reply@example.com .. 
+   $returnPath = \TYPO3\CMS\Core\Utility\MailUtility::getSystemFromAddress();
+   if ( $returnPath != "no-reply@example.com") {
+       $mail->setReturnPath($returnPath);
+   }
+   $mail->send();
 
 .. _mail-swift:
 


### PR DESCRIPTION
$from should be info-de@aserver.com OR info-en@server.com .. or any other email like support@, sales@ .. but we just have ONE SMTP Connection for all these Possible SENDERS and all not reachable Emails should be collected into the inbox of IT -> "bounces@server.com" then  returnPath is mostly needed. 
Added an Example how to set it, and placed the "defaultMailFromAddress" below SMTP Settings