### PR TITLE
Fix indented text

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -42,16 +42,16 @@ Registering :ref:`hooks or signals <hooks-concept>`, :ref:`XCLASSes
 <xclasses>` or any simple array assignments to
 :php:`$GLOBALS['TYPO3_CONF_VARS']` options will not work for the following:
 
- * class loader
- * package manager
- * cache manager
- * configuration manager
- * log manager (= :ref:`Logging Framework <logging>`)
- * time zone
- * memory limit
- * locales
- * stream wrapper
- * :ref:`error handler <error-handling-extending>`
+* class loader
+* package manager
+* cache manager
+* configuration manager
+* log manager (= :ref:`Logging Framework <logging>`)
+* time zone
+* memory limit
+* locales
+* stream wrapper
+* :ref:`error handler <error-handling-extending>`
 
 This would not work because the extension files :file:`ext_localconf.php` are
 included (:php:`loadTypo3LoadedExtAndExtLocalconf`) after the creation of the


### PR DESCRIPTION
Indented text (apart from where it is required by using a directive) should no longer be used. This creates a "quote" block with the new theme.