### PR TITLE
Fix "Examples" page

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Examples/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Examples/Index.rst
@@ -44,12 +44,6 @@ In :file:`.htaccess`::
    php_flag display_errors on
    php_flag log_errors on
    php_value error_log /path/to/php_error.log
-
-
-
-Do not set `contentObjectExceptionHandler` to 0 in production. It will
-display a complete stack dump in the Frontend, when an exception occurs. Use
-`config.contentObjectExceptionHandler = 1`, which is the default, in production.
    
 
 TypoScript::
@@ -58,10 +52,10 @@ TypoScript::
    
 Use this setting, to get more context and a stacktrace in the Frontend in case of an exception.
 
-Do not set `config.contentObjectExceptionHandler` to 0 in production. It will
-display a complete stack dump in the Frontend, when an exception occurs. Use
-`config.contentObjectExceptionHandler = 1`, which is the default, in production.
-
+.. important:: 
+   Do not set `config.contentObjectExceptionHandler` to 0 in production. It will
+   display a complete stack dump in the Frontend, when an exception occurs. Use
+   `config.contentObjectExceptionHandler = 1`, which is the default, in production.
 
 See :ref:`contentObjectExceptionHandler <t3tsref:setup-config-contentObjectExceptionHandler>` for more
 information.
@@ -82,7 +76,6 @@ In :file:`LocalConfiguration.php`::
       'displayErrors' => '2',
       'devIPmask' => '[your.IP.address]',
       'errorHandler' => 'TYPO3\\CMS\\Core\\Error\\ErrorHandler',
-      'syslogErrorReporting' => E_ALL ^ E_NOTICE ^ E_WARNING,
       'belogErrorReporting' => '0',
    ),
 
@@ -113,7 +106,6 @@ In :file:`LocalConfiguration.php`::
       'errorHandler' => '',
       'debugExceptionHandler' => '',
       'productionExceptionHandler' => '',
-      'syslogErrorReporting' => '0',
       'belogErrorReporting' => '0',
    ),
 


### PR DESCRIPTION
- Warning was shown twice.
- Warning should have a "warning" box.
- syslogErrorReporting was removed.