### PR TITLE
Add more information about composer.json type

### DIFF
--- a/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
+++ b/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
@@ -150,8 +150,15 @@ type
 
 (*required*)
 
-Just use `typo3-cms-extension` for TYPO3 extensions
+Use `typo3-cms-extension` for third party extensions. This will result in
+the extension to be installed in `{web-dir}/typo3conf/ext` instead
+of `vendor/{vendor}/{package}`. 
 
+Use `typo3-cms-framework` for system extensions. They will be installed
+in `web-dir/typo3/sysext`.
+
+See `typo3/cms-composer-installers <https://github.com/TYPO3/CmsComposerInstallers>`__
+(required by `typo3/cms-core`).
 
 license
 -------


### PR DESCRIPTION
List correct type for system and third party extension.

This also points developers to the source of typo3-cms-installers
where they can find more information (in the source) about
installation.