### PR TITLE
Add information for main module naming

### DIFF
--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -122,6 +122,9 @@ be used to add submodules to this new toplevel module:
         ]
     );
 
+.. note::
+   The main module name should contain only lowercase characters. Do not use an underscore or dash.
+
 .. _backend-modules-api-tbemodules:
 
 $TBE\_MODULES


### PR DESCRIPTION
Using wrong naming conventions for custom main modules breaks ti display of the main module and all submodules.