### PR TITLE
TASK: Keep old implementation of update wizards

### DIFF
--- a/Documentation/ApiOverview/UpdateWizards/Index.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Index.rst
@@ -16,4 +16,5 @@ wizards.
 
    Concept
    Creation
+   OldApi
    ExtUpdateFile

--- a/Documentation/ApiOverview/UpdateWizards/OldApi.rst
+++ b/Documentation/ApiOverview/UpdateWizards/OldApi.rst
@@ -1,0 +1,95 @@
+.. include:: ../../Includes.txt
+
+.. _update-wizards-creation-prior-9:
+
+========================================
+Creating generic update wizards prior V9
+========================================
+
+.. note::
+
+   This way was used prior CMS v9. It's still valid, even if not recommended.
+   Please follow :ref:`update-wizards-creation-generic` for state of the art
+   implementation.
+
+Each update wizard consists of a single PHP file containing a single PHP class. This
+class has to extend :php:`TYPO3\CMS\Install\Updates\AbstractUpdate` and implement its
+abstract methods::
+
+   <?php
+   namespace Vendor\ExtName\Updates;
+
+   use TYPO3\CMS\Install\Updates\AbstractUpdate;
+
+   class ExampleUpdateWizard extends AbstractUpdate
+   {
+       /**
+        * @var string
+        */
+       protected $title = 'Title of this updater';
+
+       /**
+        * Checks whether updates are required.
+        *
+        * @param string $description The description for the update
+        * @return bool Whether an update is required (TRUE) or not (FALSE)
+        */
+       public function checkForUpdate(&$description)
+       {
+           return true;
+       }
+
+      /**
+       * Performs the required update.
+       *
+       * @param array $dbQueries Queries done in this update
+       * @param string $customMessage Custom message to be displayed after the update process finished
+       * @return bool Whether everything went smoothly or not
+       */
+       public function performUpdate(array &$databaseQueries, &$customMessage)
+       {
+           return true;
+       }
+   }
+
+Property :php:`$title`
+   Can be overwritten to define the title used while rendering the list of available
+   update wizards.
+
+Method :php:`checkForUpdate`
+   Is called to check whether the updater has to run. Therefore a boolean has to be
+   returned. The :php:`$description` provided can be modified as a reference to
+   provide further explanation, in addition to the title.
+
+Method :php:`performUpdate`
+   Is called if the user triggers the wizard. This method should contain, or call,
+   the code that is needed to execute the update. :php:`$databaseQueries` and
+   :php:`$customMessage` can be used as reference to provide further information to
+   the user after the update function is completed. :php:`$databaseQueries` has to
+   be an array, where each value is a string containing the query. This array should
+   only contain executed queries. :php:`$customMessage` is a string, where further
+   information is provided for the user after the updated process has completed.
+
+Marking wizard as done
+======================
+
+As soon as the wizard has completely finished, e.g. it detected that no update is
+necessary anymore, or that all updates were completed successfully, the wizard should
+be marked as done. To mark the wizard as done, call :php:`$this->markWizardAsDone`.
+
+The state of completed wizards is persisted in the :ref:`TYPO3 system registry <registry>`.
+
+Registering wizard
+==================
+
+Once the wizard is created, it needs to be registered. Registration is done in
+:file:`ext_localconf.php`::
+
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\Vendor\ExtName\Updates\ExampleUpdateWizard::class]
+      = \Vendor\ExtName\Updates\ExampleUpdateWizard::class;
+
+Executing wizard
+================
+
+Wizards are listed inside the install tool, inside navigation "Upgrade Wizard".
+The registered wizard should be shown there, as long as he is not done.


### PR DESCRIPTION
Even if V9 provides a modern API, the old is still valid. As we also
keep documentation for ext_update, we should also keep this
documentation.

A hint was added to use the newer API, still if someone has to work with
old implementations, the documentation is still valid and helpful.