### PR TITLE
[TASK] Unify formatting of headers in Extension Architecture

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -3,6 +3,7 @@
 
 .. _extension-options:
 
+=====================
 Configuration options
 =====================
 

--- a/Documentation/ExtensionArchitecture/CreateNewDistribution/Index.rst
+++ b/Documentation/ExtensionArchitecture/CreateNewDistribution/Index.rst
@@ -3,6 +3,7 @@
 
 .. _distribution:
 
+===========================
 Creating a new distribution
 ===========================
 
@@ -14,7 +15,7 @@ tutorial.
 .. _distribution_concept:
 
 Concept of distributions
-------------------------
+========================
 
 Distributions are full TYPO3 CMS websites ready to be unpacked. They provide
 an easy quick start for using TYPO3 CMS. The most well known distribution is
@@ -42,7 +43,7 @@ care of the following parts:
 .. _distribution-kickstart:
 
 Kickstarting the distribution
------------------------------
+=============================
 
 A distribution is a special kind of extension. The first step
 is thus to create a new extension.
@@ -57,7 +58,7 @@ except for the "category" property which must be set to
 .. _distribution-kickstart-image:
 
 Configuring the distribution display in the EM
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------
 
 You should provide two preview images for your distribution. Provide
 a small 220x150 pixels for the list in the Extension Manager as
@@ -69,7 +70,7 @@ The welcome image is displayed in the distribution detail view inside the Extens
 .. _distribution-kickstart-fileadmin:
 
 Fileadmin files
-^^^^^^^^^^^^^^^
+---------------
 
 Create the following folder structure inside your extension:
 
@@ -111,7 +112,7 @@ site setup. This ends up with only content related stuff being located in
 .. _distribution-kickstart-database:
 
 Database data
-^^^^^^^^^^^^^
+-------------
 
 The database data is delivered as TYPO3 CMS export :file:`data.xml`.
 Generate this file by exporting your whole installation
@@ -163,7 +164,7 @@ to the needs of your distribution. The ext:introduction preset is configured as:
 .. _distribution-kickstart-configuration:
 
 Distribution configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
 
 A distribution is technically handled as an extension. Therefore you
 can make use of all :ref:`configuration options <extension-options>` as needed.
@@ -176,7 +177,7 @@ scheme) on the fly.
 .. _distribution-kickstart-custom-dependencies:
 
 Delivering custom dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 
 Normally extension dependencies are setup in the
 :ref:`Extension declaration file <extension-declaration>`.
@@ -199,7 +200,7 @@ need to be fetched.
 .. _distribution-testing:
 
 Test your distribution
-----------------------
+======================
 
 To test your distribution, simply copy your extension to an empty
 TYPO3 CMS installation and try to install it from the Extension
@@ -235,7 +236,7 @@ locally *without* uploading to TER first.
 .. _distribution-more-information:
 
 More information
-----------------
+================
 
 The `introduction extension <https://github.com/FriendsOfTYPO3/introduction>`_ is a
 good starting point to see how distributions are handled in practice. It also comes

--- a/Documentation/ExtensionArchitecture/CreateNewExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/CreateNewExtension/Index.rst
@@ -3,8 +3,9 @@
 
 .. _extension-create-new:
 
+========================
 Creating a new extension
-^^^^^^^^^^^^^^^^^^^^^^^^
+========================
 
 This chapter is not a tutorial about how to create an Extension.
 It only aims to be a list of steps to perform and key information
@@ -15,7 +16,7 @@ This is the unique identifier for your extension.
 
 
 Kickstarting the extension
-""""""""""""""""""""""""""
+==========================
 
 Although it is possible to write every single line of an extension from
 scratch, there is a tool which makes it easier to start. It is called

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -3,8 +3,9 @@
 
 .. _extension-declaration:
 
+================
 Declaration file
-^^^^^^^^^^^^^^^^
+================
 
 The :file:`ext_emconf.php` is the single most important file in an extension.
 Without it, the Extension Manager (EM) will not detect the extension, much less
@@ -280,7 +281,8 @@ values in the :code:`$EM_CONF` array if needed.
   
 
 Deprecated configuration
-""""""""""""""""""""""""
+========================
+
 The following fields are deprecated and should not be used anymore:
 
 - dependencies

--- a/Documentation/ExtensionArchitecture/ExtendingTca/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Index.rst
@@ -3,8 +3,9 @@
 
 .. _extending:
 
+========================
 Extending the $TCA array
-------------------------
+========================
 
 Being a PHP array, the Table Configuration Array can be easily
 extended. It can be accessed as the global variable :php:`$GLOBALS['TCA']`.

--- a/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
@@ -3,6 +3,7 @@
 
 .. _storing-changes:
 
+===================
 Storing the changes
 ===================
 
@@ -18,7 +19,7 @@ more details.
 .. _storing-changes-extension:
 
 Storing in extensions
----------------------
+=====================
 
 The advantage of putting your changes inside an extension is that they
 are nicely packaged in a self-contained entity which can be easily
@@ -39,7 +40,7 @@ Core APIs.
 .. _storing-changes-extension-overrides:
 
 Storing in the Overrides folder
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 Since TYPO3 CMS 6.2 (6.2.1 to be precise) changes to :php:`$GLOBALS['TCA']`
 must be stored inside a folder called :file:`Configuration/TCA/Overrides`
@@ -72,7 +73,7 @@ The advantage of this method is that all such changes are incorporated into
 .. _storing-changes-extension-exttables:
 
 Storing in ext_tables.php files
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 Until TYPO3 CMS 6.1 (still supported for 6.2) changes to :php:`$GLOBALS['TCA']` are packaged
 into an extension's :file:`ext_tables.php` file. This is strongly discouraged in more recent
@@ -86,7 +87,7 @@ until the author of the legacy extension migrates his code.
 .. _storing-changes-on-the-fly:
 
 Changing the TCA "on the fly"
------------------------------
+=============================
 
 It is also possible to perform some special manipulations on
 :php:`$GLOBALS['TCA']` right before it is stored into cache, thanks to the

--- a/Documentation/ExtensionArchitecture/ExtendingTca/Verifying/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Verifying/Index.rst
@@ -3,8 +3,9 @@
 
 .. _verifying:
 
+==================
 Verifying the $TCA
-^^^^^^^^^^^^^^^^^^
+==================
 
 You may find it necessary – at some point – to verify the full
 structure of the :php:`$GLOBALS['TCA']` in your TYPO3 installation. The **SYSTEM >


### PR DESCRIPTION
Not strictly necessary, but makes editing easier, if formatting of
headers done consistently.

See https://docs.typo3.org/typo3cms/HowToDocument/WritingReST/HeadlinesAndSection.html