### PR TITLE
Add missing required argument

### DIFF
--- a/Documentation/ApiOverview/PasswordHashing/Index.rst
+++ b/Documentation/ApiOverview/PasswordHashing/Index.rst
@@ -276,6 +276,8 @@ Example implementation for TYPO3 frontend::
    $password = 'someHopefullyGoodAndLongPassword';
    // The stored password hash from database
    $passwordHash = 'YYY';
+   // The context, either 'FE' or 'BE'
+   $mode = 'FE';
    $success = GeneralUtility::makeInstance(PasswordHashFactory::class)
        ->get($saltedPassword, $mode)
        ->checkPassword($password, $passwordHash);

--- a/Documentation/ApiOverview/PasswordHashing/Index.rst
+++ b/Documentation/ApiOverview/PasswordHashing/Index.rst
@@ -277,7 +277,7 @@ Example implementation for TYPO3 frontend::
    // The stored password hash from database
    $passwordHash = 'YYY';
    $success = GeneralUtility::makeInstance(PasswordHashFactory::class)
-       ->get($saltedPassword)
+       ->get($saltedPassword, $mode)
        ->checkPassword($password, $passwordHash);
 
 Adding a new hash mechanism


### PR DESCRIPTION
The `get()` method requires a mode to be sent as the second argument.

