### PR TITLE
Some improvements to Symfony Command page

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -18,9 +18,9 @@ writing CLI (command line interface) commands.
 
 .. note::
 
-   TYPO3 supports Symfony Console commands natively since TYPO3 v8. Extbase
-   Command Controllers are deprecated since v9.4.
+   TYPO3 supports Symfony Console commands natively since TYPO3 v8.
 
+   Extbase Command Controllers are deprecated since v9.4.
 
 Creating a new Symfony Command in Your Extension
 ================================================
@@ -32,28 +32,27 @@ Creating a new Symfony Command in Your Extension
    TYPO3 looks in this file for configured commands. It should
    return a simple array with the command name and class.
 
-   For example to add a command named **yourext:dothings**::
+   For example to add a command named `yourext:dothings`::
 
        return [
            'yourext:dothings' => [
-               'class' => \Vendor\Extension\Command\DoThingsCommand::class
+               'class' => \Vendor\Extension\Command\DoThingsCommand::class,
            ],
        ];
 
-
-
 #. Create the corresponding class file: :file:`Classes/Command/DoThingsCommand.php`
 
-   Symfony commands should extend the class :php:`Symfony\Component\Console\Command\Command`.
+   Symfony commands should extend the class :php:`\Symfony\Component\Console\Command\Command`.
 
-   The command should implement at least a :php:`configure` and an :php:`execute` method.
+   The command should implement at least a :php:`configure()` and an :php:`execute()` method.
 
+   :php:`configure()`
+      As the name would suggest allows to configure the command.
+      Allows to add a description or a help text, or mandatory and optional
+      arguments and parameters defined.
 
-   **configure()** as the name would suggest allows to configure the command.
-   Via :php:`configure()`, a description or a help text can be added, or mandatory and
-   optional arguments and parameters defined.
-
-   **execute()** contains the logic you want to execute when executing the command.
+   :php:`execute()`
+      Contains the logic when executing the command.
 
 
 .. seealso::
@@ -65,40 +64,40 @@ Creating a new Symfony Command in Your Extension
 Command Class
 -------------
 
-Example taken from :php:`ListSysLogCommand`  in the core and simplified::
+Example taken from :php:`ListSysLogCommand` in the core and simplified::
 
 
     class DoThingsCommand extends Command
     {
-       /**
-        * Configure the command by defining the name, options and arguments
-        */
-       protected function configure()
-       {
-           $this->setDescription('Show entries from the sys_log database table of the last 24 hours.');
-           $this->setHelp('Prints a list of recent sys_log entries.' . LF . 'If you want to get more detailed information, use the --verbose option.');
-       }
+        /**
+         * Configure the command by defining the name, options and arguments
+         */
+        protected function configure()
+        {
+            $this->setDescription('Show entries from the sys_log database table of the last 24 hours.');
+            $this->setHelp('Prints a list of recent sys_log entries.' . LF . 'If you want to get more detailed information, use the --verbose option.');
+        }
 
-       /**
-        * Executes the command for showing sys_log entries
-        *
-        * @param InputInterface $input
-        * @param OutputInterface $output
-        */
-       protected function execute(InputInterface $input, OutputInterface $output)
-       {
-           $io = new SymfonyStyle($input, $output);
-           $io->title($this->getDescription());
+        /**
+         * Executes the command for showing sys_log entries
+         *
+         * @param InputInterface $input
+         * @param OutputInterface $output
+         */
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            $io = new SymfonyStyle($input, $output);
+            $io->title($this->getDescription());
 
-           // ...
-           $io->writeln('Write something');
-       }
+            // ...
+            $io->writeln('Write something');
+        }
     }
 
 Passing Arguments
 -----------------
 
-:php:`TYPO3\CMS\Install\Command\UpgradeWizardRunCommand`::
+:php:`\TYPO3\CMS\Install\Command\UpgradeWizardRunCommand`::
 
 
     /**
@@ -118,12 +117,14 @@ Passing Arguments
     }
 
 
-This command takes one optional argument 'wizardName', which can be passed on the command line:
+This command takes one optional argument `wizardName`, which can be passed on the command line:
 
 .. code-block:: bash
 
    vendor/bin/typo3 upgrade:run [wizardName]
 
+
+.. _deactivating-the-command-in-scheduler:
 
 Deactivating the Command in Scheduler
 -------------------------------------
@@ -135,7 +136,7 @@ this by setting `schedulable` to `false` in :file:`Configuration/Commands.php`::
        'yourext:dothings' => [
            'class' => \Vendor\Extension\Command\DoThingsCommand::class,
            'schedulable' => false,
-       ]
+       ],
    ];
 
 
@@ -146,7 +147,7 @@ If anything related to :ref:`DataHandler  <datahandler-basics>` and backend
 permission handling is necessary, you should call this initialization
 method once in your :php:`execute()` function::
 
-   Bootstrap::initializeBackendAuthentication();.
+   Bootstrap::initializeBackendAuthentication();
 
 
 Running the Command From the Command Line
@@ -180,8 +181,6 @@ Running the Command From the Scheduler
    Running Symfony Console Commands via the scheduler is possible since TYPO3 v9.0.
    The `schedulable` option is available since v9.4.
 
-
-By default, it is possible to run the command from the
-`TYPO3 scheduler <https://docs.typo3.org/c/typo3/cms-scheduler/master/en-us/>`__ as well
-if `schedulable` is not set to false in :file:`Configuration/Commands.php`.
-
+By default, it is possible to run the command from the `TYPO3 scheduler
+<sysextscheduler:start>`__ as well, if not deactivated see:
+:ref:`deactivating-the-command-in-scheduler`.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,6 +40,7 @@ form          = https://docs.typo3.org/c/typo3/cms-form/master/en-us/
 
 sysextform    = https://docs.typo3.org/c/typo3/cms-form/master/en-us/
 sysextckedit  = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/
+sysextscheduler = https://docs.typo3.org/c/typo3/cms-scheduler/master/en-us/
 
 [notify]
 


### PR DESCRIPTION
- add information about deprecation of Extbase command controllers
- add more examples
- add information about initialization necessary for using DataHandler

Releases: master, 9.5