### PR TITLE
[TASK] Fix inconsistend handling of StringFrontend

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
@@ -93,6 +93,17 @@ Currently two different frontends are implemented. The main difference are
 the data types which can be stored using a specific frontend.
 
 
+.. _caching-frontend-string:
+
+String Frontend
+---------------
+
+.. deprecated:: 9.2
+
+   The StringFrontend should no longer be used. It was removed in TYPO3
+   version 10.0. Use the VariableFrontend instead, as explained in the
+   changelog :doc:`t3core:Changelog/9.2/Deprecation-81434-StringCacheFrontendDeprecated`.
+
 .. _caching-frontend-variable:
 
 Variable Frontend


### PR DESCRIPTION
In version 9, StringFrontend was merely deprecated while it was
removed entirely from 9.5 docs.

In 10, it was removed, but was not removed from the docs (for 10.4).

Instead, when deprecated, a note about deprecation should be added
and a link to the changelog, while it should get removed when removed
from core.

Related: #889
Releases: 

* master (was already removed)
* [x] 10.4
* [x] 9.5