### PR TITLE
Use or-operator as (nearly) all core files do

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -320,7 +320,7 @@ avoids unexpected side-effects with files of other extensions.
 The following example contains the complete code::
 
     <?php
-    defined('TYPO3_MODE') || die();
+    defined('TYPO3_MODE') or die();
 
     (function () {
         // Add your code here


### PR DESCRIPTION
Except for EXT:core/Configuration/TCA/Overrides/sys_file_storage.php, all core files are using the ||-operator here. So "Best Practices" should reflect this - or we should apply the documented best practices to the core