### PR TITLE
Remove overlay argument from section on Fluid icon ViewHelper

### DIFF
--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -77,14 +77,14 @@ You can also use the Fluid ViewHelper to render an icon in your view:
 .. code-block:: html
 
    {namespace core = TYPO3\CMS\Core\ViewHelpers}
-   <core:icon identifier="my-icon-identifier" size="small" overlay="overlay-identifier" />
+   <core:icon identifier="my-icon-identifier" size="small" />
    
 This will render the desired icon using an `img`-tag. If you prefer having the SVG inlined into your HTML (e.g. for being able to change colors with CSS), you can set the optional `alternativeMarkupIdentifier` attribute to `inline`. By default, the icon will pick up the font-color of its surrounding element if you use this option.
 
 .. code-block:: html
 
    {namespace core = TYPO3\CMS\Core\ViewHelpers}
-   <core:icon identifier="my-icon-identifier" size="small" overlay="overlay-identifier" alternativeMarkupIdentifier="inline" />
+   <core:icon identifier="my-icon-identifier" size="small" alternativeMarkupIdentifier="inline" />
 
 
 The JavaScript way


### PR DESCRIPTION
The reason is: This is not a working example and it is not explained how overlay can be used.

----

I would either explain overlay and provide working example or remove it entirely.