### PR TITLE
Clean up constants page

### DIFF
--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -80,3 +80,10 @@ so it is outside of the web document root - not within :php:`getPublicPath()`.
 
 Without Composer, the value is :php:`getPublicPath() . '/typo3conf/l10n'`, so within
 the web document root - a situation that is not optimal from a security point of view.
+
+.. _Environment-current-script:
+
+getCurrentScript()
+==================
+
+The path + filename to the current PHP script.

--- a/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
@@ -6,358 +6,129 @@
 Constants
 =========
 
-Constants normally define paths and database information. These values
-are global and cannot be changed when they are first defined. This is
-why constants are used for such vital information.
+Constants in TYPO3 define paths and database information. These values
+are global and cannot be changed.
+Constants are defined at various points during the bootstrap sequence.
 
-These constants are defined at various points during the bootstrap sequence.
+.. hint::
 
-The column "Avail. in FE" is an indicator that tells you if the
-constant, variable or class mentioned is also available to scripts
-running under the frontend of the "cms" extension.
-
-.. note::
-
-   To make the information below a bit more compact, namespaces were left out. Here
-   are the fully qualified class names referred to below:
-
-   - "SystemEnvironmentBuilder" = :php:`\TYPO3\CMS\Core\Core\SystemEnvironmentBuilder`
-   - "Bootstrap" = :php:`\TYPO3\CMS\Core\Core\Bootstrap`
+   Some constants (and global variables) are being replaced by more
+   flexible mechanisms. A number of constants have been deprecated
+   in TYPO3 9 and removed in TYPO3 10. Please see :ref:`Environment`.
+   For a list of removed constants, see :ref:`removed-constants` on
+   this page.
 
 
-Traditional List
-================
+To make the information below a bit more compact, namespaces were left out. Here
+are the fully qualified class names referred to below:
 
-TYPO3\_MODE
------------
-
-Defined in:
-   * :php:`\TYPO3\CMS\Backend\Http\Application::defineLegacyConstants()`
-   * :php:`\TYPO3\CMS\Core\Console\CommandApplication::defineLegacyConstants()`
-   * :php:`\TYPO3\CMS\Frontend\Http\Application::defineLegacyConstants()`
-   * :php:`\TYPO3\CMS\Install\Http\Application::defineLegacyConstants()`
-
-Description:
-   Mode of TYPO3: Set to either "FE" or "BE" depending on frontend or
-   backend execution and context.
-
-Available in Frontend:
-   Yes
-   value = "FE"
+- "SystemEnvironmentBuilder" = :php:`\TYPO3\CMS\Core\Core\SystemEnvironmentBuilder`
+- "Bootstrap" = :php:`\TYPO3\CMS\Core\Core\Bootstrap`
 
 
-TYPO3\_OS
----------
+Check :php:`SystemEnvironmentBuilder::defineBaseConstants()`
+for more constants.
+
+Version, Branch and Copyright
+=============================
+
+TYPO3_branch
+------------
+
+The TYPO3 version Branch, as a "x.y" number. Without the patch level.
 
 Defined in:
-   SystemEnvironmentBuilder::defineBaseConstants()
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
 
