### PR TITLE
Unify texts on files and directories

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -15,11 +15,16 @@ most important files for the execution of extensions
 within TYPO3. They contain configuration used by the system on almost
 every request. They should therefore be optimized for speed.
 
+See :ref:`extension-files-locations` for a full list of file and
+directory names typically used in extensions.
+
 
 .. _ext-localconf-php:
 
 ext_localconf.php
 =================
+
+- *optional*
 
 :file:`ext_localconf.php` is always included in global scope of the script,
 either frontend or backend.
@@ -73,6 +78,8 @@ deprecated
 
 ext_tables.php
 ==============
+
+- *optional*
 
 :file:`ext_tables.php` is *not* always included in the global scope of the
 frontend context.

--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -24,7 +24,7 @@ directory names typically used in extensions.
 ext_localconf.php
 =================
 
-- *optional*
+*-- optional*
 
 :file:`ext_localconf.php` is always included in global scope of the script,
 either frontend or backend.
@@ -79,7 +79,7 @@ deprecated
 ext_tables.php
 ==============
 
-- *optional*
+*-- optional*
 
 :file:`ext_tables.php` is *not* always included in the global scope of the
 frontend context.

--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -7,6 +7,8 @@
 Extension Configuration (ext_conf_template.txt)
 ===============================================
 
+*-- optional*
+
 In the :file:`ext_conf_template.txt` file configuration options
 for an extension can be defined. They will be accessible in the TYPO3 backend
 from Settings module.

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -8,7 +8,7 @@
 Declaration File (ext_emconf.php)
 =================================
 
-- *required*
+*-- required*
 
 The :file:`ext_emconf.php` is the single most important file in an extension.
 Without it, the Extension Manager (EM) will not detect the extension, much less

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -8,6 +8,8 @@
 Declaration File (ext_emconf.php)
 =================================
 
+- *required*
+
 The :file:`ext_emconf.php` is the single most important file in an extension.
 Without it, the Extension Manager (EM) will not detect the extension, much less
 be able to install it. This file contains a declaration of what the extension

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -43,7 +43,7 @@ extension recognized by TYPO3 without this file.
 In general, do not introduce your own files in the root directory of
 extensions with the name prefix :file:`ext_`, because that is reserved.
 
-.. _:file:`ext_emconf.php`:
+.. _ext_emconf-php:
 
 :file:`ext_emconf.php`
 ----------------------
@@ -63,7 +63,7 @@ that it is auto-written by the Extension Manager when extensions are imported fr
    extension.
 
 
-.. _:file:`ext_localconf.php`:
+.. _ext_localconf-php:
 
 :file:`ext_localconf.php`
 -------------------------
@@ -85,7 +85,7 @@ Pay attention to the rules for the contents of these files.
 For more details, see the :ref:`section below <extension-configuration-files>`.
 
 
-.. _:file:`ext_tables.php`:
+.. _ext_tables-php:
 
 :file:`ext_tables.php`
 ----------------------
@@ -115,7 +115,7 @@ For more details, see the :ref:`section below <extension-configuration-files>`.
    in :file:`Configuration/TCA/Overrides/<table name>.php`.
 
 
-.. _:file:`ext_tables.sql`:
+.. _ext_tables-sql:
 
 :file:`ext_tables.sql`
 ----------------------

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -48,13 +48,13 @@ extensions with the name prefix :file:`ext_`, because that is reserved.
 :file:`ext_emconf.php`
 ----------------------
 
-*mandatory*
+- *required*
 
 Definition of extension properties. This is the only mandatory file in the extension.
 It describes the extension.
 
 Name, category, status etc. are used by the Extension Manager. The content of this file
-is described in more details :ref:`below <extension-declaration>`. Note
+is described in more details in :ref:`extension-declaration`. Note
 that it is auto-written by the Extension Manager when extensions are imported from the repository.
 
 .. note::
@@ -68,7 +68,7 @@ that it is auto-written by the Extension Manager when extensions are imported fr
 :file:`ext_localconf.php`
 -------------------------
 
-*optional*
+- *optional*
 
 Addition to :file:`LocalConfiguration.php`.
 It should contain additional configuration of :php:`$GLOBALS['TYPO3_CONF_VARS']`.
@@ -90,7 +90,7 @@ For more details, see the :ref:`section below <extension-configuration-files>`.
 :file:`ext_tables.php`
 ----------------------
 
-*optional*
+- *optional*
 
 Contains extensions of existing tables,
 declaration of backend modules, etc. All code in such files
@@ -120,7 +120,7 @@ For more details, see the :ref:`section below <extension-configuration-files>`.
 :file:`ext_tables.sql`
 ----------------------
 
-*optional*
+- *optional*
 
 SQL definition of database tables.
 

--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -48,7 +48,7 @@ extensions with the name prefix :file:`ext_`, because that is reserved.
 :file:`ext_emconf.php`
 ----------------------
 
-- *required*
+*-- required*
 
 Definition of extension properties. This is the only mandatory file in the extension.
 It describes the extension.
@@ -68,7 +68,7 @@ that it is auto-written by the Extension Manager when extensions are imported fr
 :file:`ext_localconf.php`
 -------------------------
 
-- *optional*
+*-- optional*
 
 Addition to :file:`LocalConfiguration.php`.
 It should contain additional configuration of :php:`$GLOBALS['TYPO3_CONF_VARS']`.
@@ -90,7 +90,7 @@ For more details, see the :ref:`section below <extension-configuration-files>`.
 :file:`ext_tables.php`
 ----------------------
 
-- *optional*
+*-- optional*
 
 Contains extensions of existing tables,
 declaration of backend modules, etc. All code in such files
@@ -120,7 +120,7 @@ For more details, see the :ref:`section below <extension-configuration-files>`.
 :file:`ext_tables.sql`
 ----------------------
 
-- *optional*
+*-- optional*
 
 SQL definition of database tables.
 


### PR DESCRIPTION
- use the keywords "optional" and "required" (as already used in
  https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/DirectoryFilenames.html)
- add some links