### PR TITLE
Update code example in Page types

### DIFF
--- a/Documentation/ApiOverview/PageTypes/Index.rst
+++ b/Documentation/ApiOverview/PageTypes/Index.rst
@@ -157,7 +157,7 @@ need to add the new doktype as select item and associate it with the configured 
 
             // Add icon for new page type:
             \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule(
-                $GLOBALS['TCA']['pages'],
+                $GLOBALS['TCA'][$table],
                 [
                     'ctrl' => [
                         'typeicon_classes' => [


### PR DESCRIPTION
Instead of using a string constant for the table name, the exising `$table` variable should be used.