-Description:
-   .. note::
-
-       This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath()` to retrieve the information.
-       Use :php:`Environment::isWindows()` and :php:`Environment::isUnix()` instead.
-
-
-    Operating system; Windows = "WIN", other = "" (presumed to be some
-    sort of Unix)
+Example:
+   "10.2"
 
 Available in Frontend:
    Yes
 
-PATH\_thisScript
-----------------
-
-Defined in:
-   SystemEnvironmentBuilder::definePaths()
-
-Description:
-   .. note::
-
-      This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getCurrentScript()` to retrieve the information.
-
-
-      Abs. path to current script.
-
-Available in Frontend:
-   Yes
-
-
-TYPO3\_mainDir
---------------
-
-Defined in:
-   SystemEnvironmentBuilder::definePaths()
-
-Description:
-   This is the directory of the backend administration for the sites of
-   this TYPO3 installation. Hardcoded to :code:`typo3/`. Must be a subdirectory
-   to the website. See elsewhere for descriptions on how to change the
-   default admin directory, :code:`typo3/`, to something else.
-
-Available in Frontend:
-   Yes
-
-
-PATH\_typo3
------------
-
-Defined in:
-   SystemEnvironmentBuilder::definePaths()
-
-Description:
-   .. note::
-
-      This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3'` to retrieve the information.
-
-
-   Abs. path of the TYPO3 admin dir.
-
-Available in Frontend:
-   No
-
-
-PATH\_site
-----------
-
-Defined in:
-   SystemEnvironmentBuilder::definePaths()
-
-Description:
-   .. note::
-
-      This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/'` to retrieve the information.
-
-
-   Absolute path to directory with the frontend (one directory above
-   :code:`\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3/`)
-
-Available in Frontend:
-   Yes
-
-
-PATH\_typo3conf
----------------
-
-Defined in:
-   SystemEnvironmentBuilder::definePaths()
-
-Description:
-
-   .. note::
-
-      This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf'` to retrieve the information.
-
-
-   Absolute TYPO3 configuration path (local, not part of source).
-
-Available in Frontend:
-   Yes
-
-
-TYPO3\_version
---------------
-
-Defined:
-   SystemEnvironmentBuilder::defineBaseConstants()
-
-Description:
-   The TYPO3 version, as a "x.y.z" number. Development versions will be either
-   "x.y.z-dev" for stable versions or "x.y-dev" for the current master.
-
-Available in Frontend:
-   Yes
-
-
-TYPO3\_branch
--------------
-
-Defined in:
-   SystemEnvironmentBuilder::defineBaseConstants()
-
-Description:
-   The TYPO3 version Branch, as a "x.y" number. Without the patch level.
-
-Available in Frontend:
-   Yes
-
-
-Base Constants
-==============
-
-Check :php:`\TYPO3\CMS\Core\Core\SystemEnvironmentBuilder::defineBaseConstants()`
-for updates.
-
-
-This Version, Branch and Copyright
-----------------------------------
-
-===================================== =======================================================
-Constant                              Example value
-===================================== =======================================================
-TYPO3_version                         '7.6.1-dev'
-TYPO3_branch                          '7.6'
-TYPO3_copyright_year                  '1998-2015'
-===================================== =======================================================
-
-
-TYPO3 External Links
+TYPO3_copyright_year
 --------------------
 
-===================================== =======================================================
-Constant                              Example value
-===================================== =======================================================
-TYPO3_URL_GENERAL                     'https://typo3.org/'
-TYPO3_URL_LICENSE                     'https://typo3.org/typo3-cms/overview/licenses/'
-TYPO3_URL_EXCEPTION                   'https://typo3.org/go/exception/CMS/'
-TYPO3_URL_MAILINGLISTS                'http://lists.typo3.org/cgi-bin/mailman/listinfo'
+The TYPO3 version Branch, as a "x.y" number. Without the patch level.
 
-                                      .. note::
+Defined in:
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
 
-                                          This constant was removed in TYPO3 v10.
+Example:
+   "1998-2019"
 
-TYPO3_URL_DOCUMENTATION               'https://typo3.org/documentation/'
-
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
+Available in Frontend:
+   Yes
 
 
-TYPO3_URL_DOCUMENTATION_TSREF         'https://docs.typo3.org/typo3cms/TyposcriptReference/'
+TYPO3_version
+-------------
 
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
-
-
-TYPO3_URL_DOCUMENTATION_TSCONFIG      'https://docs.typo3.org/typo3cms/TSconfigReference/'
-
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
+The TYPO3 version, as a "x.y.z" number. Development versions will be either
+"x.y.z-dev" for stable versions or "x.y-dev" for the current master.
 
 
-TYPO3_URL_CONSULTANCY                 'https://typo3.org/support/professional-services/'
+Defined in:
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
 
-                                      .. note::
+Example:
+   "10.2.0"
 
-                                          This constant was removed in TYPO3 v10.
+Available in Frontend:
+   Yes
 
+Paths
+=====
 
-TYPO3_URL_CONTRIBUTE                  'https://typo3.org/contribute/'
+TYPO3_mainDir
+-------------
 
-                                      .. note::
+This is the directory of the backend administration for the sites of
+this TYPO3 installation. Hardcoded to :code:`typo3/`. Must be a subdirectory
+to the website.
 
-                                          This constant was removed in TYPO3 v10.
+Defined in:
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
 
