### PR TITLE
Add more information about accessing FlexForm values from TypoScript

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -298,8 +298,28 @@ method can be used:
 How to Access FlexForms From TypoScript
 ---------------------------------------
 
-It's possible to read values from FlexForms within TypoScript, this is explained
-within the TypoScript Reference:
+.. note::
+
+   Since TYPO3 8.4, it is possible to read FlexForm properties from TypoScript.
+
+
+.. code-block:: typoscript
+
+    lib.flexformContent = CONTENT
+    lib.flexformContent {
+        table = tt_content
+        select {
+            pidInList = this
+        }
+
+        renderObj = COA
+        renderObj {
+            10 = TEXT
+            10 {
+                data = flexform: pi_flexform:settings.categories
+            }
+        }
+    }
 
 .. seealso::
 


### PR DESCRIPTION
- The example in the tsref is a bit thin, add example from changelog
- Add information since when this is possible

Releases: master, 9.5, 8.7