### PR TITLE
Restructure this manual

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -1,0 +1,177 @@
+.. include:: Includes.txt
+
+.. _about:
+
+=================
+About This Manual
+=================
+
+
+TYPO3 is known for its extensibility. To really benefit from
+this power, a complete documentation is needed: "TYPO3 Explained" aims to
+provide such information to everyone. Not all areas are covered with the
+same amount of detail, but at least some pointers are provided.
+
+The document does *not* contain any significant information about
+the frontend of TYPO3. Creating templates, setting up TypoScript
+objects etc. is not the scope of the document, it addresses the
+*backend* and management part of the core only.
+
+The TYPO3 Documentation Team hopes that this document will form a complete picture
+of the TYPO3 Core architecture. It will hopefully be the knowledge base
+of choice in your work with TYPO3.
+
+
+.. _audience:
+
+Intended Audience
+=================
+
+This document is intended to be a reference for TYPO3 CMS developers and partially
+for integrators. The document explains all major parts of TYPO3 and the concepts.
+Some chapters presumes knowledge in the technical end: PHP, MySQL, Unix etc, depending
+on the specific chapter.
+
+The goal is to take you "under the hood" of TYPO3 CMS. To make the
+principles and opportunities clear and less mysterious. To educate you
+to help continue the development of TYPO3 along the already
+established lines so we will have a consistent CMS application in a
+future as well. And hopefully this teaching on the deep technical level
+will enable you to educate others higher up in the "hierarchy". Please
+consider that as well!
+
+
+.. _code-examples:
+
+Code examples
+=============
+
+Many of the code examples found in this document come from the TYPO3
+Core itself.
+
+Quite a few others come from the "`styleguide <https://github.com/TYPO3/styleguide>`__"
+extension. You can install it, if you want to try out these examples yourself and
+use them as a basis for your own extensions.
+
+.. _contribute:
+.. _feedback:
+
+Feedback and Contribute
+=======================
+
+If you find an error in this manual, please be so kind to hit
+the "Edit me on GitHub" button in the top right corner
+and submit a pull request via GitHub.
+
+Alternatively you can just `report an issue
+on GitHub <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/new>`__.
+
+You can find more about this in Writing Documentation:
+
+- :ref:`h2document:docs-contribute` : Make a change by editing directly on
+  GitHub and creating a pull request
+- :ref:`h2document:docs-contribute-git-docker` : If you are experienced
+  with Docker and Git you can edit and render locally.
+
+If you are currently not reading the online version, go to
+https://docs.typo3.org/typo3cms/CoreApiReference/.
+
+Maintaining high quality documentation requires time and effort
+and the TYPO3 Documentation Team always appreciates support.
+
+If you want to support us, please join the slack channel **#typo3-documentation**
+on `Slack <https://typo3.slack.com/>`__ (`Register for Slack <https://my.typo3.org/about-mytypo3org/slack/>`__).
+
+And finally, as a last resort, you can get in touch with the documentation team
+`by mail <documentation@typo3.org>`_.
+
+
+.. _credits:
+
+Credits
+=======
+
+This manual was originally written by Kasper Skårhøj. It was further
+maintained, refreshed and expanded by François Suter.
+
+The first version of the security chapter has been written by Ekkehard Guembel and Michael Hirdes
+and we would like to thank them for this. Further thanks to the TYPO3 Security Team for
+their work for the TYPO3 project. A special thank goes to Stefan Esser for his books and
+articles on PHP security, Jochen Weiland for an initial foundation and Michael Schams
+for compiling the content of the security chapter and coordinating the collaboration between
+several teams. He managed the whole process of getting the Security Guide to a high quality.
+
+
+.. _dedication:
+
+Dedication
+==========
+
+I want to dedicate this document to the people in the TYPO3 community
+who have the  *discipline* to do the boring job of writing
+documentation for their extensions or contribute to the TYPO3
+documentation in general. It's great to have good coders, but it's
+even more important to have coders with character to carry their work
+through till the end - even when it means spending days writing good
+documents. Go for completeness!
+
+\- kasper
+
+
+.. _next-steps:
+
+Further Documentation
+=====================
+
+This manual covers many different APIs of the TYPO3 CMS Core, but some
+other documents exist which cover more specific aspects.
+
+
+:ref:`TCA Reference <t3tca:start>`
+----------------------------------
+
+`TCA` is the backbone of database tables displayed in the backend, it configures
+how data is stored if editing records in the backend, how fields are displayed,
+relations to other tables and much more. It is a huge array loaded in almost all
+access contexts.
+
+A detailed insight on `TCA` is documented in the :ref:`TCA Reference <t3tca:start>`.
+Next to a small introduction, the document forms a complete reference of all
+different `TCA` options, with bells and whistles. The document is a must-read for
+Developers, partially for Integrators, and is often used as a reference book on a daily basis.
+
+
+:ref:`TypoScript Reference <t3tsref:start>`
+-------------------------------------------
+
+`TypoScript` - or more precisely `Frontend TypoScript` - is used in TYPO3 to steer
+the frontend rendering (the actual website) of a TYPO3 instance. It is based on the
+TypoScript syntax which is outlined in detail :ref:`here in this document <typoscript-syntax-start>`.
+
+Frontend TypoScript is very powerful and has been the backbone of frontend rendering ever since.
+However, with the rise of the Fluid templating engine, many parts of Frontend TypoScript are much less
+often used. Nowadays, TypoScript in real life projects is often not much more than a way to
+set a series of options for plugins, to set some global config options, and to act as a simple
+pre processor between database data and Fluid templates.
+
+Still, the :ref:`TypoScript Reference <t3tsref:start>` reference document that goes deep into
+the incredible power of Frontend TypoScript is daily bread for Integrators.
+
+
+:ref:`TSconfig Reference <t3tsconfig:start>`
+--------------------------------------------
+
+While `Frontend TypoScript` is used to steer the rendering of the frontend, `TSconfig` is used
+to configure backend details for backend users. Using `TSconfig` it is possible to enable or
+disable certain views, change the editing interfaces, and much more. All that without coding a single
+line of PHP. `TSconfig` can be set on a page (Page TSconfig), as well as a user / group (User TSconfig)
+basis.
+
+`TSconfig` uses the same syntax as `Frontend TypoScript`, the syntax is outlined in detail
+:ref:`here in this document <typoscript-syntax-start>`. Other than that, TSconfig and Frontend TypoScript
+don't have much more in common - they consist of entirely different properties.
+
+A full reference of properties as well as an introduction to explain details configuration usage, API and
+load orders can be found in the :ref:`TSconfig Reference document <t3tsconfig:start>`. While Developers
+should have an eye on this document, it is mostly used as a reference for Integrators who make life as
+easy as possible for backend users.

