### PR TITLE
[FEATURE] Clarify backend module api

### DIFF
--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -8,12 +8,22 @@ Backend Module API
 ==================
 
 
+As for frontend plugins, you can use :ref:`Fluid templates <t3extbasebook:fluid-start>` to
+create the view and :ref:`controller actions <t3extbasebook:controlling-the-flow-with-controllers>`
+for the functionality.
+
+
+.. tip::
+
+   The :ref:`extension builder <extension-builder>` can be used to generate basic code
+   for a new extension. You can also use this to create backend modules.
+
 .. _backend-modules-api-registration:
 
 Registering new Modules
 =======================
 
-Modules added by extensions are registered in the :file:`ext_tables.php`
+Modules added by extensions are registered in the file :ref:`ext_tables.php <ext-tables.php>`
 using the following API:
 
 .. code-block:: php
@@ -35,28 +45,45 @@ using the following API:
         ]
     );
 
-Here the module ``tx_Beuser`` is declared as being a submodule of main module ``system``.
-It should be placed at the ``top`` of that main module, if possible (if several modules
-are declared at the same position, the last one wins). The following positions are possible:
+Here the module ``tx_Beuser`` is declared as a submodule of the already existing
+main module ``system``.
 
-* ``top``: the module is prepended to the top of the submodule list
-* ``bottom`` or empty string: the module is appended to the end of the submodule list
-* ``before:<submodulekey>``: the module is inserted before the submodule identified by ``<submodulekey>``
-* ``after:<submodulekey>``: the module is inserted after the submodule identified by ``<submodulekey>``
+Parameters:
 
-The last array is the module configuration and contains important information:
-the module is accessible only to admin users. The following options are available
-and should be defined as comma-separated string:
+#. A vendor shorthand and the extension key in upper camel case:
+   **'Vendor.ExtensionName'**.
+#. **Main module** name, in which the new module will be placed,
+   for example 'web' or 'system'.
+#. **Submodule key**: This is an identifier for your new module.
+#. **Position** of the module: Here, the module should be placed at the ``top`` of the main
+   module, if possible. If several modules are declared at the same position, the last one wins.
+   The following positions are possible:
 
-* ``admin``: the module is accessible to admins only
-* ``user``: the module can be made accessible per user
-* ``group``: the module can be made accessible per usergroup
+   * ``top``: the module is prepended to the top of the submodule list
+   * ``bottom`` or empty string: the module is appended to the end of the submodule list
+   * ``before:<submodulekey>``: the module is inserted before the submodule identified by ``<submodulekey>``
+   * ``after:<submodulekey>``: the module is inserted after the submodule identified by ``<submodulekey>``
 
-The configuration also contains pointers to the module ``icon`` and the
-language file containing ``labels`` like the module title and description,
-for building the module menu and for the display of information in the
-**About Modules** module (found in the main help menu in the top bar).
-The `LLL:` prefix is mandatory here and is there for historical reasons.
+#. Allowed **controller => action** combinations
+#. **Module configuration**: The following options are available:
+
+   * ``access``: can contain several, separated by comma
+
+      * ``admin``: the module is accessible to admins only
+      * ``user``: the module can be made accessible per user
+      * ``group``: the module can be made accessible per usergroup
+
+   * Module ``icon``
+   * A language file containing ``labels`` like the module title and description,
+     for building the module menu and for the display of information in the
+     **About Modules** module (found in the main help menu in the top bar).
+     The `LLL:` prefix is mandatory here and is there for historical reasons.
+
+
+.. note::
+   When registering frontend plugins, you must define which actions are not to be stored
+   in the cache. This is not necessary for backend modules, because the actions are
+   generally not being cached in the backend.
 
 Registering a Toplevel Module
 =============================
@@ -114,3 +141,26 @@ navigation frame).
 
 
 The list of modules is parsed by the class :php:`\TYPO3\CMS\Backend\Module\ModuleLoader`.
