### PR TITLE
Fix information about TS conditions (6.2)

### DIFF
--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -280,26 +280,6 @@ from the top level. This is normally done when TypoScript code from
 various records is combined.
 
 
-.. _typoscript-syntax-conditions-expression-language:
-
-Custom Conditions With Symfony Expression Language
-==================================================
-
-It is possible to provide own functions with extensions.
-Use as reference the class :php:`TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionFunctionsProvider` which implements
-the most core functions.
-
-Add new methods by implementing own providers which implement the :php:`ExpressionFunctionProviderInterface` and
-register the provider in :file:`ext_localconf.php`:
-
-.. code-block:: php
-
-   if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'])) {
-      $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'] = [];
-   }
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Core\ExpressionLanguage\TypoScriptConditionProvider']['additionalExpressionLanguageProvider'][] = \My\NameSpace\Provider\TypoScriptConditionProvider::class;
-
-
 .. _typoscript-syntax-conditions-summary:
 
 Summary


### PR DESCRIPTION
Due to migration from "TypoScript syntax and in depth study" and
partial backporting of documentation from newer version, some
information about TypoScript conditions based on Symfony expression
language was backported to older versions.

This is now fixed.