### PR TITLE
Update link to EXT:logs repository

### DIFF
--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -45,7 +45,7 @@ logTable  no         Database table  :code:`sys_log`
    there, you will not be able to see them using that module.
 
 *Tip:* There's a tool for viewing such records in the TYPO3 backend at
-`github.com/vertexvaar/logs <https://github.com/vertexvaar/logs>`__.
+`gitlab.com/co-stack.com/co-stack.com/typo3-extensions/logs <https://gitlab.com/co-stack.com/co-stack.com/typo3-extensions/logs>`__.
 
 Example of a CREATE TABLE statement for logTable:
 


### PR DESCRIPTION
The repository of EXT:logs was moved to gitlab.com and the ownership was transferred to co-stack:

![image](https://user-images.githubusercontent.com/5037116/84994503-128b3d00-b14b-11ea-91de-c7943b139d01.png)