+
+
+Configuration With TypoScript
+=============================
+
+Backend modules can, like frontend plugins, be configured via TypoScript. While the frontend plugins
+are configured with :ts:`plugin.tx_[pluginkey]`, for the configuration of the backend
+:ts:`module.tx_[pluginkey]` is used.
+
+Example for configuring the paths of Fluid files:
+
+.. code-block:: typoscript
+
+   module.tx_example {
+       view {
+           templateRootPaths {
+               10 = EXT:example/Resources/Private/Backend/Templates/
+           }
+           layoutRootPaths {
+              10 = EXT:example/Resources/Private/Backend/Layouts/
+           }
+       }
+   }

--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -13,6 +13,9 @@ most important files for the execution of extensions
 within TYPO3. They contain configuration used by the system on almost
 every request. They should therefore be optimized for speed.
 
+
+.. _ext-localconf-php:
+
 ext_localconf.php
 =================
 
@@ -41,6 +44,9 @@ These are the typical functions that extension authors should place within :file
 * Adding slots to signals via Extbase's SignalSlotDispatcher
 * Registering Icons to the IconRegistry
 * Registering Services via the Service API
+
+
+.. _ext-tables.php:
 
 ext_tables.php
 ==============

--- a/Documentation/ExtensionArchitecture/CreateNewExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/CreateNewExtension/Index.rst
@@ -13,6 +13,7 @@ to remember.
 First you have to :ref:`register an extension key <extension-key>`.
 This is the unique identifier for your extension.
 
+.. _extension-builder:
 
 Kickstarting the extension
 """"""""""""""""""""""""""

--- a/Documentation/ExtensionArchitecture/ExtensionKey/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtensionKey/Index.rst
@@ -7,15 +7,28 @@ Choosing an extension key
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The "extension key" is a string uniquely identifying the extension.
-The folder where the extension resides is named by this string. The
-string can contain characters a-z0-9 and underscore. No uppercase
-characters should be used (keeps folder-,file- and table/field-names
-in lowercase). Furthermore the name must not start with a "tx" or "u"
-(these are prefixes used for modules) and because backend modules
-related to the extension should be named by the extension name
-*without* underscores, the extension name must still be unique even if
-underscores are removed (underscores are allowed to make the extension
-key easily readable).
+The folder where the extension resides is named by this string.
+
+The extension key must follow these rules:
+
+* It can contain characters a-z,0-9 and underscore
+* No uppercase characters should be used (keeps folder-,file- and table/field-names
+  in lowercase).
+* Furthermore the name must **not start** with any of these (these are prefixes used for modules):
+
+  * **tx**
+  * **user_**
+  * **pages**
+  * **tt_**
+  * **sys_**
+  * **ts_language**
+  * **csh_**
+
+* The extension name must still be unique even if underscores are removed
+  because backend modules related to the extension should be named by
+  the extension name *without* underscores. (Underscores are allowed
+  to make the extension key easily readable).
+* Extension
 
 The naming conventions of extension keys are automatically validated
 by the registration at the repository, so you have nothing to worry
@@ -96,7 +109,8 @@ on typo3.org (unless you plan to make an implementation-specific
 extension – of course – which it does not make sense to share).
 
 Go to typo3.org, log in with your (pre-created) username / password
-and go to Extensions > Extension Keys and click on the "Register keys"
+and go to `Extensions <https://extensions.typo3.org>`__
+> My Extensions and click on the "Register extension key"
 tab. On that page you can enter the key name you want to register.
 
 .. figure:: ../../Images/Typo3OrgRegistration.png


### PR DESCRIPTION
- use formatted lists for parameters to make it more readable
- add additional information about parameters
- add information about how to configure modules with TypoScript
- add note about backend actions not being cached

There is currently a nearly identical page about "Backend Modules"
in the [Extbase / Fluid book](https://docs.typo3.org/typo3cms/ExtbaseFluidBook/Index.html#start). Since this page and the one in the Extbase book
overlap in most parts, the page in the Extbase book can be
taken down and just link to "TYPO3 Explained". For this reason, we
add the part about TypoScript and the note about backend actions
not being cached, so the information will not be lost.

**Update**:

The page in the [Extbase / Fluid book](https://docs.typo3.org/typo3cms/ExtbaseFluidBook/Index.html#start) has since been taken down and replaced with link to TYPO3 Explained.