-
-TYPO3_URL_SECURITY                    'https://typo3.org/teams/security/'
-
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
-
-
-TYPO3_URL_DOWNLOAD                    'https://typo3.org/download/'
-
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
-
-
-TYPO3_URL_SYSTEMREQUIREMENTS          'https://typo3.org/typo3-cms/overview/requirements/'
-
-                                      .. note::
-
-                                          This constant was removed in TYPO3 v10.
-
-
-TYPO3_URL_DONATE                      'https://typo3.org/donate/online-donation/'
-TYPO3_URL_WIKI_OPCODECACHE            'https://wiki.typo3.org/Opcode_Cache'
-===================================== =======================================================
-
-
-String Constants
-----------------
-
-===================================== ======================================================= ============
-Constant                              Value                                                   Description
-===================================== ======================================================= ============
-NUL                                   chr(0)                                                  A null
-
-                                                                                              .. note::
-
-                                                                                                This constant was removed in TYPO3 v10.
-                                                                                                Use :php:`"\0"` instead.
-
-TAB                                   chr(9)                                                  A tabulator
-
-
-                                                                                              .. note::
-
-                                                                                                This constant was removed in TYPO3 v10.
-                                                                                                Use :php:`"\t"` instead.
-
-LF                                    chr(10)                                                 A linefeed
-CR                                    chr(13)                                                 A carriage return
-SUB                                   chr(26)                                                 A sub (substitute) character
-
-
-                                                                                              .. note::
-
-                                                                                                This constant was removed in TYPO3 v10.
-                                                                                                Use :php:`chr(26)` instead.
-
-CRLF                                  CR + LF                                                 Carriage return + linefeed pair
-===================================== ======================================================= ============
+Available in Frontend:
+   Yes
 
 
 Security Related Constant
+=========================
+
+FILE_DENY_PATTERN_DEFAULT
 -------------------------
 
-===================================== ======================================================= ============
-Constant                              Value                                                   Description
-===================================== ======================================================= ============
-FILE_DENY_PATTERN_DEFAULT             '\\.(php[3-7]?|phpsh|phtml)(\\..*)?$|^\\.htaccess$'     Default value of fileDenyPattern
-PHP_EXTENSIONS_DEFAULT                'php,php3,php4,php5,php6,php7,phpsh,inc,phtml'          List of file extensions that should be registered as php script file extensions
-===================================== ======================================================= ============
+Default value of fileDenyPattern.
+
+Defined in:
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
+
+Example:
+   :php:`'\\.(php[3-7]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$'`
+
+Available in Frontend:
+   Yes
+
+PHP_EXTENSIONS_DEFAULT
+----------------------
+
+List of file extensions that should be registered as php script file extensions.
+
+Defined in:
+   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
+
+Example:
+   :php:`'php,php3,php4,php5,php6,php7,phpsh,inc,phtml,pht,phar'`
+
+Available in Frontend:
+   Yes
 
 
-Operating System Identifier
----------------------------
-
-===================================== ======================================================= ============
-Constant                              Value                                                   Description
-===================================== ======================================================= ============
-TYPO3_OS                              self::getTypo3Os())                                     Either "WIN" or empty string
-
-                                                                                              .. note::
-
-                                                                                                This constant was removed in TYPO3 v10. Use :php:`\TYPO3\CMS\Core\Core\Environment::getPublicPath()` to retrieve the information.
-                                                                                                Use :php:`Environment::isWindows()` and :php:`Environment::isUnix()` instead.
-
-===================================== ======================================================= ============
-
-
-Service Error Constants
------------------------
-
-===================================== ======================================================= ============
-Constant                              Value                                                   Description
-===================================== ======================================================= ============
-T3_ERR_SV_GENERAL                     -1                                                      General error - something went wrong
-T3_ERR_SV_NOT_AVAIL                   -2                                                      During execution it showed that the service is not available and should be ignored. The service itself should call $this->setNonAvailable()
-T3_ERR_SV_WRONG_SUBTYPE               -3                                                      Passed subtype is not possible with this service
-T3_ERR_SV_NO_INPUT                    -4                                                      Passed subtype is not possible with this service
-T3_ERR_SV_FILE_NOT_FOUND              -20                                                     File not found which the service should process
-T3_ERR_SV_FILE_READ                   -21                                                     File not readable
-T3_ERR_SV_FILE_WRITE                  -22                                                     File not writable
-T3_ERR_SV_PROG_NOT_FOUND              -40                                                     Passed subtype is not possible with this service
-T3_ERR_SV_PROG_FAILED                 -41                                                     Passed subtype is not possible with this service
-===================================== ======================================================= ============
 
 Filetypes
----------
+=========
 
 Different types of files constants are defined in :php:`TYPO3\CMS\Core\Resource\AbstractFile`.
 These constants are available for different groups of files as documented in
@@ -378,7 +149,116 @@ FILETYPE_APPLICATION     5 Any kind of application
 ==================== ===== =======================
 
 HTTP Status Codes
------------------
+=================
 
 The different status codes available are defined in :php:`TYPO3\CMS\Core\Utility\HttpUtility`.
 These constants are defined as documented in https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+
