### PR TITLE
Add a remark that using the meta tag is not always needed

### DIFF
--- a/Documentation/ApiOverview/MetaTagApi/Index.rst
+++ b/Documentation/ApiOverview/MetaTagApi/Index.rst
@@ -11,9 +11,8 @@ In order to have the possibility to set metatags in a flexible (but regulated wa
 
 .. note::
 
-    Usually, it is sufficient to just use the API of :php:`PageRenderer` for most simple cases like setting 
-    MetaTags from Extensions. :php:`PageRenderer` uses the MetaTag API internally. If the :php:`PageRenderer` API 
-    doesn't fit your needs, you should consider using the MetaTag API directly.
+    Usually, it is sufficient to set met tags using the API of the :php:`PageRenderer` which uses the Meta Tag API
+    internally. For all other cases, use the Meta Tag API directly.
 
 The API uses :php:`MetaTagManagers` to manage the tags for a "family" of meta tags. The core e.g. ships an
 OpenGraph MetaTagManager that is responsible for all OpenGraph tags.

--- a/Documentation/ApiOverview/MetaTagApi/Index.rst
+++ b/Documentation/ApiOverview/MetaTagApi/Index.rst
@@ -9,6 +9,12 @@ MetaTag API
 
 In order to have the possibility to set metatags in a flexible (but regulated way), a new Meta Tag API is introduced.
 
+.. note::
+
+    Usually, it is sufficient to just use the API of :php:`PageRenderer` for most simple cases like setting 
+    MetaTags from Extensions. :php:`PageRenderer` uses the MetaTag API internally. If the :php:`PageRenderer` API 
+    doesn't fit your needs, you should consider using the MetaTag API directly.
+
 The API uses :php:`MetaTagManagers` to manage the tags for a "family" of meta tags. The core e.g. ships an
 OpenGraph MetaTagManager that is responsible for all OpenGraph tags.
 In addition to the MetaTagManagers included in the core, you can also register your own


### PR DESCRIPTION
The remark explains that the pageRenderer API is usually sufficient as it is the "outermost" API.