### PR TITLE
Default value for lockIP / lockIPv6 changed (10.3)

### DIFF
--- a/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst.txt
+++ b/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst.txt
@@ -121,16 +121,23 @@ The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern
 lockIP / lockIPv6
 """""""""""""""""
 
-If a frontend or backend user logs into TYPO3, the user's session is
+If a frontend or backend user logs into TYPO3, the user's session can be
 locked to its IP address. The `lockIP` configuration for IPv4 and `lockIPv6` for IPv6 control how
 many parts of the IP address have to match with the IP address used at
 authentication time.
+
+.. ATTENTION::
+   IP locking breaks modern IPv6 setups because of the
+   `Fast Fallback aka. Happy Eyeballs <https://en.wikipedia.org/wiki/Happy_Eyeballs>`__
+   algorithm that can cause users to jump between IPv4 and IPv6
+   arbitrarily. Enabling an IP lock should be a very conscious decision. Therefore,
+   this is disabled by default.
 
 Possible values for **IPv4** are: `0`, `1`, `2`, `3` or `4` (integer)
 with the following meaning:
 
 `0`
-   Disable IP locking at all, not recommended.
+   Disable IP locking at all.
 
 `1`
    Only the first part of the IPv4 address needs to match, e.g. `123.xxx.xxx.xxx`.
@@ -144,13 +151,11 @@ with the following meaning:
 `4`
    The complete IPv4 address has to match (e.g. `123.45.67.89`).
 
-The default value for frontend is `2` and for backend is `4`.
-
 Possible values for **IPv6** are: `0`, `1`, `2`, `3`, `4`,  `5`,  `6`, `7`, `8` (integer)
 with the following meaning:
 
 `0`
-   Disable IP locking at all, not recommended.
+   Disable IP locking at all.
 
 `1`
    Only the first block (16 bits) of the IPv6 address needs to match, e.g. `2001:`
@@ -175,8 +180,6 @@ with the following meaning:
 
 `8`
    The full IPv6 address has to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e:0370:7344`
-
-The default value for frontend and backend is `2`.
 
 If your users experience that their sessions sometimes drop out, it
 might be because of a changing IP address (this may happen with

--- a/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst.txt
+++ b/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst.txt
@@ -137,7 +137,7 @@ Possible values for **IPv4** are: `0`, `1`, `2`, `3` or `4` (integer)
 with the following meaning:
 
 `0`
-   Disable IP locking at all.
+   Disable IP locking entirely.
 
 `1`
    Only the first part of the IPv4 address needs to match, e.g. `123.xxx.xxx.xxx`.
@@ -155,7 +155,7 @@ Possible values for **IPv6** are: `0`, `1`, `2`, `3`, `4`,  `5`,  `6`, `7`, `8` 
 with the following meaning:
 
 `0`
-   Disable IP locking at all.
+   Disable IP locking entirely.
 
 `1`
    Only the first block (16 bits) of the IPv6 address needs to match, e.g. `2001:`


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Important-89869-ChangeLockIpDefaultToDisabled.html