### PR TITLE
Remove note about new site handling

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling.rst
@@ -16,10 +16,6 @@ The configuration consists of two parts:
 
 You can define one error handler per HTTP error code and add a generic one that serves all error pages.
 
-.. tip::
-    No more trouble with translated 404 error pages. With the new site handling getting translated
-    404 is easy!
-
 .. figure:: ../../Images/SiteHandlingErrorHandling-1.png
    :class: with-shadow
    :alt: Error Handling


### PR DESCRIPTION
In TYPO3 >= 10, the site handling is no longer new

Releases: master, 10.4