### PR TITLE
[TASK] Fix missing menu point "Cache backends", update snippets

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
@@ -31,7 +31,7 @@ the cache system falls back to the default backend and default frontend settings
 .. code-block:: php
 
    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = array();
+       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
    }
 
 Extensions like **extbase** define default caches this way, giving administrators full freedom for specific and
@@ -42,20 +42,20 @@ example configuration to switch **cache_pages** to the **redis** backend using d
 
 .. code-block:: php
 
-   return array(
-       'SYS' => array(
-           'caching' => array(
-               'cacheConfigurations' => array(
-                   'cache_pages' => array(
-                       'backend' => 'TYPO3\CMS\Core\Cache\Backend\RedisBackend',
-                       'options' => array(
+   return [
+       'SYS' => [
+           'caching' => [
+               'cacheConfigurations' => [
+                   'cache_pages' => [
+                       'backend' => \TYPO3\CMS\Core\Cache\Backend\RedisBackend::class,
+                       'options' => [
                            'database' => 3,
-                       ),
-                   ),
-               ),
-           ),
-       ),
-   );
+                       ],
+                   ],
+               ],
+           ],
+       ],
+   ];
 
 
 Some backends have mandatory as well as optional parameters (which are documented below).
@@ -79,4 +79,4 @@ Example entry to switch the *runtime* cache to use the **null** backend:
 .. code-block:: php
 
    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']
-      ['cache_runtime']['backend'] = 'TYPO3\CMS\Core\Cache\Backend\NullBackend';
+      ['cache_runtime']['backend'] = \TYPO3\CMS\Core\Cache\Backend\NullBackend::class;

--- a/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
@@ -29,7 +29,7 @@ and the :ref:`database backend <caching-backend-db>` by default.
 .. code-block:: php
 
    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = array();
+       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
    }
 
 .. tip::
@@ -54,10 +54,10 @@ should hint an integrator about specific caching needs or setups in this case.
 .. code-block:: php
 
    if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = array();
+       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
    }
    if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] = 'TYPO3\\CMS\\Core\\Cache\\Backend\\TransientMemoryBackend';
+       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
    }
 
 To get an instance of a cache, :code:`GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('myext_mycache')`

--- a/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
@@ -140,8 +140,9 @@ the simple file backend fulfill this requirement.
 
 .. _caching-backend:
 
+===============
 Cache backends
-^^^^^^^^^^^^^^
+===============
 
 A variety of storage backends exists. They have different characteristics
 and can be used for different caching needs. The best backend depends on

--- a/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
@@ -31,21 +31,21 @@ database backend with compression for the pages cache:
 
 .. code-block:: php
 
-   return array(
+   return [
    // ...
-      'SYS' => array(
+      'SYS' => [
       // ...
-         'caching' => array(
+         'caching' => [
             // ...
-            'cache_pages' => array(
-               'backend' => 'TYPO3\CMS\Core\Cache\Backend\RedisBackend',
-               'options' => array(
+            'cache_pages' => [
+               'backend' => \TYPO3\CMS\Core\Cache\Backend\RedisBackend::class,
+               'options' => [
                   'database' => 42,
-               ),
-            ),
-         ),
-      ),
-   );
+               ],
+            ],
+         ],
+      ],
+   ];
 
 .. _caching-quickstart-garbage:
 


### PR DESCRIPTION
There was a menu point "Cache backends" until Docs 8.7 inside of "API Overview > Caching Framework".