### PR TITLE
[DOCS] Remove outdated value displayErrors 2

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
@@ -167,14 +167,6 @@ Values in plain text can be changed in LocalConfiguration.php.
 |             |                    | ^ E_USER\_NOTICE  |                |           |                             |                 |
 |             |                    | ^ E_USER\_WARNING |                |           |                             |                 |
 +-------------+--------------------+-------------------+----------------+-----------+-----------------------------+-----------------+
-|     2       | E_ALL ^ E_NOTICE   | E_ALL ^ E_NOTICE  | \TYPO3\CMS     | Matters   | If devIPmask matches:       | **1 (On)**      |
-|             |                    | ^ E_WARNING       | \Core\Error    |           | debugExceptionHandler       |                 |
-|             |                    | ^ E_USER\_ERROR   | \ErrorHandler  |           |                             |                 |
-|             |                    | ^ E_USER\_NOTICE  |                |           +-----------------------------+-----------------+
-|             |                    | ^ E_USER\_WARNING |                |           | If devIPmask doesn't match: |                 |
-|             |                    |                   |                |           | productionExceptionHandler  | **0 (Off)**     |
-|             |                    |                   |                |           |                             |                 |
-+-------------+--------------------+-------------------+----------------+-----------+-----------------------------+-----------------+
 
 .. seealso::
 


### PR DESCRIPTION
According to @bmack (see [here](https://forge.typo3.org/issues/82782#note-6)) this feature was deprecated and therefore should not be used anymore. The documentation should reflect that.