### PR TITLE
Remove caption "meta" from menu

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -172,8 +172,6 @@ address the task at hand.
 
 .. toctree::
    :maxdepth: 1
-   :caption: meta
-
 
    Sitemap
    About


### PR DESCRIPTION
This was not a good choice and having a caption is now no longer necessary.
The individual toctrees are seperated via a line in the new menu.

Related: TYPO3-Documentation/TYPO3CMS-Reference-CoreApi#421

Before:

![image](https://user-images.githubusercontent.com/13206455/87220344-32d1a480-c363-11ea-8cca-af3f3605ed15.png)


after:

![image](https://user-images.githubusercontent.com/13206455/87220353-3f55fd00-c363-11ea-8fd8-d45feca067a0.png)
