### PR TITLE
Make code blocks syntactically correct on TS conditions page

### DIFF
--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -64,11 +64,11 @@ A condition is written on its own line and is detected by :code:`[`
 
 .. code-block:: typoscript
 
-   (Some TypoScript)
+   # ... some TypoScript
 
    [ condition ]
 
-   (Some TypoScript only parsed if the condition is met.)
+   # .... some more TypoScript (only parsed if the condition is met.)
 
    [GLOBAL]
 


### PR DESCRIPTION
- code blocks should use syntactically correct code (to be parsed correctly and not fill up warnings.txt)
- Also, for the user, it makes it easier and more clear