### PR TITLE
[TASK] Update security related TS example

### DIFF
--- a/Documentation/Security/GuidelinesIntegrators/Typoscript.rst.txt
+++ b/Documentation/Security/GuidelinesIntegrators/Typoscript.rst.txt
@@ -43,7 +43,7 @@ The following code snippet gives an example:
 Argument passed by the `GET` / `POST` request `pageid` wrapped as markers are properly
 escaped and quoted to prevent SQL injection problems.
 
-See :ref:`TypoScript Reference <t3tsref:Functions/Select.html#markers>` for more
+See :ref:`TypoScript Reference <t3tsref:select-markers>` for more
 information.
 
 As a rule, you cannot trust (and must not use) any data from a source

--- a/Documentation/Security/GuidelinesIntegrators/Typoscript.rst.txt
+++ b/Documentation/Security/GuidelinesIntegrators/Typoscript.rst.txt
@@ -33,17 +33,18 @@ The following code snippet gives an example:
      table = tt_content
      select {
        pidInList = 123
-       where = deleted=0
-       andWhere.data = GP:pageid
-       andWhere.wrap = uid=|
-       andWhere.intval = 1
+       where = deleted=0 AND uid=###PAGEID###
+       markers {
+           PAGEID.data = GP:pageid
+       }
      }
    }
 
-Without the :typoscript:`andWhere.intval = 1` instruction, the not sanitized
-argument passed by the `GET` / `POST` request `pageid` is being used for the
-database query. Specially formed `GET` / `POST` requests would cause an SQL
-injection.
+Argument passed by the `GET` / `POST` request `pageid` wrapped as markers are properly
+escaped and quoted to prevent SQL injection problems.
+
+See :ref:`TypoScript Reference <t3tsref:Functions/Select.html#markers>` for more
+information.
 
 As a rule, you cannot trust (and must not use) any data from a source
 you do not control without proper verification and validation (e.g.


### PR DESCRIPTION
TypoScript `select.andWhere` is deprecated since TYPO3 v7.1
Change example and description to recommended use of markers

refs #328