### PR TITLE
Remove information about examples extension

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -53,8 +53,9 @@ Code examples
 Many of the code examples found in this document come from the TYPO3
 Core itself.
 
-Quite a few others come from the "examples" and the `styleguide <https://github.com/TYPO3/styleguide>`__ extension. 
-
+Quite a few others come from the "`styleguide <https://github.com/TYPO3/styleguide>`__"
+extension. You can install it, if you want to try out these examples yourself and
+use them as a basis for your own extensions.
 
 .. _feedback:
 


### PR DESCRIPTION
because it is outdated