### PR TITLE
Insert note about new PreviewRenderer pattern

### DIFF
--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -215,6 +215,11 @@ saved by the richtext editor:
 4. Optional: Configure Custom Backend Preview
 =============================================
 
+.. note::
+
+    With TYPO3 10.3, the backend rendering process is being replaced by the new Fluid-based `PreviewRenderer pattern. <https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-78450-IntroducePreviewRendererPattern.html>`__
+    The process described below can still be used after disabling the option in *Settings > Feature Toggles > Fluid based page module*.
+
 If you want to generate a special preview in the backend :guilabel:`Web > Page` module, you can use a hook for this:
 
 .. code-block:: php


### PR DESCRIPTION
This tutorial describes how to generate a special backend preview using the `PageLayoutViewDrawItemHookInterface`. In [Feature #78450](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-78450-IntroducePreviewRendererPattern.html) a new process using the `PreviewRendererInterface` was introduced.

This pull request includes a note under Heading 4 which gives a hint that the new process exists and links to the feature description.