### PR TITLE
Do not call closeCursor() in prepared statements on TYPO3 8.7

### DIFF
--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -138,3 +138,7 @@ Looking at a mysql debug log:
 
 
 The log shows one statement preparation with two executions.
+
+.. note::
+
+   In TYPO3 v8.7 calling `$statement->closeCursor();` in order to free the resources for a result will lead to unexpected results due to a bug in `doctrine/dbal#2546 <https://github.com/doctrine/dbal/pull/2546>`__. In TYPO3 >= v9.5 calling `$statement->closeCursor();` after `$statement->fetch();` is recommended.

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -141,4 +141,7 @@ The log shows one statement preparation with two executions.
 
 .. note::
 
-   In TYPO3 v8.7 calling :php:`$statement->closeCursor();` in order to free the resources for a result will lead to unexpected results due to a bug in `doctrine/dbal#2546 <https://github.com/doctrine/dbal/pull/2546>`__. In TYPO3 >= v9.5 calling :php:`$statement->closeCursor();` after :php:`$statement->fetch();` is recommended.
+   In TYPO3 v8.7 calling :php:`$statement->closeCursor();` in order to free the resources
+   for a result will lead to unexpected results due to a bug
+   in `doctrine/dbal#2546 <https://github.com/doctrine/dbal/pull/2546>`__. In TYPO3 >= v9.5
+   calling :php:`$statement->closeCursor();` after :php:`$statement->fetch();` is recommended.

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -123,11 +123,9 @@ and executes it twice with different arguments:
         ->getSQL();
     $statement = $connection->executeQuery($sqlStatement, [ 24 ]);
     $result1 = $statement->fetch();
-    $statement->closeCursor(); // free the resources for this result
     $statement->bindValue(1, 25);
     $statement->execute();
     $result2 = $statement->fetch();
-    $statement->closeCursor(); // free the resources for this result
 
 
 Looking at a mysql debug log:

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -141,4 +141,4 @@ The log shows one statement preparation with two executions.
 
 .. note::
 
-   In TYPO3 v8.7 calling `$statement->closeCursor();` in order to free the resources for a result will lead to unexpected results due to a bug in `doctrine/dbal#2546 <https://github.com/doctrine/dbal/pull/2546>`__. In TYPO3 >= v9.5 calling `$statement->closeCursor();` after `$statement->fetch();` is recommended.
+   In TYPO3 v8.7 calling :php:`$statement->closeCursor();` in order to free the resources for a result will lead to unexpected results due to a bug in `doctrine/dbal#2546 <https://github.com/doctrine/dbal/pull/2546>`__. In TYPO3 >= v9.5 calling :php:`$statement->closeCursor();` after :php:`$statement->fetch();` is recommended.


### PR DESCRIPTION
Calling `closeCursor()` in prepared statements on TYPO3 8.7 leads to always the first result being returned. In TYPO3 >= 9.5 the calls to closeCursor are correct.