### PR TITLE
Update section for upgrade wizards

### DIFF
--- a/Documentation/ApiOverview/UpdateWizards/Creation.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation.rst
@@ -4,6 +4,7 @@
 
 .. _update-wizards-creation-generic:
 .. _upgrade-wizards-creation:
+.. _upgrade-wizard-interface:
 
 ================================
 Creating Generic Upgrade Wizards
@@ -123,6 +124,9 @@ Method :php:`getPrerequisites`
        ];
    }
 
+.. _upgrade-wizards-mark-as-done:
+.. _repeatable-interface:
+
 Marking wizard as done
 ======================
 
@@ -130,10 +134,77 @@ As soon as the wizard has completely finished, e.g. it detected that no update i
 necessary anymore, or that all updates were completed successfully, the wizard
 is marked as done and won't be checked anymore.
 
-To force TYPO3 to check the wizard everytime, the interface
-:php:``\TYPO3\CMS\Install\Updates\RepeatableInterface`` has to be implemented.
+To force TYPO3 to check the wizard every time, the interface
+:php:`\TYPO3\CMS\Install\Updates\RepeatableInterface` has to be implemented.
 This interface works as a marker and does not force any methods to be
 implemented.
+
+.. _upgrade-wizards-generate-output:
+.. _uprade-wizards-chatty-interface:
+
+Generating Output
+=================
+
+The :php:`ChattyInterface` can be implemented for wizards which should generate output.
+:php:`ChattyInterface` uses the Symfony interface
+`OutputInterface <https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/OutputInterface.php>`__.
+
+Classes using this interface must implement the following method::
+
+    /**
+     * Setter injection for output into upgrade wizards
+     *
+     * @param OutputInterface $output
+     */
+    public function setOutput(OutputInterface $output): void;
+
+
+
+
+The class :php:`FormFileExtensionUpdate` in the extension "form" implements this interface.
+We show a simplified example here, based on this class::
+
+    use Symfony\Component\Console\Output\OutputInterface;
+    use TYPO3\CMS\Install\Updates\ChattyInterface;
+    use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+    class FormFileExtensionUpdate implements ChattyInterface, UpgradeWizardInterface
+    {
+         /**
+         * @var OutputInterface
+         */
+        protected $output;
+
+
+        public function setOutput(OutputInterface $output): void
+        {
+            $this->output = $output;
+        }
+
+        /**
+         * Checks whether updates are required.
+         *
+         * @return bool Whether an update is required (TRUE) or not (FALSE)
+         */
+        public function updateNecessary(): bool
+        {
+            $updateNeeded = false;
+
+            if (
+                $formDefinitionInformation['hasNewFileExtension'] === false
+                && $formDefinitionInformation['location'] === 'storage'
+            ) {
+                $updateNeeded = true;
+                $this->output->writeln('Form definition files were found that should be migrated to be named .form.yaml.');
+            }
+            // etc.
+
+            return $updateNeeded;
+        }
+
+        // etc.
+
+    }
 
 Registering wizard
 ==================

--- a/Documentation/ApiOverview/UpdateWizards/ExtUpdateFile.rst
+++ b/Documentation/ApiOverview/UpdateWizards/ExtUpdateFile.rst
@@ -6,10 +6,14 @@
 class.ext_update.php
 ====================
 
-While the upgarde wizards already provide a skeleton and integration into TYPO3
+.. note::
+
+   Using the file :file:`class.ext_update.php` is discouraged.
+   Use the new API as explained in this chapter.
+
+While the update wizards already provide a skeleton and integration into TYPO3
 CMS, there is a file from old times. This file is placed in the extension root
-and called :file:`class.ext_update.php`. For better overview it's recommended to
-use the new update wizards with separate classes for each update.
+and called :file:`class.ext_update.php`.
 
 If this file is found it will install a new menu item, "UPDATE", in the
 Extension Manager when looking at details for the extension. When this menu item

--- a/Documentation/ApiOverview/UpdateWizards/Index.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Index.rst
@@ -9,10 +9,23 @@
 Upgrade Wizards
 ===============
 
+.. note::
+
+   In TYPO3 9.4, `a new API for upgrade wizards <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Feature-86076-NewAPIForUpgradeWizards.html>`__
+   was introduced. This chapter was updated to use the new API.
+
 TYPO3 CMS offers a way for extension authors to provide automated updates for
 extensions. TYPO3 itself provides upgrade wizards to ease updates of TYPO3
 versions. This chapter will explain the concept and how to write upgrade
 wizards.
+
+The API for upgrade wizards comes with the following interfaces:
+
+* (required) :ref:`UpgradeWizardInterface <upgrade-wizard-interface>`: Main interface for UpgradeWizards. All
+ upgrade wizards using the new API MUST implement this interface.
+* (optional) :ref:`RepeatableInterface <repeatable-interface>`: Semantic interface to denote wizards that can be repeated
+* (optional) :ref:`ChattyInterface <uprade-wizards-chatty-interface>`:  Interface for wizards generating output
+* (optional) :php:`ConfirmableInferface`: Interface for wizards that need user confirmation
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
- mention all interfaces for new API
- add additional section for explaining output
- add note to mention since when new api is available
- discourage usage of class.ext_update.php

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/112
Releases: 

* [x] master
* [ ] 9.5