### PR TITLE
Add missing configuration categories

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/Index.rst
@@ -112,19 +112,25 @@ may themselves be arrays.
 The configuration categories are:
 
 BE
-  Options related to the TYPO3 CMS backend
+  Options related to the TYPO3 CMS backend.
 
 DB
-  Database connection configuration
+  Database connection configuration.
+
+EXT
+  Extension installation options.
 
 EXTCONF
   Backend related language pack configuration resides here.
 
 EXTENSIONS
-  Extension specific settings
+  Extension specific settings.
 
 FE
   Frontend-related options.
+
+HTTP
+  Settings for tuning HTTP requests made by TYPO3.
 
 GFX
   Options related to image manipulation.

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/Index.rst
@@ -124,7 +124,7 @@ EXTCONF
   Backend related language pack configuration resides here.
 
 EXTENSIONS
-  Extension specific settings.
+  :ref:`Extension configuration <extension-configuration>`.
 
 FE
   Frontend-related options.

--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -2,6 +2,7 @@
 
 
 .. _extension-options:
+.. _extension-configuration:
 
 ===============================================
 Extension Configuration (ext_conf_template.txt)


### PR DESCRIPTION
The configuration categories in TYPO3_CONF_VARS:

 - EXT
 - HTTP

were missing in the documentation according to:
https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Configuration/DefaultConfigurationDescription.yaml