### PR TITLE
Fixed typo, correct menu path

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
@@ -8,7 +8,7 @@
 Quick Start for Integrators
 ===========================
 
-This section gives come simple instructions for getting started with using
+This section gives some simple instructions for getting started using
 the caching framework without giving the whole details under the hood.
 
 
@@ -23,7 +23,7 @@ and can be overridden in :file:`LocalConfiguration.php`.
 
 If specific settings should be applied to the configuration, they should be added to :file:`LocalConfiguration.php`.
 All settings in :file:`LocalConfiguration.php` will be merged with :file:`DefaultConfiguration.php`. The easiest way to see
-the final cache configuration is to use the TYPO3 Backend module **ADMIN TOOLS > Configuration > $GLOBALS['TYPO3_CONF_VARS']**.
+the final cache configuration is to use the TYPO3 Backend module **SYSTEM > Configuration > $GLOBALS['TYPO3_CONF_VARS']** (with installed lowlevel system extension).
 
 Example for a configuration of redis cache backend on redis database number 42 instead of the default
 database backend with compression for the pages cache:


### PR DESCRIPTION
- Fixed typo
- Corrected Configuration menu entry path in v9 and add hint to lowlevel extension