### PR TITLE
PageRepository class moved in v10

### DIFF
--- a/Documentation/ApiOverview/PageTypes/Index.rst
+++ b/Documentation/ApiOverview/PageTypes/Index.rst
@@ -22,13 +22,13 @@ allowed on a certain page type.
 This is the default array as set in :file:`EXT:core/ext_tables.php`::
 
    $GLOBALS['PAGES_TYPES'] = array(
-    (string) \TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_LINK => array(
+    (string) \TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_LINK => array(
     ),
-    (string) \TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SHORTCUT => array(
+    (string) \TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_SHORTCUT => array(
     ),
     // ...
     //  Doktype 254 is a 'Folder' - a general purpose storage folder for whatever you like. In CMS context it's NOT a viewable page. Can contain any element.
-    (string) \TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_SYSFOLDER => array(
+    (string) \TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_SYSFOLDER => array(
         'type' => 'sys',
         'allowedTables' => '*'
     ),

--- a/Documentation/ApiOverview/PageTypes/Index.rst
+++ b/Documentation/ApiOverview/PageTypes/Index.rst
@@ -221,7 +221,7 @@ need to add the new doktype as select item and associate it with the configured 
                     // add all page standard fields and tabs to your new page type
                     'types' => [
                         (string) $archiveDoktype => [
-                            'showitem' => $GLOBALS['TCA'][$table]['types'][\TYPO3\CMS\Frontend\Page\PageRepository::DOKTYPE_DEFAULT]['showitem']
+                            'showitem' => $GLOBALS['TCA'][$table]['types'][\TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_DEFAULT]['showitem']
                         ]
                     ]
                 ]

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -71,7 +71,7 @@ then overlay the future version and eventually check if it is hidden
 and if so exclude it. The same problem applies to all other
 "enableFields", future versions with "delete" flags and current
 versions which are invisible placeholders for future records. Anyway,
-all that is handled by the :code:`\TYPO3\CMS\Frontend\Page\PageRepository` class which includes
+all that is handled by the :code:`\TYPO3\CMS\Core\Domain\Repository\PageRepository` class which includes
 functions for "enableFields" and "deleted" so it will work out of the
 box for you. But as soon as you do selection based on other fields
 like email, username, alias etc. it will fail.
@@ -451,7 +451,7 @@ see if a placeholder exists for a move operation and if so the record
 will take over the pid / "sortby" value upon publishing.
 
 Preview of move operations is almost fully functional through the
-:code:`\TYPO3\CMS\Frontend\Page\PageRepository::versionOL()` and
+:code:`\TYPO3\CMS\Core\Domain\Repository\PageRepository::versionOL()` and
 :code:`\TYPO3\CMS\Backend\Utility\BackendUtility::workspaceOL()` functions.
 When the online placeholder is selected it simply looks up the source
 record, overlays any version on top and displays it. When the source


### PR DESCRIPTION
The PageRepository class was moved from Frontend to Core Extension:
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Deprecation-88746-PageRepositoryPHPClassMovedFromFrontendToCoreExtension.html