### PR TITLE
Remove backslashes

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Configuration/Index.rst
@@ -77,7 +77,7 @@ part of :php:`$GLOBALS['TYPO3_CONF_VARS'][SYS]`:
          The :php:`E_*` constant that will be handled as an exception by the error
          handler.
 
-         Default: :php:`E_ALL ^ E_NOTICE ^ E_WARNING ^ E_USER\_ERROR ^ E_USER\_NOTICE ^ E_USER\_WARNING`
+         Default: :php:`E_ALL ^ E_NOTICE ^ E_WARNING ^ E_USER_ERROR ^ E_USER_NOTICE ^ E_USER_WARNING`
          (4341) and "0" if :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = 0`.
 
          Refer to the PHP documentation for more details on this value.


### PR DESCRIPTION
Remove backslashes in code parts for PHP Constants.