### PR TITLE
Remove TYPO3_DB from code examples (backport for 9.5)

### DIFF
--- a/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/PhpSyntaxFormatting.rst
@@ -64,7 +64,6 @@ characters.
 Examples::
 
    $GLOBALS['TYPO3_CONF_VARS']
-   $GLOBALS['TYPO3_DB']
 
 
 Comments
@@ -213,19 +212,19 @@ Assignment in conditions should be avoided. However if it makes sense
 to do an assignment in a condition, it should be surrounded by the
 extra pair of brackets. Example::
 
-   if (($fields = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
+   if (($fields = $this->getFields())) {
        // Do something
    }
 
 The following is allowed, but not recommended::
 
-   if (false !== ($fields = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
+   if (false !== ($fields = $this->getFields())) {
        // Do something
    }
 
 The following is not allowed (missing the extra pair of brackets)::
 
-   while ($fields = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res)) {
+   while ($fields = $this->getFields()) {
        // Do something
    }
 
@@ -292,7 +291,7 @@ The following is not allowed::
 :php:`do` and :php:`while` loops must use extra brackets, if an
 assignment happens in the loop::
 
-   while (($fields = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
+   while (($fields = $this->getFields())) {
        // Do something
    }
 


### PR DESCRIPTION
$GLOBALS['TYPO3_DB'] has been removed from the core. Remove this from
the examples as well.

#705 should be merged first.

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/108
Related: #705
Related: #655
Releases: master, 9.5