### PR TITLE
values stored as an array

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -86,7 +86,7 @@ Where user functions have to be written the following way:
 Accessing saved options
 =======================
 
-Once you saved the configuration in the Settings module, it will be stored in
+Once you saved the configuration in the Settings module, it will be persisted into the LocalConfiguration.php file and made available via 
 :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['your_extension_key']`
 as an array.
 

--- a/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationOptions/Index.rst
@@ -81,14 +81,14 @@ Where user functions have to be written the following way:
    # cat=basic/enable/050; type=user[Vendor\MyExtensionKey\ViewHelpers\MyConfigurationClass->render]; label=MyLabel
    myVariable = 1
 
+
 .. _extension-options-accessing-saved-options:
 
 Accessing saved options
 =======================
 
-Once you saved the configuration in the Settings module, it will be persisted into the LocalConfiguration.php file and made available via 
-:php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['your_extension_key']`
-as an array.
+When saved in the Settings module, the configuration will be kept in the :file:`LocalConfiguration.php`
+file and is available as array :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['your_extension_key']`.
 
 To retrieve the configuration use the API provided by the :php:`\TYPO3\CMS\Core\Configuration\ExtensionConfiguration` class::
 


### PR DESCRIPTION
I think the value isn't really stored into an array. It is stored into the LocalConfiguration.php file and made available as array. This is important to know when you have the LocalConfiguration.php in Git. We can only store values into the database or a file. Arrays are only available during runtime....