### PR TITLE
Backport Supported Languages from master

### DIFF
--- a/Documentation/ApiOverview/Internationalization/Index.rst
+++ b/Documentation/ApiOverview/Internationalization/Index.rst
@@ -17,5 +17,6 @@ Internationalization and Localization
    :titlesonly:
 
    Introduction
+   Languages
    ManagingTranslations
    XliffFormat

--- a/Documentation/ApiOverview/Internationalization/Languages.rst
+++ b/Documentation/ApiOverview/Internationalization/Languages.rst
@@ -1,0 +1,76 @@
+.. include:: ../../Includes.txt
+
+
+.. _i18n_languages:
+
+===================
+Supported languages
+===================
+
+The list of supported languages is defined in :php:`\TYPO3\CMS\Core\Localization\Locales::$languages`.
+
+.. csv-table:: Languages
+   :header: "Locale in TYPO3", "Name"
+   :widths: 15, 15
+
+         "af", "Afrikaans"
+         "ar", "Arabic"
+         "bs", "Bosnian"
+         "bg", "Bulgarian"
+         "ca", "Catalan"
+         "ch", "Chinese (Simple)"
+         "cs", "Czech"
+         "da", "Danish"
+         "de", "German"
+         "el", "Greek"
+         "eo", "Esperanto"
+         "es", "Spanish"
+         "et", "Estonian"
+         "eu", "Basque"
+         "fa", "Persian"
+         "fi", "Finnish"
+         "fo", "Faroese"
+         "fr", "French"
+         "fr_CA", "French (Canada)"
+         "gl", "Galician"
+         "he", "Hebrew"
+         "hi", "Hindi"
+         "hr", "Croatian"
+         "hu", "Hungarian"
+         "is", "Icelandic"
+         "it", "Italian"
+         "ja", "Japanese"
+         "ka", "Georgian"
+         "kl", "Greenlandic"
+         "km", "Khmer"
+         "ko", "Korean"
+         "lt", "Lithuanian"
+         "lv", "Latvian"
+         "mi", "Maori"
+         "mk", "Macedonian"
+         "ms", "Malay"
+         "nl", "Dutch"
+         "no", "Norwegian"
+         "pl", "Polish"
+         "pt", "Portuguese"
+         "pt_BR", "Brazilian Portuguese"
+         "ro", "Romanian"
+         "ru", "Russian"
+         "rw", "Kinyarwanda"
+         "sk", "Slovak"
+         "sl", "Slovenian"
+         "sq", "Albanian"
+         "sr", "Serbian"
+         "sv", "Swedish"
+         "th", "Thai"
+         "tr", "Turkish"
+         "uk", "Ukrainian"
+         "vi", "Vietnamese"
+         "zh", "Chinese (Trad)"
+
+.. tip::
+
+   If you need additional languages there are 2 possible options:
+
+   - Open an issue at https://forge.typo3.org/projects/typo3cms-core/issues and describe your usecase. The language might be added to the next major release of TYPO3.
+   - Take a look at the section :ref:`xliff-translating-languages` to solve it in your project.


### PR DESCRIPTION
The supported languages for master + 9.5 are identical as checked:

https://raw.githubusercontent.com/TYPO3/TYPO3.CMS/master/typo3/sysext/core/Classes/Localization/Locales.php
https://raw.githubusercontent.com/TYPO3/TYPO3.CMS/9.5/typo3/sysext/core/Classes/Localization/Locales.php