### PR TITLE
Restructure extension chapter

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -4,9 +4,9 @@
 .. _extension-configuration-files:
 
 
-===================
-Configuration Files
-===================
+========================================================
+Configuration Files (ext_tables.php & ext_localconf.php)
+========================================================
 
 Files :file:`ext_tables.php` and :file:`ext_localconf.php` are the two
 most important files for the execution of extensions

--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -3,9 +3,9 @@
 
 .. _extension-options:
 
-=====================
-Configuration Options
-=====================
+===============================================
+Extension Configuration (ext_conf_template.txt)
+===============================================
 
 In the :file:`ext_conf_template.txt` file configuration options
 for an extension can be defined. They will be accessible in the TYPO3 backend

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -4,9 +4,9 @@
 .. _extension-declaration:
 
 
-================
-Declaration File
-================
+=================================
+Declaration File (ext_emconf.php)
+=================================
 
 The :file:`ext_emconf.php` is the single most important file in an extension.
 Without it, the Extension Manager (EM) will not detect the extension, much less

--- a/Documentation/ExtensionArchitecture/Index.rst
+++ b/Documentation/ExtensionArchitecture/Index.rst
@@ -8,22 +8,39 @@ Extension Development
 =====================
 
 
+INTRODUCTION
+
 .. toctree::
    :titlesonly:
    :maxdepth: 1
 
    Introduction/Index
    ExtensionManagement/Index
-   FilesAndLocations/Index
    SystemAndLocalExtensions/Index
-   ExtensionKey/Index
-   NamingConventions/Index
+
+RESERVED FILES & HOW THEY DEFINE FUNCTIONALITY
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+
+   FilesAndLocations/Index
    DeclarationFile/Index
    ConfigurationFiles/Index
+   NamingConventions/Index
    ConfigurationOptions/Index
    ExtendingTca/Index
+
+STEPS TOWARDS CREATING AN EXTENSION
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+
+   ExtensionKey/Index
    CreateNewExtension/Index
    CreateNewDistribution/Index
    Documentation/Index
    Resources/Index
-

--- a/Documentation/ExtensionArchitecture/SystemAndLocalExtensions/Index.rst
+++ b/Documentation/ExtensionArchitecture/SystemAndLocalExtensions/Index.rst
@@ -3,8 +3,9 @@
 
 .. _extension-scope:
 
-System and Local extensions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===============================
+System and Local Extensions
+===============================
 
 The files for an extension are located in a folder named by the
 *extension key* . The location of this folder can be either inside
@@ -13,10 +14,12 @@ The files for an extension are located in a folder named by the
 The extension *must* be programmed so that it does automatically
 detect where it is located and can work from all two locations.
 
+
+
 .. _extension-local:
 
-Local extensions
-""""""""""""""""
+Local Extensions
+================
 
 Local extensions are located in the :file:`typo3conf/ext/` directory.
 
@@ -27,11 +30,12 @@ If you put an extension here it will be available for a single TYPO3
 installation only. This is a "per-database" way to install an
 extension.
 
+
 .. _extension-global:
 .. _extension-system:
 
-System extensions
-"""""""""""""""""
+System Extensions
+=================
 
 System extensions are located in the :file:`typo3/sysext/` directory.
 
@@ -39,10 +43,11 @@ This is system default extensions which cannot and should not be
 updated by the EM. They are distributed with TYPO3 core source code
 and generally understood to be a part of the core system.
 
+
 .. _extension-loading-precedence:
 
-Loading precedence
-""""""""""""""""""
+Loading Precedence
+==================
 
 Local extensions take precedence which means that if an extension
 exists both in :file:`typo3conf/ext/` and :file:`typo3/sysext/` the one in :file:`typo3conf/ext/`


### PR DESCRIPTION
- move 3 chapters about files together
- add subheaders on overview page
- add filenames to headers
- change order slightly
- Rename Configuration Options to "Extension Configuration"
  (because that is what it is called in the backend)