### PR TITLE
Restructure configuration section

### DIFF
--- a/Documentation/ApiOverview/Configuration/ConfigurationMethods.rst
+++ b/Documentation/ApiOverview/Configuration/ConfigurationMethods.rst
@@ -4,7 +4,7 @@
 .. _configuration-methods:
 
 ==========================
-Configuration Methods
+Configuration methods list
 ==========================
 
 These are the main configuration methods used by TYPO3:
@@ -47,27 +47,6 @@ Additionally, some system extensions use yaml for configuration:
 * :ref:`rte_ckeditor <ckedit:configuration>`: configure editing rich text editing
 
 
-**Table of Contents**
-
-More information can be found in these subchapters, the arrow `➜` indicates that
-you will be directed to another manual or to a different section in this manual.
-
-
-.. toctree:: 1
-   :maxdepth: 1
-
-   Extension Configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationOptions/Index.html>
-   ../FeatureToggles/Index
-   FlexForms ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/FlexForms/Index.html>
-   Form configuration ➜ <https://docs.typo3.org/c/typo3/cms-form/master/en-us/I/Concepts/Configuration/Index.html#concepts-configuration>
-   ../GlobalValues/GlobalVariables/Index
-   rte_ckeditor configuration ➜  <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/Configuration/Index.html#configuration>
-   Site configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SiteHandling/Index.html#sitehandling>
-   TCA ➜ <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/Introduction/Index.html>
-   ../Tsconfig/Index
-   ../GlobalValues/Typo3ConfVars/Index
-   TypoScript Templates ➜ <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
-   ../UserSettingsConfiguration/Index
 
 .. _next-steps:
 

--- a/Documentation/ApiOverview/Configuration/ConfigurationSyntax.rst
+++ b/Documentation/ApiOverview/Configuration/ConfigurationSyntax.rst
@@ -3,9 +3,9 @@
 
 .. _configuration-syntax:
 
-====================
-Configuration Syntax
-====================
+=========================
+Configuration syntax list
+=========================
 
 These are the main languages TYPO3 uses for configuration:
 
@@ -33,12 +33,9 @@ what they mean) are not.
    confusion, we will use the term "TypoScript syntax" and "TypoScript configuration
    method", at least in this chapter.
 
-**Table of Contents**
+More information can be found in these chapters:
 
-More information can be found in these subchapters.
+.. seealso::
 
-.. toctree::
-   :maxdepth: 1
-
-   ../TypoScriptSyntax/Index
-   ../Yaml/Index
+   * :ref:`typoscript-syntax-start`
+   * :ref:`yaml`

--- a/Documentation/ApiOverview/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Configuration/Index.rst
@@ -5,7 +5,7 @@
 .. _configuration:
 
 ======================
-Configuration Overview
+Configuration
 ======================
 
 A primary feature of TYPO3 is its configurability. Not only can
@@ -22,15 +22,38 @@ sources of confusion.
 For a more extensive introduction we will refer you to the
 respective chapter or reference.
 
+**Table of Contents**
+
+More information can be found in these subchapters. The arrow `➜` indicates that
+you will be directed to another manual or to a different section in this manual.
+
+
 .. toctree::
    :maxdepth: 1
 
    Glossary
-
-.. toctree::
-   :maxdepth: 2
-
-
    ConfigurationSyntax
    ConfigurationMethods
+   ../TypoScriptSyntax/Index
+   ../Yaml/Index
+   ../GlobalValues/GlobalVariables/Index
+   ../GlobalValues/Typo3ConfVars/Index
+   Site configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/SiteHandling/Index.html#sitehandling>
+   TypoScript Templates ➜ <https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/>
+   ../Tsconfig/Index
+   TCA ➜ <https://docs.typo3.org/m/typo3/reference-tca/master/en-us/Introduction/Index.html>
+   Extension Configuration ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationOptions/Index.html>
+   ../FeatureToggles/Index
+   FlexForms ➜ <https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/FlexForms/Index.html>
+   ../UserSettingsConfiguration/Index
+   Form configuration ➜ <https://docs.typo3.org/c/typo3/cms-form/master/en-us/I/Concepts/Configuration/Index.html#concepts-configuration>
+   rte_ckeditor configuration ➜  <https://docs.typo3.org/c/typo3/cms-rte-ckeditor/master/en-us/Configuration/Index.html#configuration>
+
+
+
+
+
+
+
+
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -117,15 +117,7 @@ address the task at hand.
    ApiOverview/BroadcastChannels/Index
    ApiOverview/CachingFramework/Index
    CodingGuidelines/Index
-
-.. toctree::
-   :maxdepth: 3
-
    ApiOverview/Configuration/Index
-
-.. toctree::
-   :maxdepth: 2
-
    ApiOverview/GlobalValues/Constants/Index
    ApiOverview/ContentElements/Index
    ApiOverview/Context/Index


### PR DESCRIPTION
Pull everything up to the top menu level in the configuration
chapter. That makes it easier to navigate and we can unify the
toctree in the main Index.rst (previously we displayed the
contents with a level of 2 for all and a level of 3 for configuration.
Now we can change all to level of 2 which makes maintainance easier).