### PR TITLE
Add important note about using $_EXTKEY in ext_emconf

### DIFF
--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -20,8 +20,38 @@ The keys are described in the table below.
 This file is overwritten, when extensions are imported from the online repository. So don't write your custom code in this file - only change
 values in the :php:`$EM_CONF` array if needed.
 
+
+.. code-block:: php
+
+   <?php
+   $EM_CONF[$_EXTKEY] = [
+       'title' => 'Extension title',
+       'description' => 'Extension description',
+       'category' => 'plugin',
+       'author' => 'John Doe',
+       'author_email' => 'john@example.org',
+       'author_company' => 'some company',
+       'state' => 'stable',
+       'createDirs' => '',
+       'clearCacheOnLoad' => 0,
+       'version' => '1.0.0',
+       'constraints' => [
+           'depends' => [
+               'typo3' => '11.0.0-11.99.99',
+           ],
+           'conflicts' => [
+           ],
+           'suggests' => [
+           ],
+       ],
+   );
+
+$_EXTKEY is set globally and contains the extension key.
+
 .. important::
-   However, due to limitations to TER, the `$_EXTKEY` option should be kept within an extension’s ext_emconf.php. Do **not** use a constant or a string.
+   Due to limitations to the TER (`TYPO3 Extension Repository <https://extensions.typo3.org>`__),
+   `$_EXTKEY` should be used here and **not** a constant or a string.
+
 
 .. t3-field-list-table::
  :header-rows: 1

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -20,6 +20,9 @@ The keys are described in the table below.
 This file is overwritten, when extensions are imported from the online repository. So don't write your custom code in this file - only change
 values in the :php:`$EM_CONF` array if needed.
 
+.. important::
+However, due to limitations to TER, the `$_EXTKEY` option should be kept within an extension’s ext_emconf.php. Do **not** use a constant or a string.
+
 .. t3-field-list-table::
  :header-rows: 1
 

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -21,7 +21,7 @@ This file is overwritten, when extensions are imported from the online repositor
 values in the :php:`$EM_CONF` array if needed.
 
 .. important::
-However, due to limitations to TER, the `$_EXTKEY` option should be kept within an extension’s ext_emconf.php. Do **not** use a constant or a string.
+   However, due to limitations to TER, the `$_EXTKEY` option should be kept within an extension’s ext_emconf.php. Do **not** use a constant or a string.
 
 .. t3-field-list-table::
  :header-rows: 1


### PR DESCRIPTION
This note is already on the page https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ConfigurationFiles/Index.html, but it should be on this page + more prominent.