### PR TITLE
Fix onChange and displayCond location

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -244,10 +244,10 @@ on database fields of current record or be defined by a user function.
 
 .. code-block:: xml
 
+    <!-- Hide field if value of neighbour field "settings.orderBy" on same sheet is not "title" -->
+    <displayCond>FIELD:settings.orderBy:!=:title</displayCond>
     <config>
-        <type>select</type>
-        <!-- Hide field if value of neighbour field "settings.orderBy" on same sheet is not "title" -->
-        <displayCond>FIELD:settings.orderBy:!=:title</displayCond>
+        <!-- ... -->
     </config>
 
 Again, the syntax and available fields and comparison operators is documented
@@ -282,11 +282,12 @@ can do that with:
 
 .. code-block:: xml
 
+   <onChange>reload</onChange>
    <config>
        <!-- ... -->
-       <onChange>reload</onChange>
+   </config>
 
-This element is optional and must go inside the `<config>` element.
+This element is optional and must go next to the `<config>` element.
 
 .. _read-flexforms:
 .. _read-flexforms-extbase:


### PR DESCRIPTION
`onChange` and `displayCond` don't belong into `config`.

It's documented here: https://docs.typo3.org/m/typo3/reference-tca/master/en-us/Columns/Index.html `[‘columns’]` instead of `[‘columns’][*][‘config’]`