### PR TITLE
Remove section in CGL about assignments in conditions

### DIFF
--- a/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/PhpSyntaxFormatting.rst
@@ -208,26 +208,6 @@ Wrong usage of the ternary conditional operator::
 
    $result = ($useComma ? ',' : $useDot ? '.' : ';');
 
-Assignment in conditions should be avoided. However if it makes sense
-to do an assignment in a condition, it should be surrounded by the
-extra pair of brackets. Example::
-
-   if (($fields = $this->getFields())) {
-       // Do something
-   }
-
-The following is allowed, but not recommended::
-
-   if (false !== ($fields = $this->getFields())) {
-       // Do something
-   }
-
-The following is not allowed (missing the extra pair of brackets)::
-
-   while ($fields = $this->getFields()) {
-       // Do something
-   }
-
 
 Switch
 ======


### PR DESCRIPTION
The recommendation to not use assignments in condition and add
extra parenthethese does not reflect current practice in core
and in newer examples in documentation.

In the docs, it said:

> Assignment in conditions should be avoided. However if it makes sense to do an assignment in a condition, it should be surrounded by the extra pair of brackets. Example:
> 
> if (($fields = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res))) {
>    // Do something
> }

see https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/CodingGuidelines/CglPhp/PhpFileFormatting/PhpSyntaxFormatting.html#conditions

**But**, Assignments in condition are used in abundance in the core and in newer examples, e.g. doctrine-dbal:

> while ($row = $statement->fetch()) {
>   // Do something useful with that single $row
> }

https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/Database/Statement/Index.html



Releases: master, 9.5