### PR TITLE
Querybuilder missing value in Like/NotLike

### DIFF
--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -97,9 +97,9 @@ A set of methods to create various comparison expressions or SQL functions:
 
 * :php:`->isNotNull($fieldName)` "IS NOT NULL" comparison
 
-* :php:`->like($fieldName)` "LIKE" comparison
+* :php:`->like($fieldName, $value)` "LIKE" comparison
 
-* :php:`->notLike($fieldName)` "NOT LIKE" comparison
+* :php:`->notLike($fieldName, $value)` "NOT LIKE" comparison
 
 * :php:`->in($fieldName, $valueArray)` "IN ()" comparison
 


### PR DESCRIPTION
Value for Like / notLike is missing in the listing. 

The syntax just below it is correct:

   // `bodytext` LIKE 'klaus'
   ->like(
      'bodytext',
      $queryBuilder->createNamedParameter($queryBuilder->escapeLikeWildcards('klaus'))
   )

So I assume it should be:

->like($fieldName, $value)
