### PR TITLE
TASK: Add V8 version of update wizards

### DIFF
--- a/Documentation/ApiOverview/Index.rst
+++ b/Documentation/ApiOverview/Index.rst
@@ -47,6 +47,7 @@ http://api.typo3.org/.
    Http/Index
    Icon/Index
    Hooks/Index
+   UpdateWizards/Index
    Xclasses/Index
    JavaScript/Index
    SoftReferences/Index

--- a/Documentation/ApiOverview/UpdateWizards/Concept.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Concept.rst
@@ -1,0 +1,35 @@
+.. include:: ../../Includes.txt
+
+.. _update-wizards-concept:
+
+=============================
+The concept of update wizards
+=============================
+
+Update wizards are single PHP classes that provide an automated way to update certain
+parts of a TYPO3 installation. Usually those affected parts are sections of the
+database (e.g. contents of fields change) as well as segments in the file system
+(e.g. locations of files have changed).
+
+wizards should be provided to ease updates for integrators and administrators. They
+are an addition to the database migration, which is handled by the core based on
+:file:`ext_tables.sql`.
+
+The execution order is not defined. Each administrator is able to execute wizards and
+migrations in any order. They are also completely skippable.
+
+Each wizard is able to check pre-conditions to prevent execution, if nothing has to
+be updated. The wizard can log information and executed SQL statements, that can be
+displayed after execution.
+
+Best practice
+=============
+
+Each extension can provide as many update wizards as necessary. Each wizard should do
+exactly one specific update.
+
+Examples
+========
+
+The TYPO3 core itself provides update wizards inside
+:file:`typo3/sysext/install/Classes/Updates/`.

--- a/Documentation/ApiOverview/UpdateWizards/Creation.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation.rst
@@ -1,0 +1,89 @@
+.. include:: ../../Includes.txt
+
+.. _update-wizards-creation-generic:
+
+===============================
+Creating generic update wizards
+===============================
+
+Each update wizard consists of a single PHP file containing a single PHP class. This
+class has to extend :php:`TYPO3\CMS\Install\Updates\AbstractUpdate` and implement its
+abstract methods::
+
+   <?php
+   namespace Vendor\ExtName\Updates;
+
+   use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+   class ExampleUpdateWizard extends AbstractUpdate
+   {
+       /**
+        * @var string
+        */
+       protected $title = 'Title of this updater';
+
+       /**
+        * Checks whether updates are required.
+        *
+        * @param string $description The description for the update
+        * @return bool Whether an update is required (TRUE) or not (FALSE)
+        */
+       public function checkForUpdate(&$description)
+       {
+           return true;
+       }
+
+      /**
+       * Performs the required update.
+       *
+       * @param array $dbQueries Queries done in this update
+       * @param string $customMessage Custom message to be displayed after the update process finished
+       * @return bool Whether everything went smoothly or not
+       */
+       public function performUpdate(array &$databaseQueries, &$customMessage)
+       {
+           return true;
+       }
+   }
+
+Property :php:`$title`
+   Can be overwritten to define the title used while rendering the list of available
+   update wizards.
+
+Method :php:`checkForUpdate`
+   Is called to check whether the updater has to run. Therefore a boolean has to be
+   returned. The :php:`$description` provided can be modified as a reference to
+   provide further explanation, in addition to the title.
+
+Method :php:`performUpdate`
+   Is called if the user triggers the wizard. This method should contain, or call,
+   the code that is needed to execute the update. :php:`$databaseQueries` and
+   :php:`$customMessage` can be used as reference to provide further information to
+   the user after the update function is completed. :php:`$databaseQueries` has to
+   be an array, where each value is a string containing the query. This array should
+   only contain executed queries. :php:`$customMessage` is a string, where further
+   information is provided for the user after the updated process has completed.
+
+Marking wizard as done
+======================
+
+As soon as the wizard has completely finished, e.g. it detected that no update is
+necessary anymore, or that all updates were completed successfully, the wizard should
+be marked as done. To mark the wizard as done, call :php:`$this->markWizardAsDone`.
+
+The state of completed wizards is persisted in the :ref:`TYPO3 system registry <registry>`.
+
+Registering wizard
+==================
+
+Once the wizard is created, it needs to be registered. Registration is done in
+:file:`ext_localconf.php`::
+
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\Vendor\ExtName\Updates\ExampleUpdateWizard::class]
+      = \Vendor\ExtName\Updates\ExampleUpdateWizard::class;
+
+Executing wizard
+================
+
+Wizards are listed inside the install tool, inside navigation "Upgrade Wizard".
+The registered wizard should be shown there, as long as he is not done.

--- a/Documentation/ApiOverview/UpdateWizards/ExtUpdateFile.rst
+++ b/Documentation/ApiOverview/UpdateWizards/ExtUpdateFile.rst
@@ -1,0 +1,23 @@
+.. include:: ../../Includes.txt
+
+.. _update-wizards-extupdatefile:
+
+====================
+class.ext_update.php
+====================
+
+While the update wizards already provide a skeleton and integration into TYPO3
+CMS, there is a file from old times. This file is placed in the extension root
+and called :file:`class.ext_update.php`. For better overview it's recommended to
+use the new update wizards with separate classes for each update.
+
+If this file is found it will install a new menu item, "UPDATE", in the
+Extension Manager when looking at details for the extension. When this menu item
+is selected the class inside of this file (named :php:`ext_update`) will be
+instantiated and the method :php:`main()` will be called and expected to return
+HTML content.
+
+Also the method :php:`access()` has to be added. This method should return a
+boolean value whether or not the menu item should be shown. This feature is
+meant to disable the update tool if it has already been run and doesn't need to
+run again.

--- a/Documentation/ApiOverview/UpdateWizards/Index.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Index.rst
@@ -1,0 +1,19 @@
+.. include:: ../../Includes.txt
+
+.. _update-wizards:
+
+==============
+Update wizards
+==============
+
+TYPO3 CMS offers a way for extension authors to provide automated updates for
+extensions. TYPO3 itself provides update wizards to smooth updates of TYPO3
+versions. This chapter will explain the concept and how to write those update
+wizards.
+
+.. toctree::
+   :titlesonly:
+
+   Concept
+   Creation
+   ExtUpdateFile


### PR DESCRIPTION
This was already added to latest branch. Now since V9 there is a new way
to write update wizards and the information were removed.
To allow everybody to find V8 information in V8 Docs, these information
are added back to the branch.