### PR TITLE
Add information that $GLOBALS['TYPO3_REQUEST'] was deprecated

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -37,7 +37,7 @@ Depending on the context, there are two main ways to access them:
 
 .. hint::
     The first method is preferred if possible as :php:`$GLOBALS['TYPO3_REQUEST']` was
-    deprecated in 9.2 and removed in future versions.
+    deprecated in 9.2 and will be removed in future versions.
 
 Methods::
 

--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -36,8 +36,8 @@ Depending on the context, there are two main ways to access them:
 * via :php:`$GLOBALS['TYPO3_REQUEST']` - everywhere you don't have a ServerRequest object
 
 .. hint::
-    The first method is preferred if possible as the global access will be
-    deprecated and removed in future versions.
+    The first method is preferred if possible as :php:`$GLOBALS['TYPO3_REQUEST']` was
+    deprecated in 9.2 and removed in future versions.
 
 Methods::
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/110
Releases: master, 9.5