### PR TITLE
Remove createDirs from extension declaration

### DIFF
--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -204,13 +204,6 @@ values in the :code:`$EM_CONF` array if needed.
          underscore]" should be present!
 
  - :Key:
-         createDirs
-   :Data type:
-         list of strings
-   :Description:
-         Comma list of directories to create upon extension installation.
-
- - :Key:
          clearCacheOnLoad
    :Data type:
          boolean
@@ -245,12 +238,12 @@ values in the :code:`$EM_CONF` array if needed.
    :Data type:
          array
    :Description:
-         To get better class loading support for websites in **non-composer mode+** 
+         To get better class loading support for websites in **non-composer mode+**
          the following information can be provided.
-         
+
          **Extensions having one folder with classes or single files**
-         
-         Considering you have an Extbase extension (or an extension where all classes 
+
+         Considering you have an Extbase extension (or an extension where all classes
          and interfaces reside in a :file:`Classes` folder) or single classes you can simply
          add the following to your :file:`ext_emconf.php` file::
 
@@ -260,28 +253,28 @@ values in the :code:`$EM_CONF` array if needed.
                   'a-class.php',
                ]
             ],
-            
+
          **Extensions using namespaces**
-         
-         If the extension has namespaced classes following the PSR-4 standard, then you 
+
+         If the extension has namespaced classes following the PSR-4 standard, then you
          can add the following to your :file:`ext_emconf.php` file::
-         
+
             'autoload' => [
                'psr-4' => [
                   'Vendor\\ExtName\\' => 'Classes'
                ]
             ],
-            
-         // Important: The prefix must end with a backslash.          
+
+         // Important: The prefix must end with a backslash.
 
  - :Key:
          autoload-dev
    :Data type:
          array
    :Description:
-         Same as the configuration "autoload" but it is only used if the 
+         Same as the configuration "autoload" but it is only used if the
          *ApplicationContext* is set to *Testing*.
-  
+
 
 Deprecated Configuration
 ========================
@@ -290,8 +283,8 @@ The following fields are deprecated and should not be used anymore:
 
 - dependencies
 - conflicts
-- suggests 
-- docPath 
+- suggests
+- docPath
 - CGLcompliance
 - CGLcompliance_note
 - private


### PR DESCRIPTION
According to https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-88525-RemoveCreateDirsDirectiveOfExtensionInstallationEm_confphp.html