### PR TITLE
[WIP][BUGFIX] Use extension key instead of $_EXTKEY

### DIFF
--- a/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
+++ b/Documentation/ApiOverview/Examples/ContentElementWizard/Index.rst
@@ -24,7 +24,7 @@ plugin with the wizard. First of all, the class is declared in :file:`ext_tables
 
    // Add "pierror" plugin to new element wizard
    if (TYPO3_MODE == 'BE') {
-      $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['tx_examples_pierror_wizicon'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath($_EXTKEY) . 'pierror/class.tx_examples_pierror_wizicon.php';
+      $TBE_MODULES_EXT['xMOD_db_new_content_el']['addElClasses']['tx_examples_pierror_wizicon'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('tx_examples') . 'pierror/class.tx_examples_pierror_wizicon.php';
    }
 
 


### PR DESCRIPTION
This PR needs more work as described method is discouraged!

See
* https://scripting-base.de/blog/cleaning-the-hood-record-wizard.html
------
"Additionally, it is recommended to use the extension name
(e.g. “tt_address”) instead of $_EXTKEY within the two
configuration files as this variable will be removed in the future."

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationFiles/Index.html