### PR TITLE
[TASK] Mention migration for escapeStrForLike()

### DIFF
--- a/Documentation/ApiOverview/Database/Migration/Index.rst
+++ b/Documentation/ApiOverview/Database/Migration/Index.rst
@@ -260,6 +260,12 @@ fullQuoteStr()
       ->execute();
 
 
+escapeStrForLike()
+==================
+
+:php:`$GLOBALS['TYPO3_DB']->escapeStrForLike()` is replaced by :php:`$queryBuilder->escapeLikeWildcards()`.
+
+
 ext_tables.sql
 ==============
 


### PR DESCRIPTION
Add a note about the former `escapeStrForLike()` function and its replacement in doctrine.