### PR TITLE
Fix getenv condition in Site's baseVariants

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -132,7 +132,7 @@ like
     `like("foobarbaz", "*bar*")`
 
 
-env
+getenv
 ---
 
 :aspect:`Datatype`
@@ -142,4 +142,4 @@ env
     Wrapper for PHPs `getenv()` function. Allows accessing environment variables.
 
 :aspect:`Example`
-    `env("TYPO3_BASE_URL")`
+    `getenv("TYPO3_BASE_URL")`

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -133,7 +133,7 @@ like
 
 
 getenv
----
+------
 
 :aspect:`Datatype`
     string


### PR DESCRIPTION
The function is named "getenv" and not "env". See https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/Conditions/Index.html#getenv