--- a/Documentation/ApiOverview/Configuration/ConfigurationMethods.rst
+++ b/Documentation/ApiOverview/Configuration/ConfigurationMethods.rst
@@ -1,0 +1,63 @@
+.. include:: ../../Includes.txt
+
+
+.. _configuration-methods:
+
+==========================
+Configuration Methods
+==========================
+
+These are the main configuration methods used by TYPO3:
+
+The :php:`$GLOBALS` array consists:
+
+* :ref:`Global Configuration <typo3ConfVars>` :php:`$GLOBALS['TYPO3_CONF_VARS']`
+  is used for system wide configuration. A subset of this is
+  :ref:`Extension Configuration <extension-options>`
+  (:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']`). It is used for
+  configuration specific to one extension.
+* :ref:`TCA <t3tca:introduction>` :php:`GLOBALS['TCA']` is specific to
+  database fields and how they behave and can be edited in the backend.
+* :ref:`User settings <user-settings>` :php:`$GLOBALS['TYPO3_USER_SETTINGS']`
+  defines configuration for backend users
+* ... you can find more in the TYPO3 backend :guilabel:`SYSTEM > Configuration`
+  or by viewing the :php:`$GLOBALS` array in a debugger. Read more about this
+  on :ref:`globals-variables`.
+
+
+Furthermore, we have:
+
+* :ref:`TSconfig <tsconfig>` is used to configure and **customize the backend** on a page (page TSconfig)
+  and a user or group basis (user TSconfig).
+* :ref:`TypoScript configuration method <t3tsref:introduction>` is used to
+  configure plugins (FE) and modules (BE), as well as some
+  global settings (config). It is also used to define the rendering, but that is
+  beyond the scope of this page, which focuses only on configuration. TypoScript
+  is mostly used for configuration that affects the Frontend (FE).
+* :ref:`Flexform <flexforms>` is used to configure plugins and content elements.
+
+
+Additionally, some system extensions use yaml for configuration:
+
+* :ref:`Site <sitehandling>` configuration is stored in :file:`<project-root>/config/sites/<identifier>/config.yaml`
+  and can be configured in the sites module.
+* :ref:`form <form:concepts-configuration>`
+* :ref:`rte_ckeditor <ckedit:configuration>`
+
+.. toctree:: 1
+   :maxdepth: 1
+
+   ../GlobalValues/Constants/Index
+   Extension Configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationOptions/Index.html>
+   ../FeatureToggles/Index
+   FlexForms ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/FlexForms/Index.html>
+   Form configuration ➜ <https://docs.typo3.org/c/typo3/cms-form/master/en-us/I/Concepts/Configuration/Index.html#concepts-configuration>
+   ../GlobalValues/GlobalVariables/Index
+   rte_ckeditor configuration ➜  <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/Configuration/Index.html#configuration>
+   Site configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SiteHandling/Index.html#sitehandling>
+   TCA ➜ <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/Introduction/Index.html>
+   ../Tsconfig/Index
+   ../GlobalValues/Typo3ConfVars/Index
+   TypoScript Templates ➜ <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
+   ../UserSettingsConfiguration/Index
+

--- a/Documentation/ApiOverview/Configuration/ConfigurationSyntax.rst
+++ b/Documentation/ApiOverview/Configuration/ConfigurationSyntax.rst
@@ -1,0 +1,40 @@
+
+.. include:: ../../Includes.txt
+
+.. _configuration-syntax:
+
+====================
+Configuration Syntax
+====================
+
+These are the main languages TYPO3 uses for configuration:
+
+* :ref:`TypoScript syntax <typoscript-syntax-start>` is used for TypoScript
+  and TSconfig.
+* :ref:`TypoScript constant syntax <t3tsref:typoscript-syntax-constant-editor>` is
+  used for Extension Configuration and for defining constants for TypoScript.
+* Yaml is the configuration language of choice for newer TYPO3 system extensions
+  like rte_ckeditor, form and the sites module. It has partly replaced TypoScript
+  and TSconfig as configuration languages.
+* XML is used in FlexForms.
+* PHP is used for the :php:`$GLOBALS` array which includes TCA
+  (:php:`$GLOBALS['TCA']`, Global Configuration (:php:`GLOBALS['TYPO3_CONF_VARS']`),
+  User Settings (:php:`$GLOBALS['TYPO3_USER_SETTINGS']`, etc.
+
+What is most important here, is that TypoScript has its own syntax. And the
+TypoScript syntax is used for the configuration methods **TypoScript and TSconfig**.
+The syntax for both is the same, while the semantics (what variables can be used and
+what they mean) are not.
+
+.. tip::
+
+   Hence, the term **TypoScript** is used to both define the pure syntax TypoScript
+   and the configuration method TypoScript. These are different things. To avoid
+   confusion, we will use the term "TypoScript syntax" and "TypoScript configuration
+   method", at least on this page.
+
+.. toctree::
+   :maxdepth: 1
+
+   ../TypoScriptSyntax/Index
+   ../Yaml/Index

--- a/Documentation/ApiOverview/Configuration/Glossary.rst
+++ b/Documentation/ApiOverview/Configuration/Glossary.rst
@@ -1,0 +1,60 @@
+.. include:: ../../Includes.txt
+
+.. _configuration-glossary:
+
+===========
+Glossary
+===========
+
+To differentiate between different configuration languages we use the
+terms syntax and semantics:
+
+Configuration syntax
+====================
+
+**Syntax** describes common rules for a language (e.g. how are lines terminated,
+how are values assigned, what are separators, etc.) while semantics define the meaning.
+
+For example, using only the basic syntax of yaml, this is a syntactically
+correct snippet:
+
+.. code-block:: yaml
+
+   foo: bar
+
+
+Most of the configuration languages used in TYPO3 basically assign values to
+variables in one way another. In its simplest form, these can be simple
+string assignments as in the yaml example, which may result in assigning
+the value 'bar' to a variable `foo`.
+
+The assignment in TypoScript syntax would look like this:
+
+.. code-block:: typoscript
+
+   foo = bar
+
+Configuration methods
+=====================
+
+However, without defining what are correct keys, values and data types, we
+have no idea about the meaning (**semantics**) of the file and cannot interpret
+it. We (or rather the TYPO3 core) have no idea, what `foo` means, whether
+it is a valid assignment, what data type can be used as value etc. We can only
+check whether the syntax is correct.
+
+For this reason, we don't just need a language with a predefined syntax (like
+XML, JSON, Yaml).
+
+We also need to define the configuration schema: What are allowed variables
+and datatypes? What are the default values? What settings are mandatory and
+which are optional? And we define the semantics: What do these variables mean,
+how will they be interpreted? Additionally, we must define where the
+values are stored, who can change the values (privileges)
+and to what the values apply (scope). Are they global or do they only
+apply to certain pages, users or usergroups?
+
+We refer to a configuration language, that only defines the syntax as
+**configuration syntax**. When we refer to semantics, where the values
+are stored, the scope etc. we use the term **configuration method**.
+

--- a/Documentation/ApiOverview/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Configuration/Index.rst
@@ -2,6 +2,7 @@
 
 
 .. _config-overview:
+.. _configuration:
 
 ======================
 Configuration Overview
@@ -21,123 +22,15 @@ sources of confusion.
 For a more extensive introduction we will refer you to the
 respective chapter or reference.
 
-Terminology
-===========
+.. toctree::
+   :maxdepth: 1
 
-To differentiate between different configuration languages we use the
-terms syntax and semantics:
+   Glossary
 
-**Syntax** describes common rules for a language (e.g. how are lines terminated,
-how are values assigned, what are separators, etc.) while semantics define the meaning.
-
-For example, using only the basic syntax of yaml, this is a syntactically
-correct snippet:
-
-.. code-block:: yaml
-
-   foo: bar
+.. toctree::
+   :maxdepth: 2
 
 
-Most of the configuration languages used in TYPO3 basically assign values to
-variables in one way another. In its simplest form, these can be simple
-string assignments as in the yaml example, which may result in assigning
-the value 'bar' to a variable `foo`.
-
-The assignment in TypoScript syntax would look like this:
-
-.. code-block:: typoscript
-
-   foo = bar
-
-
-However, without defining what are correct keys, values and data types, we
-have no idea about the meaning (**semantics**) of the file and cannot interpret
-it. We (or rather the TYPO3 core) have no idea, what `foo` means, whether
-it is a valid assignment, what data type can be used as value etc. We can only
-check whether the syntax is correct.
-
-For this reason, we don't just need a language with a predefined syntax (like
-XML, JSON, Yaml).
-
-We also need to define the configuration schema: What are allowed variables
-and datatypes? What are the default values? What settings are mandatory and
-which are optional? And we define the semantics: What do these variables mean,
-how will they be interpreted? Additionally, we must define where the
-values are stored, who can change the values (privileges)
-and to what the values apply (scope). Are they global or do they only
-apply to certain pages, users or usergroups?
-
-We refer to a configuration language, that only defines the syntax as
-**configuration syntax**. When we refer to semantics, where the values
-are stored, the scope etc. we use the term **configuration method**.
-
-Configuration Syntax
-====================
-
-These are the main languages TYPO3 uses for configuration:
-
-* :ref:`TypoScript syntax <typoscript-syntax-start>` is used for TypoScript
-  and TSconfig.
-* :ref:`TypoScript constant syntax <t3tsref:typoscript-syntax-constant-editor>` is
-  used for Extension Configuration and for defining constants for TypoScript.
-* Yaml is the configuration language of choice for newer TYPO3 system extensions
-  like rte_ckeditor, form and the sites module. It has partly replaced TypoScript
-  and TSconfig as configuration languages.
-* XML is used in FlexForms.
-* PHP is used for the :php:`$GLOBALS` array which includes TCA
-  (:php:`$GLOBALS['TCA']`, Global Configuration (:php:`GLOBALS['TYPO3_CONF_VARS']`),
-  User Settings (:php:`$GLOBALS['TYPO3_USER_SETTINGS']`, etc.
-
-What is most important here, is that TypoScript has its own syntax. And the
-TypoScript syntax is used for the configuration methods **TypoScript and TSconfig**.
-The syntax for both is the same, while the semantics (what variables can be used and
-what they mean) are not.
-
-.. tip::
-
-   Hence, the term **TypoScript** is used to both define the pure syntax TypoScript
-   and the configuration method TypoScript. These are different things. To avoid
-   confusion, we will use the term "TypoScript syntax" and "TypoScript configuration
-   method", at least on this page.
-
-
-Main Configuration Methods
-==========================
-
-These are the main configuration methods used by TYPO3:
-
-The :php:`$GLOBALS` array consists:
-
-* :ref:`Global Configuration <typo3ConfVars>` :php:`$GLOBALS['TYPO3_CONF_VARS']`
-  is used for system wide configuration. A subset of this is
-  :ref:`Extension Configuration <extension-options>`
-  (:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']`). It is used for
-  configuration specific to one extension.
-* :ref:`TCA <t3tca:introduction>` :php:`GLOBALS['TCA']` is specific to
-  database fields and how they behave and can be edited in the backend.
-* :ref:`User settings <user-settings>` :php:`$GLOBALS['TYPO3_USER_SETTINGS']`
-  defines configuration for backend users
-* ... you can find more in the TYPO3 backend :guilabel:`SYSTEM > Configuration`
-  or by viewing the :php:`$GLOBALS` array in a debugger. Read more about this
-  on :ref:`globals-variables`.
-
-
-Furthermore, we have:
-
-* :ref:`TSconfig <tsconfig>` is used to configure and **customize the backend** on a page (page TSconfig)
-  and a user or group basis (user TSconfig).
-* :ref:`TypoScript configuration method <t3tsref:introduction>` is used to
-  configure plugins (FE) and modules (BE), as well as some
-  global settings (config). It is also used to define the rendering, but that is
-  beyond the scope of this page, which focuses only on configuration. TypoScript
-  is mostly used for configuration that affects the Frontend (FE).
-* :ref:`Flexform <flexforms>` is used to configure plugins and content elements.
-
-
-Additionally, some system extensions use yaml for configuration:
-
-* :ref:`Site <sitehandling>` configuration is stored in :file:`<project-root>/config/sites/<identifier>/config.yaml`
-  and can be configured in the sites module.
-* :ref:`form <form:concepts-configuration>`
-* :ref:`rte_ckeditor <ckedit:configuration>`
+   ConfigurationSyntax
+   ConfigurationMethods
 

--- a/Documentation/ApiOverview/ContentElements/Index.rst
+++ b/Documentation/ApiOverview/ContentElements/Index.rst
@@ -23,9 +23,6 @@ Content Elements & Plugins
 
    AddingYourOwnContentElements
    ContentElementsWizard
-
-.. seealso::
-
-   * :ref:`Some content elements <fsc:content-elements>` are supplied by the TYPO3
-     system extension **fluid_styled_content**.
+   ../FlexForms/Index
+   ..//BackendLayout/Index
 

--- a/Documentation/ApiOverview/Examples/Clipboard/Index.rst
+++ b/Documentation/ApiOverview/Examples/Clipboard/Index.rst
@@ -3,9 +3,9 @@
 
 .. _examples-clipboard:
 
-=======================
-Accessing the Clipboard
-=======================
+=========
+Clipboard
+=========
 
 You can easily access the internal clipboard in TYPO3 from your
 backend modules::

--- a/Documentation/ApiOverview/Examples/Index.rst
+++ b/Documentation/ApiOverview/Examples/Index.rst
@@ -1,11 +1,21 @@
+:orphan:
+
 .. include:: ../../Includes.txt
 
+
+.. todo:: merge examples into other chapters in TYPO3 API
 
 .. _examples:
 
 ========
 Examples
 ========
+
+For a list of TYPO3 features, see the
+
+.. rst-class:: horizbuttons-tip-xxl
+
+- :ref:`Sitemap`
 
 This chapter presents some examples of how you can use the APIs
 of Core libraries. They are not meant to be exhaustive,
@@ -28,7 +38,4 @@ another whole lot of examples.
    ContextualMenu/Index
    ParsingHtml/Index
    EditLinks/Index
-   ContentElementWizard/Index
    CustomPermissions/Index
-
-

--- a/Documentation/ApiOverview/GlobalValues/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. include:: ../../Includes.txt
 
 .. _globals:
@@ -10,11 +12,10 @@ After TYPO3's bootstrap sequence has completed, a number of
 global variables, constants and classes are available to any script.
 
 
-.. toctree::
-   :titlesonly:
+.. the toctree is now in ApiOverview/ConfigurationMethods.rst
 
-   Constants/Index
-   GlobalVariables/Index
-   Typo3ConfVars/Index
+* :ref:`globals-constants`
+* :ref:`globals-variables`
+* :ref:`typo3ConfVars`
 
 

--- a/Documentation/ApiOverview/Hooks/EventDispatcher/Index.rst
+++ b/Documentation/ApiOverview/Hooks/EventDispatcher/Index.rst
@@ -3,9 +3,9 @@
 
 .. _EventDispatcher:
 
-=============
-PSR-14 Events
-=============
+===============================
+EventDispatcher (PSR-14 Events)
+===============================
 
 The EventDispatcher system was added to extend TYPO3's Core behaviour in TYPO3 10.0 via PHP code. In the past,
 this was done via Extbase's SignalSlot and TYPO3's custom hook system. The new EventDispatcher

--- a/Documentation/ApiOverview/Index.rst
+++ b/Documentation/ApiOverview/Index.rst
@@ -1,10 +1,19 @@
+:orphan:
+
 .. include:: ../Includes.txt
 
-.. _api-overview:
+
 
 ============
 API Overview
 ============
+
+For a list of TYPO3 features, see the
+
+.. rst-class:: horizbuttons-tip-xxl
+
+- :ref:`Sitemap`
+
 
 The TYPO3 APIs are first and foremost documented inside of the source
 scripts. It would be impossible to maintain documentation at more than
@@ -14,172 +23,4 @@ This chapter describes the most important elements of the API.
 .. note::
 
    The source is the documentation! (General wisdom)
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   DirectoryStructure/Index
-
-
-GLOBAL PROPERTIES
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Environment/Index
-   Context/Index
-   GlobalValues/Index
-
-
-BOOTSTRAPPING
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Namespaces/Index
-   Autoloading/Index
-   Bootstrapping/Index
-   RequestHandling/Index
-
-DATABASE & FILES
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Database/Index
-   Typo3CoreEngine/Index
-   Fal/Index
-
-CONFIGURATION
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Configuration/Index
-   TypoScriptSyntax/Index
-   SymfonyExpressionLanguage/Index
-   Yaml/Index
-   Tsconfig/Index
-   FeatureToggles/Index
-   UserSettingsConfiguration/Index
-   FlexForms/Index
-
-CACHING
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   CachingFramework/Index
-
-LOGGING, ERRORS, EXCEPTIONS
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Logging/Index
-   SystemLog/Index
-   Deprecation/Index
-   ErrorAndExceptionHandling/Index
-
-BACKEND
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   AccessControl/Index
-   BackendModules/Index
-   BackendRouting/Index
-   BackendUserObject/Index
-   BackendLayout/Index
-   BroadcastChannels/Index
-   FlashMessages/Index
-   FormEngine/Index
-   JavaScript/Index
-   LinkBrowser/Index
-   Rte/Index
-
-HANDLING SITES, URLS, LANGUAGES
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   SiteHandling/Index
-   Internationalization/Index
-   Routing/Index
-
-SECURITY, AUTHENTICATION, PASSWORDS, ...
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Authentication/Index
-   PasswordHashing/Index
-   FormProtection/Index
-
-UPDATES
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   UpdateWizards/Index
-   ExtensionScanner/Index
-
-SEO & SOCIAL MEDIA
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Seo/Index
-   MetaTagApi/Index
-   PageTitleApi/Index
-   XmlSitemap/Index
-
-HOOKS, SIGNALS, XCLASSES
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   Hooks/Index
-   Xclasses/Index
-
-VARIOUS
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   CommandControllers/Index
-   ContentElements/Index
-   ContextSensitiveHelp/Index
-   Enumerations/Index
-   FileProcessing/Index
-   Http/Index
-   Icon/Index
-   LockingApi/Index
-   Mail/Index
-   PageTypes/Index
-   Pagination/Index
-   SessionStorageFramework/Index
-   Services/Index
-   SoftReferences/Index
-   Categories/Index
-   Collections/Index
-   SystemRegistry/Index
-   Workspaces/Index
-   DependencyInjection/Index
-
-
 

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -4,8 +4,8 @@
 
 .. _namespaces:
 
-PHP Namespaces
-==============
+Namespaces
+==========
 
 Since version 6.0, TYPO3 CMS uses PHP namespaces for all classes in the Core.
 

--- a/Documentation/ApiOverview/Seo/Index.rst
+++ b/Documentation/ApiOverview/Seo/Index.rst
@@ -9,39 +9,36 @@ SEO
 TYPO3 contains various SEO related functionality out of the box. The following provides an introduction in those features.
 
 Site title
-==========
+    The site title is basically a variable that describes the current web site. It is used
+    in title tag generation as for example prefix. If your website is called "TYPO3 News" and
+    the current page is called "Latest" the page title will be something like "TYPO3 News: Latest".
 
-The site title is basically a variable that describes the current web site. It is used 
-in title tag generation as for example prefix. If your website is called "TYPO3 News" and 
-the current page is called "Latest" the page title will be something like "TYPO3 News: Latest".
-
-The site title can be configured in the sites module and is translatable.
+    The site title can be configured in the sites module and is translatable.
 
 Hreflang Tags
-=============
- "hreflang" tags are added automatically for multilanguage websites based on the one-tree principle.
+    "hreflang" tags are added automatically for multilanguage websites based on the one-tree principle.
 
-The href is relative as long as the domain is the same. If the domain differs the href becomes absolute. 
-The x-default href is the first supported language. The value of "hreflang" is the one set in the sites module
-(see :ref:`sitehandling-addingLanguages`)
+    The href is relative as long as the domain is the same. If the domain differs the href becomes absolute.
+    The x-default href is the first supported language. The value of "hreflang" is the one set in the sites module
+    (see :ref:`sitehandling-addingLanguages`)
+
+
 
 Canonical Tags
-==============
+    TYPO3 provides built-in support for the :html:`<link rel="canonical" href="">` tag.
 
-TYPO3 provides built-in support for the :html:`<link rel="canonical" href="">` tag.
+    If the core extension "seo" is installed, it will automatically add the canonical link to the page.
 
-If the core extension "seo" is installed, it will automatically add the canonical link to the page.
+    The canonical link is basically the same absolute link as the link to the current hreflang and is meant
+    to indicate where the original source of the content is. It is a tool to prevent duplicate content
+    penalties.
 
-The canonical link is basically the same absolute link as the link to the current hreflang and is meant
-to indicate where the original source of the content is. It is a tool to prevent duplicate content
-penalties.
+    In the page properties, the canonical link can be overwritten per language. The link wizard offers all
+    possibilities including external links and link handler configurations.
 
-In the page properties, the canonical link can be overwritten per language. The link wizard offers all
-possibilities including external links and link handler configurations.
-
-Should an empty href occur when generating the link to overwrite the canonical (this happens e.g. if the
-selected page is not available in the current language), the fallback to the current hreflang will be activated
-automatically. This ensures that there is no empty canonical.
+    Should an empty href occur when generating the link to overwrite the canonical (this happens e.g. if the
+    selected page is not available in the current language), the fallback to the current hreflang will be activated
+    automatically. This ensures that there is no empty canonical.
 
 
 .. warning::
@@ -49,16 +46,19 @@ automatically. This ensures that there is no empty canonical.
     If both core and an extension are generating a canonical link, it will
     result in 2 canonical links which might cause confusion for search engines.
 
-XML Sitemap 
-===========
-
-see :ref:`xmlsitemap` 
+XML Sitemap
+    see :ref:`xmlsitemap`
 
 
 SEO for Developers
-==================
+    TYPO3 provides various APIs for developers to implement further SEO features:
 
-TYPO3 provides various APIs for developers to implement further SEO features:
+    - The MetaTagApi (see :ref:`metatagapi`) to add dynamic meta tags
+    - The PageTitleAPI (see :ref:`pagetitle`) to manipulate the page title
 
-- The MetaTagApi (see :ref:`metatagapi`) to add dynamic meta tags 
-- The PageTitleAPI (see :ref:`pagetitle`) to manipulate the page title
+.. toctree::
+   :maxdepth: 1
+
+   ../MetaTagApi/Index
+   ../PageTitleApi/Index
+   ../XmlSitemap/Index

--- a/Documentation/ApiOverview/SystemRegistry/Index.rst
+++ b/Documentation/ApiOverview/SystemRegistry/Index.rst
@@ -7,9 +7,9 @@
 
 .. _registry:
 
-=========================
-Using the System Registry
-=========================
+===============
+System Registry
+===============
 
 The purpose of the registry (introduced in TYPO3 4.3) is to hold key-
 value pairs of information. You can actually think of it being an

--- a/Documentation/ApiOverview/Tsconfig/Index.rst
+++ b/Documentation/ApiOverview/Tsconfig/Index.rst
@@ -3,9 +3,9 @@
 
 .. _tsconfig:
 
-======================
-User and Page TSconfig
-======================
+========
+TSconfig
+========
 
 "User TSconfig" and "Page TSconfig" are very flexible concepts for
 adding fine-grained configuration to the backend of TYPO3 CMS. It is a text-

--- a/Documentation/ApiOverview/Typo3CoreEngine/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Index.rst
@@ -7,7 +7,7 @@
 .. _tce:
 
 =====================================
-TYPO3 Core Engine (TCE) & DataHandler
+TCE (TYPO3 Core Engine) & DataHandler
 =====================================
 
 

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -3,7 +3,7 @@
 .. _xclasses:
 
 ============================
-Extending Classes (XCLASSes)
+XCLASSes (Extending Classes)
 ============================
 
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,10 +1,24 @@
 .. include:: Includes.txt
 
 .. _start:
+.. _api-overview:
 
 ===============
 TYPO3 Explained
 ===============
+
+.. rst-class:: horizbuttons-tip-m
+
+- :ref:`Configuration <configuration>`
+- :ref:`Doctrine-dbal <database>`
+- :ref:`DependencyInjection`
+- :ref:`FAL <fal>`
+- :ref:`Internationalization <internationalization>`
+- :ref:`PSR-15 middlewares <request-handling>`
+- :ref:`Routing <request-handling>`
+- :ref:`Security <security>`
+- :ref:`Sites <sitehandling>`
+
 
 :Version:
       |release|
@@ -19,7 +33,7 @@ TYPO3 Explained
       forEditors, forBeginners, forDevelopers, forAdmins, forAdvanced, security
 
 :Copyright:
-      2000-2018
+      Since 2000
 
 :Authors:
       Core Team, Documentation Team & community (see :ref:`credits`)
@@ -34,13 +48,14 @@ TYPO3 Explained
 :Shortcut:
       `t3coreapi` is the usual alias for :ref:`h2document:cheat-sheet-intersphinx`.
 
-:Rendered:
-      |today|
+.. rst-class:: horizbuttons-tip-xxl
+
+- :ref:`Sitemap`
+
 
 The content of this document is related to TYPO3 CMS,
 a GNU/GPL CMS/Framework available from `www.typo3.org
 <https://typo3.org/>`_
-
 
 **Official Documentation**
 
@@ -64,18 +79,127 @@ Core Manuals are written as reference manuals. The reader should rely
 on the Table of Contents to identify what particular section will best
 address the task at hand.
 
+**Table of Contents**
+
+..   Note for editors:
+..     temporarily removed from menu:
+..   Introduction/Index
+
 
 .. toctree::
    :hidden:
 
-   Introduction/Index
+   Quicklinks
+
+
+.. toctree::
+   :maxdepth: 2
+
    ExtensionArchitecture/Index
-   ApiOverview/Index
-   ApiOverview/Examples/Index
-   Security/Index
-   Testing/Index
+
+
+.. toctree::
+   :caption: TYPO3 A-Z
+   :maxdepth: 2
+
+   ApiOverview/Authentication/Index
+   ApiOverview/Autoloading/Index
+   ApiOverview/AccessControl/Index
+   ApiOverview/BackendModules/Index
+   ApiOverview/BackendRouting/Index
+   ApiOverview/BackendUserObject/Index
+   ApiOverview/Bootstrapping/Index
+   ApiOverview/BroadcastChannels/Index
+   ApiOverview/CachingFramework/Index
    CodingGuidelines/Index
+
+.. toctree::
+   :maxdepth: 3
+
+   ApiOverview/Configuration/Index
+
+.. toctree::
+   :maxdepth: 2
+
+   ApiOverview/ContentElements/Index
+   ApiOverview/Context/Index
+   ApiOverview/ContextSensitiveHelp/Index
+   ApiOverview/FileProcessing/Index
+   ApiOverview/Database/Index
    DataFormats/Index
+   ApiOverview/DependencyInjection/Index
+   ApiOverview/Deprecation/Index
+   ApiOverview/Fal/Index
+   ApiOverview/DirectoryStructure/Index
+   ApiOverview/Enumerations/Index
+   ApiOverview/Environment/Index
+   ApiOverview/ErrorAndExceptionHandling/Index
+   ApiOverview/Hooks/Index
+   ApiOverview/ExtensionScanner/Index
+   ApiOverview/FlashMessages/Index
+   ApiOverview/FormEngine/Index
+   ApiOverview/FormProtection/Index
+   ApiOverview/Http/Index
+   ApiOverview/Icon/Index
+   ApiOverview/Internationalization/Index
+   ApiOverview/JavaScript/Index
+   ApiOverview/LinkBrowser/Index
+   ApiOverview/LockingApi/Index
+   ApiOverview/Logging/Index
+   ApiOverview/Mail/Index
+   ApiOverview/Namespaces/Index
+   ApiOverview/PageTypes/Index
+   ApiOverview/Pagination/Index
+   ApiOverview/PasswordHashing/Index
+   ApiOverview/RequestHandling/Index
+   ApiOverview/Rte/Index
+   ApiOverview/Routing/Index
+   Security/Index
+   ApiOverview/Seo/Index
+   ApiOverview/Services/Index
+   ApiOverview/SessionStorageFramework/Index
+   ApiOverview/SiteHandling/Index
+   ApiOverview/SoftReferences/Index
+   ApiOverview/CommandControllers/Index
+   ApiOverview/SymfonyExpressionLanguage/Index
+   ApiOverview/Categories/Index
+   ApiOverview/Collections/Index
+   ApiOverview/SystemLog/Index
+   ApiOverview/SystemRegistry/Index
+   ApiOverview/Typo3CoreEngine/Index
+   Testing/Index
+   ApiOverview/UpdateWizards/Index
+   ApiOverview/Workspaces/Index
+   ApiOverview/Xclasses/Index
+
+.. toctree::
+   :maxdepth: 1
+   :caption: meta
+
+
    Sitemap
+   About
    Targets
 
+
+.. todo:: ApiOverview/Examples/
+
+
+.. the following have been moved in the menu:
+
+.. to ApiOverview/ContentElements/Index
+..    - ApiOverview/FlexForms/Index
+..    - ApiOverview/BackendLayout/Index
+
+.. to ApiOverview/Configuration/Index
+..    - ApiOverview/Yaml/Index
+..    - ApiOverview/TypoScriptSyntax/Index
+..    - ApiOverview/Tsconfig/Index
+..    - ApiOverview/GlobalValues/Index
+..    - ApiOverview/FeatureToggles/Index
+..    - ApiOverview/UserSettingsConfiguration/Index
+
+.. to ApiOverview/Seo/Index
+..    - ApiOverview/MetaTagApi/Index
+..    - ApiOverview/XmlSitemap/Index
+..    - ApiOverview/PageTitleApi/Index

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,3 +1,12 @@
+:orphan:
+
+.. -------------------------------------------------
+.. Note for editors:
+..   This page is currently not included in the menu
+..   We may add it again, once it is reworked and
+..   extended to explain the basic concepts of TYPO3
+.. -------------------------------------------------
+
 .. include:: ../Includes.txt
 
 .. _introduction:
@@ -5,181 +14,6 @@
 ============
 Introduction
 ============
-
-
-.. _about:
-
-About this document
-===================
-
-TYPO3 is known for its extensibility. To really benefit from
-this power, a complete documentation is needed: "TYPO3 Explained" aims to
-provide such information to everyone. Not all areas are covered with the
-same amount of detail, but at least some pointers are provided.
-
-The document does *not* contain any significant information about
-the frontend of TYPO3. Creating templates, setting up TypoScript
-objects etc. is not the scope of the document, it addresses the
-*backend* and management part of the core only.
-
-The TYPO3 Documentation Team hopes that this document will form a complete picture
-of the TYPO3 Core architecture. It will hopefully be the knowledge base
-of choice in your work with TYPO3.
-
-
-.. _audience:
-
-Intended Audience
-=================
-
-This document is intended to be a reference for TYPO3 CMS developers and partially
-for integrators. The document explains all major parts of TYPO3 and the concepts.
-Some chapters presumes knowledge in the technical end: PHP, MySQL, Unix etc, depending
-on the specific chapter.
-
-The goal is to take you "under the hood" of TYPO3 CMS. To make the
-principles and opportunities clear and less mysterious. To educate you
-to help continue the development of TYPO3 along the already
-established lines so we will have a consistent CMS application in a
-future as well. And hopefully this teaching on the deep technical level
-will enable you to educate others higher up in the "hierarchy". Please
-consider that as well!
-
-
-.. _code-examples:
-
-Code examples
-=============
-
-Many of the code examples found in this document come from the TYPO3
-Core itself.
-
-Quite a few others come from the "`styleguide <https://github.com/TYPO3/styleguide>`__"
-extension. You can install it, if you want to try out these examples yourself and
-use them as a basis for your own extensions.
-
-.. _contribute:
-.. _feedback:
-
-Feedback and Contribute
-=======================
-
-If you find an error in this manual, please be so kind to hit
-the "Edit me on GitHub" button in the top right corner
-and submit a pull request via GitHub.
-
-Alternatively you can just `report an issue
-on GitHub <https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/new>`__.
-
-You can find more about this in Writing Documentation:
-
-- :ref:`h2document:docs-contribute` : Make a change by editing directly on
-  GitHub and creating a pull request
-- :ref:`h2document:docs-contribute-git-docker` : If you are experienced
-  with Docker and Git you can edit and render locally. 
-
-If you are currently not reading the online version, go to
-https://docs.typo3.org/typo3cms/CoreApiReference/.
-
-Maintaining high quality documentation requires time and effort
-and the TYPO3 Documentation Team always appreciates support.
-
-If you want to support us, please join the slack channel **#typo3-documentation**
-on `Slack <https://typo3.slack.com/>`__ (`Register for Slack <https://my.typo3.org/about-mytypo3org/slack/>`__).
-
-And finally, as a last resort, you can get in touch with the documentation team
-`by mail <documentation@typo3.org>`_.
-
-
-.. _credits:
-
-Credits
-=======
-
-This manual was originally written by Kasper Skårhøj. It was further
-maintained, refreshed and expanded by François Suter.
-
-The first version of the security chapter has been written by Ekkehard Guembel and Michael Hirdes
-and we would like to thank them for this. Further thanks to the TYPO3 Security Team for
-their work for the TYPO3 project. A special thank goes to Stefan Esser for his books and
-articles on PHP security, Jochen Weiland for an initial foundation and Michael Schams
-for compiling the content of the security chapter and coordinating the collaboration between
-several teams. He managed the whole process of getting the Security Guide to a high quality.
-
-
-.. _dedication:
-
-Dedication
-==========
-
-I want to dedicate this document to the people in the TYPO3 community
-who have the  *discipline* to do the boring job of writing
-documentation for their extensions or contribute to the TYPO3
-documentation in general. It's great to have good coders, but it's
-even more important to have coders with character to carry their work
-through till the end - even when it means spending days writing good
-documents. Go for completeness!
-
-\- kasper
-
-
-.. _next-steps:
-
-Further Documentation
-=====================
-
-This manual covers many different APIs of the TYPO3 CMS Core, but some
-other documents exist which cover more specific aspects.
-
-
-:ref:`TCA Reference <t3tca:start>`
-----------------------------------
-
-`TCA` is the backbone of database tables displayed in the backend, it configures
-how data is stored if editing records in the backend, how fields are displayed,
-relations to other tables and much more. It is a huge array loaded in almost all
-access contexts.
-
-A detailed insight on `TCA` is documented in the :ref:`TCA Reference <t3tca:start>`.
-Next to a small introduction, the document forms a complete reference of all
-different `TCA` options, with bells and whistles. The document is a must-read for
-Developers, partially for Integrators, and is often used as a reference book on a daily basis.
-
-
-:ref:`TypoScript Reference <t3tsref:start>`
--------------------------------------------
-
-`TypoScript` - or more precisely `Frontend TypoScript` - is used in TYPO3 to steer
-the frontend rendering (the actual website) of a TYPO3 instance. It is based on the
-TypoScript syntax which is outlined in detail :ref:`here in this document <typoscript-syntax-start>`.
-
-Frontend TypoScript is very powerful and has been the backbone of frontend rendering ever since.
-However, with the rise of the Fluid templating engine, many parts of Frontend TypoScript are much less
-often used. Nowadays, TypoScript in real life projects is often not much more than a way to
-set a series of options for plugins, to set some global config options, and to act as a simple
-pre processor between database data and Fluid templates.
-
-Still, the :ref:`TypoScript Reference <t3tsref:start>` reference document that goes deep into
-the incredible power of Frontend TypoScript is daily bread for Integrators.
-
-
-:ref:`TSconfig Reference <t3tsconfig:start>`
---------------------------------------------
-
-While `Frontend TypoScript` is used to steer the rendering of the frontend, `TSconfig` is used
-to configure backend details for backend users. Using `TSconfig` it is possible to enable or
-disable certain views, change the editing interfaces, and much more. All that without coding a single
-line of PHP. `TSconfig` can be set on a page (Page TSconfig), as well as a user / group (User TSconfig)
-basis.
-
-`TSconfig` uses the same syntax as `Frontend TypoScript`, the syntax is outlined in detail
-:ref:`here in this document <typoscript-syntax-start>`. Other than that, TSconfig and Frontend TypoScript
-don't have much more in common - they consist of entirely different properties.
-
-A full reference of properties as well as an introduction to explain details configuration usage, API and
-load orders can be found in the :ref:`TSconfig Reference document <t3tsconfig:start>`. While Developers
-should have an eye on this document, it is mostly used as a reference for Integrators who make life as
-easy as possible for backend users.
 
 
 .. _overview:

--- a/Documentation/Quicklinks.rst
+++ b/Documentation/Quicklinks.rst
@@ -1,0 +1,32 @@
+.. include:: Includes.txt
+
+.. _quick-links:
+
+
+===========
+Quick Links
+===========
+
+.. toctree::
+   :hidden:
+
+   Configuration Overview                   <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Configuration/Index.html>
+   Database (doctrine-dbal)                 <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Database/Index.html>
+   Dependency Injection                     <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/DependencyInjection/Index.html>
+   Digital Assets Management                <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Fal/Index.html>
+   Internationalization and Localization    <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Internationalization/Index.html>
+   Request Handling (Middlewares)           <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/RequestHandling/Index.html>
+   Routing - "Speaking URLs"                <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Routing/Index.html>
+   Security Guidelines                      <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/Security/Index.html>
+   Site Handling                            <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SiteHandling/Index.html>
+
+
+- :ref:`Configuration <configuration>`
+- :ref:`Doctrine-dbal <database>`
+- :ref:`DependencyInjection`
+- :ref:`FAL <fal>`
+- :ref:`Internationalization <internationalization>`
+- :ref:`PSR-15 middlewares <request-handling>`
+- :ref:`Routing <request-handling>`
+- :ref:`Security <security>`
+- :ref:`Sites <sitehandling>`

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -39,6 +39,7 @@ t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
 t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/
 t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/master/en-us/
 
+
 # TYPO3 system extensions
 ckedit        = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/
 fsc           = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/master/en-us/


### PR DESCRIPTION
- Move content in "Introduction" to "About this manual" to end
  of menu
- make API overview alphabetic
- Add some quick links to the top


Next steps:

- [ ] separate "Extension Development" into "Extension Architecture", "Extension Files" and "Extension Development" into main menu
- [ ] migrate content from ApiOverview/Examples
- (reconsider chapter "Data Formats") : handled in #728

Related: #632
Related: #633


Depends on:
    
Related: https://github.com/TYPO3-Documentation/t3SphinxThemeRtd/pull/131
