### PR TITLE
[TASK] Add max_line_length to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 3
+max_line_length = 80
 
 # MD-Files
 [*.md]


### PR DESCRIPTION
The maximum line length of documentation files (80 characters)
should be reflected in the .editorconfig as described in
https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/CodingGuidelines.html#line-length