### PR TITLE
[TASK] Add description for complex restrictions

### DIFF
--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -236,9 +236,10 @@ that you have content in table `tt_content` that could have another record as pa
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
-   // use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction
-   // use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction
-   // use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction
+   // use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+   // use TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction;
+   // use TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction;
+   // use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
 
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    
@@ -248,14 +249,14 @@ that you have content in table `tt_content` that could have another record as pa
       ->removeAll()
    
    // build a custom restriction container
-   $myRestrictionContainer = new \TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer();
+   $myRestrictionContainer = new DefaultRestrictionContainer();
    
    // remove all restricitons that should not been used
    // with this, only the HiddenRestriction stays in the restriction container
    $myRestrictionContainer
-      ->removeByType(\TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction::class)
-      ->removeByType(\TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction::class)
-      ->removeByType(\TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction::class);
+      ->removeByType(DeletedRestriction::class)
+      ->removeByType(EndTimeRestriction::class)
+      ->removeByType(StartTimeRestriction::class);
    
    // apply the restrictions in "$myRestrictionContainer" only to one table
    $doctrineQueryBuilderExpressions = $myRestrictionContainer->buildExpression(['c2' => 'tt_content'], $queryBuilder->expr());

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -146,11 +146,11 @@ Restrictions
    records need to be handled after the SQL results are fetched, by overlaying the records with
    :php:`BackendUtility::getRecordWSOL()`, :php:`PageRepository->versionOL()` or `PlainDataResolver`.
 
-If a Restriction needs to be enforced as it should always be applied, a restrition could implement the interface `EnforceableQueryRestrictionInterface`. Is this interface implemented for a Restrition, please take care of the following behavior:
+If a restriction needs to be enforced, a restriction could implement the interface `EnforceableQueryRestrictionInterface`. If a restriction implements `EnforceableQueryRestrictionInterface`, the following applies:
 
 * `->removeAll()` will remove all restrictions except the ones that implement the interface `EnforceableQueryRestrictionInterface`
 
-* `->removeByType()` will remove a restriction completely, also restritions that implement the interface `EnforceableQueryRestrictionInterface`
+* `->removeByType()` will remove a restriction completely, also restrictions that implement the interface `EnforceableQueryRestrictionInterface`
 
 
 QueryRestrictionContainer
@@ -230,9 +230,9 @@ deliver and use an own set of restrictions for own query statements if needed.
    take care these calls **do not** :ref:`end up in production <database-query-builder-get-sql>` code.
 
 
-A very complex example is that you might want to apply one or more restriction/s to only one table. Let's say,
+If you want to apply one or more restriction/s to only one table, that is possible as follows. Let's say,
 that you have content in table `tt_content` that could have another record as parent record assigned in field
-`parent`. Now you would like to get all records except the child records where the parent record is hidden.
+`parent`. Now you would like to get all records except the child records where the parent record is hidden. ::
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -242,22 +242,22 @@ that you have content in table `tt_content` that could have another record as pa
    // use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
 
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
-   
+
    // Remove all restrictions first
    $queryBuilder
       ->getRestrictions()
       ->removeAll()
-   
+
    // build a custom restriction container
    $myRestrictionContainer = new DefaultRestrictionContainer();
-   
-   // remove all restricitons that should not been used
+
+   // remove all restrictions that should not be used
    // with this, only the HiddenRestriction stays in the restriction container
    $myRestrictionContainer
       ->removeByType(DeletedRestriction::class)
       ->removeByType(EndTimeRestriction::class)
       ->removeByType(StartTimeRestriction::class);
-   
+
    // apply the restrictions in "$myRestrictionContainer" only to one table
    $doctrineQueryBuilderExpressions = $myRestrictionContainer->buildExpression(['c2' => 'tt_content'], $queryBuilder->expr());
 
@@ -269,6 +269,8 @@ that you have content in table `tt_content` that could have another record as pa
       ->orWhere($queryBuilder->expr()->isNull('c2.uid'), $doctrineQueryBuilderExpressions);
 
 With this you will end up with the following query:
+
+.. code-block: sql
 
    SELECT `c1`.*
    FROM `tt_content` `c1`


### PR DESCRIPTION
With this change a description for very complex scenarios about
the usage of restrictions in combination of joins is added.

Furthermore a little hint is added regarding the interface
`EnforceableQueryRestrictionInterface` for restrictions and the
impact while using `->removeAll()` and `removeByType()` of the
RestrictionsContainer on those restrictions.