### PR TITLE
Fix BeforeJavaScriptsRenderingEvent class name in example

### DIFF
--- a/Documentation/ApiOverview/Hooks/Events/Core/Page/AssetRendererEvent.rst.txt
+++ b/Documentation/ApiOverview/Hooks/Events/Core/Page/AssetRendererEvent.rst.txt
@@ -73,7 +73,7 @@ from a CDN.
              tags:
                - name: event.listener
                  identifier: 'myExt/LibraryVersion'
-                 event: TYPO3\CMS\Core\Page\Event\AssetRendererBeforeRenderingEvent
+                 event: TYPO3\CMS\Core\Page\Event\BeforeJavaScriptsRenderingEvent
 
 
    2. Implement Listener to enforce a library version or CDN URI


### PR DESCRIPTION
The class was changed during the review. See https://forge.typo3.org/issues/92702