### PR TITLE
Elaborate section about Fluid access

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -360,7 +360,7 @@ How to Access FlexFroms From Fluid
 ----------------------------------
 
 Flexform settings can be read from within a Fluid template using
-:html:`{settings}`.
+:html:`{settings}`. Note that this only works for Flexform variables which are prefixed with `settings.` - variables which are not prefixed will have to be extracted from within a controller, data processor or other PHP context which allows arbitrary access to the Flexform values.
 
 
 Steps to Perform (Editor)


### PR DESCRIPTION
Describes that `settings.` is required as variable name prefix to make variables automatically available in Fluid.