### PR TITLE
[DOCUMENTATION] Adjust configuration of expression condition provider

### DIFF
--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -285,7 +285,7 @@ various records is combined.
 Custom Conditions With Symfony Expression Language
 ==================================================
 
-Further information about how to extend TypoScript with your own custom conditions can be found within :ref:`symfony-expression-language`
+Further information about how to extend TypoScript with your own custom conditions can be found within :ref:`sel-within-typoscript-conditions`.
 
 .. _typoscript-syntax-conditions-summary:
 
@@ -304,5 +304,3 @@ Summary
 - Conditions can be used outside of confinements (curly braces) only.
   However the :code:`[GLOBAL]` condition will always break a confinement if
   entered inside of one.
-
-https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SymfonyExpressionLanguage/Index.html

--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -290,15 +290,20 @@ Use as reference the class :php:`TYPO3\CMS\Core\ExpressionLanguage\TypoScriptCon
 the most core functions.
 
 Add new methods by implementing own providers which implement the :php:`ExpressionFunctionProviderInterface` and
-register the provider in :file:`ext_localconf.php`:
+register the provider in :file:`Configuration/ExpressionLanguage.php`:
 
 .. code-block:: php
+  <?php
+  return [
+      'typoscript' => [
+          // Simple register you provider class
+          \My\NameSpace\Provider\TypoScriptConditionProvider::class
+      ]
+  ];
 
-   if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'])) {
-      $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'] = [];
-   }
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'][] = \My\NameSpace\Provider\TypoScriptConditionProvider::class;
+The keyword :code:`typoscript` indicates that the condition is used for TypoScript.
 
+Next to :code:`typoscript` additional providers could registered for :code:`form` and :code:`site`.
 
 .. _typoscript-syntax-conditions-summary:
 

--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -285,25 +285,7 @@ various records is combined.
 Custom Conditions With Symfony Expression Language
 ==================================================
 
-It is possible to provide own functions with extensions.
-Use as reference the class :php:`TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionFunctionsProvider` which implements
-the most core functions.
-
-Add new methods by implementing own providers which implement the :php:`ExpressionFunctionProviderInterface` and
-register the provider in :file:`Configuration/ExpressionLanguage.php`:
-
-.. code-block:: php
-  <?php
-  return [
-      'typoscript' => [
-          // Simple register you provider class
-          \My\NameSpace\Provider\TypoScriptConditionProvider::class
-      ]
-  ];
-
-The keyword :code:`typoscript` indicates that the condition is used for TypoScript.
-
-Next to :code:`typoscript` additional providers could registered for :code:`form` and :code:`site`.
+Further information about how to extend TypoScript with your own custom conditions can be found within :ref:`symfony-expression-language`
 
 .. _typoscript-syntax-conditions-summary:
 
@@ -323,3 +305,4 @@ Summary
   However the :code:`[GLOBAL]` condition will always break a confinement if
   entered inside of one.
 
+https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SymfonyExpressionLanguage/Index.html


### PR DESCRIPTION
This pull request adjusts the documentation how to redister additional provider for Symfony expression language inside of TYPO3.