### PR TITLE
Corrected replacement of PATH_site in the Notes

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
@@ -121,7 +121,7 @@ Table 1: Traditional List
    :Description:
          .. note::
 
-            this constant has been marked as deprecated and will be removed with TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath()` to retrieve the information.
+            this constant has been marked as deprecated and will be removed with TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/'` to retrieve the information.
 
 
          Absolute path to directory with the frontend (one directory above


### PR DESCRIPTION
see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85285-DeprecatedSystemConstants.html

The following constants have been marked as deprecated and should not be used any longer:
...
`PATH_site Use Environment::getPublicPath() . '/' instead`
...