+
+
+
+Legacy Constants
+================
+
+
+TYPO3_MODE
+----------
+
+Mode of TYPO3: Set to either "FE" or "BE" depending on frontend or
+backend execution and context.
+
+.. important::
+
+   About using TYPO3\_MODE in :file:`ext_localconf.php` and :file:`ext_tables.php`:
+
+   It is recommended to AVOID checks for values on TYPO3_MODE or TYPO3_REQUESTTYPE constants
+   (e.g. :php:`if (TYPO3_MODE === 'BE')` within these files (:file:`ext_localconf.php` and :file:`ext_tables.php`)
+   as it limits the functionality to cache the whole systems configuration.
+   Any extension author should remove the checks if not explicitly
+   necessary, and re-evaluate if these context-depending checks could go inside the hooks / caller
+   function directly.
+
+   For more best practices of using these files, see :ref:`extension-configuration-files`.
+
+Defined in:
+   * :php:`\TYPO3\CMS\Backend\Http\Application::defineLegacyConstants()`
+   * :php:`\TYPO3\CMS\Core\Console\CommandApplication::defineLegacyConstants()`
+   * :php:`\TYPO3\CMS\Frontend\Http\Application::defineLegacyConstants()`
+   * :php:`\TYPO3\CMS\Install\Http\Application::defineLegacyConstants()`
+
+Example:
+   "FE" or "BE"
+
+Available in Frontend:
+   Yes, value = "FE"
+
+
+
+.. _removed-constants:
+
+Removed Constants
+=================
+
+.. todo:: Remove this list in a next release and remove link on top of this page.
+
+These constants were removed in TYPO3 10. You will find replacements in :ref:`Environment`.
+
+String constants
+----------------
+
+* :php:`TAB` (Use :php:`"\t"` instead)
+* :php:`NUL` (Use :php:`"\0"` instead)
+* :php:`SUB` (Use :php:`chr(26)` instead)
+
+Paths constants
+---------------
+
+* :php:`PATH_site`: Use :php:`Environment::getPublicPath()` to
+  return the absolute path to the publically accessible folder (previously known
+  as :php:`PATH_site`) without the trailing slash.
+* :php:`PATH_thisScript`: Use :php:`Environment::getCurrentScript()` instead.
+* :php:`PATH_typo3`: Use :php:`Environment::getPublicPath() . '/typo3/'` instead.
+* :php:`PATH_typo3conf`: Use :php:`Environment::getPublicPath() . '/typo3conf'` instead
+
+.. seealso::
+
+   * :ref:`Environment::getPublicPath() <Environment-public-path>`
+   * :ref:`Environment::getCurrentScript() <Environment-current-script>`
+
+
+URL constants
+-------------
+
+* :php:`TYPO3_URL_MAILINGLISTS`
+* :php:`TYPO3_URL_DOCUMENTATION`
+* :php:`TYPO3_URL_DOCUMENTATION_TSREF`
+* :php:`TYPO3_URL_DOCUMENTATION_TSCONFIG`
+* :php:`TYPO3_URL_DOCUMENTATION_TSCONFIG`
+* :php:`TYPO3_URL_DOCUMENTATION_TSCONFIG`
+* :php:`TYPO3_URL_CONSULTANCY`
+* :php:`TYPO3_URL_CONTRIBUTE`
+* :php:`TYPO3_URL_SECURITY`
+* :php:`TYPO3_URL_DOWNLOAD`
+* :php:`TYPO3_URL_SYSTEMREQUIREMENTS`
+
+Service constants
+-----------------
+
+The according constants have been moved to class constants of :php:`TYPO3\CMS\Core\Service\AbstractService`.
+
+- :php:`T3_ERR_SV_GENERAL`
+- :php:`T3_ERR_SV_NOT_AVAIL`
+- :php:`T3_ERR_SV_WRONG_SUBTYPE`
+- :php:`T3_ERR_SV_NO_INPUT`
+- :php:`T3_ERR_SV_FILE_NOT_FOUND`
+- :php:`T3_ERR_SV_FILE_READ`
+- :php:`T3_ERR_SV_FILE_WRITE`
+- :php:`T3_ERR_SV_PROG_NOT_FOUND`
+- :php:`T3_ERR_SV_PROG_FAILED`
+
+
+Other constants
+---------------
+
+* :php:`TYPO3_OS` (Use :php:`Environment::isWindows()` and :php:`Environment::isUnix()` instead)
+* :php:`TYPO3_REQUESTTYPE_CLI`


### PR DESCRIPTION
- move all removed constants to separate section on bottom of page
  (declutters page)
- remove duplicates (some constants were listed in more than one
  section)
- add information about Environment
- add warning about using TYPO3_MODE in ext_tables.php and
  ext_localconf.php and link to the chapter on those files