### PR TITLE
Modernize code snippets in logging configuration

### DIFF
--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -38,16 +38,16 @@ The Log Writer configuration is read from the subkey :code:`writerConfiguration`
 
 .. code-block:: php
 
-   $GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = array(
+   $GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
        // configuration for ERROR level log entries
-     \TYPO3\CMS\Core\Log\LogLevel::ERROR => array(
-         // add a FileWriter
-       'TYPO3\\CMS\\Core\\Log\\Writer\\FileWriter' => array(
-           // configuration for the writer
-         'logFile' => 'typo3temp/var/log/typo3_7ac500bce5.log'
-       )
-     )
-   );
+       \TYPO3\CMS\Core\Log\LogLevel::ERROR => [
+           // add a FileWriter
+           \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
+               // configuration for the writer
+               'logFile' => 'typo3temp/var/log/typo3_7ac500bce5.log'
+           ]
+       ]
+   ];
 
 The above configuration applies to **all** log entries of level "ERROR" or above.
 
@@ -65,14 +65,14 @@ use the following configuration:
 
 .. code-block:: php
 
-   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Documentation']['Examples']['Controller']['writerConfiguration'] = array(
-      // configuration for WARNING severity, including all
-      // levels with higher severity (ERROR, CRITICAL, EMERGENCY)
-       \TYPO3\CMS\Core\Log\LogLevel::WARNING => array(
-        // add a SyslogWriter
-           'TYPO3\\CMS\\Core\\Log\\Writer\\SyslogWriter' => array(),
-       ),
-   );
+   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Documentation']['Examples']['Controller']['writerConfiguration'] = [
+       // configuration for WARNING severity, including all
+       // levels with higher severity (ERROR, CRITICAL, EMERGENCY)
+       \TYPO3\CMS\Core\Log\LogLevel::WARNING => [
+           // add a SyslogWriter
+           \TYPO3\CMS\Core\Log\Writer\SyslogWriter::class => [],
+       ],
+   ];
 
 This overwrites the default configuration shown in the first example for classes
 located in the namespace :code:`\Documentation\Examples\Controller`.
@@ -81,9 +81,9 @@ For extension "foo" with key "tx_foo" (not using namespaces), the configuration 
 
 .. code-block:: php
 
-   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Tx']['Foo']['writerConfiguration'] = array(
+   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Tx']['Foo']['writerConfiguration'] = [
       // ...
-   );
+   ];
 
 An arbitrary number of writers can be added for every severity level (INFO, WARNING, ERROR, ...).
 The configuration based on severity levels is applied to log entries of the particular severity level
@@ -111,14 +111,14 @@ basis from the subkey :code:`processorConfiguration`
 
 .. code-block:: php
 
-   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Documentation']['Examples']['Controller']['processorConfiguration'] = array(
+   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Documentation']['Examples']['Controller']['processorConfiguration'] = [
        // configuration for ERROR level log entries
-     \TYPO3\CMS\Core\Log\LogLevel::ERROR => array(
-         // add a MemoryUsageProcessor
-       'TYPO3\\CMS\\Core\\Log\\Processor\\MemoryUsageProcessor' => array(
-         'formatSize' => TRUE
-       )
-     )
-   );
+       \TYPO3\CMS\Core\Log\LogLevel::ERROR => [
+           // add a MemoryUsageProcessor
+           \TYPO3\CMS\Core\Log\Processor\MemoryUsageProcessor::class => [
+               'formatSize' => TRUE
+           ]
+       ]
+   ];
 
 For a list of processors shipped with the TYPO3 Core, see the section about :ref:`logging-processors`.


### PR DESCRIPTION
- use array short syntax
- use ::class instead of class names in string

Releases:

* [x] master
* [ ]  9.5
* [ ]  8.7
* [ ] 7.6
* [ ]  6.2