### PR TITLE
Add .html configuration

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -266,9 +266,10 @@ It is also possible to set :yaml:`default` to e.g. ".html" to add a ".html" suff
    routeEnhancers:
       PageTypeSuffix:
          type: PageType
-         default: '.json'
+         default: '.html'
          index: 'index'
          map:
+            '.html': 0
             'rss.feed': 13
             '.json': 26
 


### PR DESCRIPTION
I was trying the existing routeEnhancer code block to no avail. I had to change the default to '.html' and add the '.html': 0 to the map, otherwise I would run into following error:

```
Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1538327510: map must be array | InvalidArgumentException thrown in file /Users/andy/Sites/mysite/public/typo3/sysext/core/Classes/Routing/Enhancer/PageTypeDecorator.php in line 78.
```