### PR TITLE
Minor readability improvements

### DIFF
--- a/Documentation/ExtensionArchitecture/SystemAndLocalExtensions/Index.rst
+++ b/Documentation/ExtensionArchitecture/SystemAndLocalExtensions/Index.rst
@@ -8,11 +8,11 @@ System and Local Extensions
 ===============================
 
 The files for an extension are located in a folder named by the
-*extension key* . The location of this folder can be either inside
+*extension key*. The location of this folder can be either inside
 `typo3/sysext/` or `typo3conf/ext/`.
 
 The extension *must* be programmed so that it does automatically
-detect where it is located and can work from all two locations.
+detect where it is located and can work from both locations.
 
 
 
@@ -23,9 +23,9 @@ Local Extensions
 
 Local extensions are located in the :file:`typo3conf/ext/` directory.
 
-This is where to put extensions  *which are local* for a particular
+This is where to put extensions *which are local* for a particular
 TYPO3 installation. The :file:`typo3conf` directory is always local, containing
-local configuration (e.g.  :file:`LocalConfiguration.php`), local modules etc.
+local configuration (e.g. :file:`LocalConfiguration.php`), local modules etc.
 If you put an extension here it will be available for a single TYPO3
 installation only. This is a "per-database" way to install an
 extension.


### PR DESCRIPTION
I replaced the phrase "all two," which is not used in English, with "both." Since I had the file open, I also removed some extraneous spaces where there were double spaces or a space before a period.

I hope such relatively minor changes are welcome; if they are I will continue to submit them for the documentation as I make my way through it. I'm new to the TYPO3 community, so please either let me know or just ignore this if such relatively minor improvements are not welcome. Thanks!