### PR TITLE
Fix example access to current site language

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -44,7 +44,7 @@ Methods::
     $site = $request->getAttribute('site');
 
     // current site language
-    $siteLanguage = $request->getAttribute('siteLanguage');
+    $siteLanguage = $request->getAttribute('language');
 
 
 .. warning::


### PR DESCRIPTION
We could not access to current language using `$request->getAttribute('siteLanguage')` but `$request->getAttribute('language')` worked for us. Is this correct?