### PR TITLE
Fix TSconfig folder naming

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -426,12 +426,12 @@ Configuration/TCA/Overrides
   For extending existing tables, one file per database table, using the name of
   the table for the file, plus ".php".
 
-Configuration/TsConfig/Page
+Configuration/TSconfig/Page
   Page TSconfig, see chapter :ref:`'Page TSconfig' in the TSconfig Reference
   <t3tsconfig:PageTSconfig>`. Files should have the file extension
   :file:`.tsconfig`.
 
-Configuration/TsConfig/User
+Configuration/TSconfig/User
   User TSconfig, see chapter :ref:`'User TSconfig' in the TSconfig Reference
   <t3tsconfig:UserTSconfig>`. Files should have the file extension
   :file:`.tsconfig`.


### PR DESCRIPTION
Change folder name from `TsConfig` to `TSconfig` to unify
between different documentations and comply with the 
convention as found here: https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/UsingSetting/Index.html#register-static-page-tsconfig-files