### PR TITLE
[BUGFIX] Fix error and exception handlers page

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Extending/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Extending/Index.rst
@@ -7,23 +7,37 @@
 How to extend the error and exception handling
 ==============================================
 
-If you want to register your own error or exception handler, simply
-include the class and insert its name into `productionExceptionHandler`,
-`debugExceptionHandler` or `errorHandler`::
+If you want to register your own error or exception handler:
 
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler'] = \Vendor\Ext\Error\MyOwnErrorHandler::class;
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler'] = \Vendor\Ext\Error\MyOwnDebugExceptionHandler::class;
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler'] = \Vendor\Ext\Error\MyOwnProductionExceptionHandler::class;
+#. Create a corresponding class in your extension
 
+#. Override the core defaults for `productionExceptionHandler`, `debugExceptionHandler`
+   or `errorHandler` in :file:`typo3conf/AdditionalConfiguration.php`::
+
+      $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler'] = \Vendor\Ext\Error\MyOwnErrorHandler::class;
+      $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler'] = \Vendor\Ext\Error\MyOwnDebugExceptionHandler::class;
+      $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler'] = \Vendor\Ext\Error\MyOwnProductionExceptionHandler::class;
+
+.. tip::
+
+   We use :file:`typo3conf/AdditionalConfiguration.php` and **not** :file:`ext_localconf.php`
+   in the extension (as previously documented) because that will be executed
+   **after** the error / exception handlers are initialized in the bootstrap process.
 
 An error or exception handler class must register an error (exception)
 handler in its constructor. Have a look at the files in :file:`EXT:core/Classes/Error/`
 to see how this should be done.
 
 If you want to use the built-in error and exception handling but
-extend it with your own functionality, simply derive your class from the
-error and exception handling classes shipped with TYPO3 and register
-this class as error (exception) handler::
+extend it with your own functionality, derive your class from the
+error and exception handling classes shipped with TYPO3.
+
+Example Debug Exception Handler
+===============================
+
+This uses the default core exception handler `DebugExceptionHandler` and overrides some
+of the functionality::
+
 
    namespace Vendor\Ext\Error;
 
@@ -40,7 +54,7 @@ this class as error (exception) handler::
        }
    }
    
-Then add the following lines to the `ext_localconf.php` of your extension::
+:file:`typo3conf/AdditionalConfiguration.php`::
 
    $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler'] = \Vendor\Ext\Error\PostExceptionsOnTwitter::class;
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler'] = \Vendor\Ext\Error\PostExceptionsOnTwitter::class;
+

--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -48,13 +48,14 @@ bootstrap class:
  or any simple array assignments to :php:`$GLOBALS['TYPO3_CONF_VARS']` options
  will not work for those.
 
-
 Should Not Be Used For
 ----------------------
 
 * While you *can* put functions and classes into the script, it is a really bad
   practice because such classes and functions would *always* be loaded. It is
   better to have them included only as needed.
+* Error and exception handlers should be registered in :file:`typo3conf/AdditionalConfiguration.php`.
+  See :ref:`error-handling-extending`.
 
 Should Be Used For
 ------------------


### PR DESCRIPTION
Error and exception handlers should be registered in AdditionalConfiguration.php,
not in ext_localconf.php of extension.

Resolves: #648
Releases:

* [ ] master
* [ ] 9.5 ?
* ... ?