### PR TITLE
Improve documentation of icon registration

### DIFF
--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -17,7 +17,7 @@ Registration
 
 All icons must be registered in the :php:`IconRegistry`.
 To register icons for your own extension use the following
-code in your :php:`ext_tables.php` file:
+code in your :php:`ext_localconf.php` file:
 
 .. code-block:: php
 


### PR DESCRIPTION
Registration of icons in the IconRegistry should be placed in ext_localconf.php.
https://docs.typo3.org/typo3cms/CoreApiReference/ExtensionArchitecture/ConfigurationFiles/Index.html