### PR TITLE
Remove duplicate information about deprecation

### DIFF
--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -6,6 +6,11 @@
 Deprecation
 ===========
 
+.. note::
+
+   For information how to handle deprecations in the TYPO3 CMS core,
+   see the Contribution Guide: :ref:`t3contrib:deprecations`.
+
 Since TYPO3 4.3, calls to deprecated functions are logged to track usage of
 deprecated/outdated methods in the TYPO3 Core. Developers have to make sure to adjust their code to avoid
 using this old functionality since deprecated methods will be removed in future TYPO3 releases.

--- a/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/HandlingDeprecations.rst
+++ b/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/HandlingDeprecations.rst
@@ -7,45 +7,7 @@
 Handling Deprecation
 ====================
 
-This section describes the rules to follow for removing existing
-functions or parameters from TYPO3 CMS. The general principle is that
-functions or parameters are removed **two major versions** after they
-were set to be deprecated.
+.. note::
 
-To start the deprecation process for a parameter of a TYPO3 CMS core
-function, please mark it within the phpDoc param part::
-
-   /**
-    * ...
-    * @param string DEPRECATED since TYPO3 CMS 9 - is not used anymore because...
-    * ...
-    */
-
-
-For a whole function inside one of the TYPO3 CMS core classes, use the
-phpDoc `@deprecated` annotation::
-
-   /**
-    * ...
-    * @return ...
-    * @deprecated
-    */
-
-
-At the beginning of the deprecated function you must add the following
-code::
-
-   trigger_error('since TYPO3 CMS 9, will be removed in TYPO3 CMS 10, use FUNCNAME instead', E_USER_DEPRECATED);
-
-
-It is also possible to deprecate finer-grained elements, such as
-TypoScript or TSconfig properties. In such a case, a log message can be
-used inside the code itself::
-
-   if ($fooBar !== null) {
-      trigger_error('A useful message', E_USER_DEPRECATED);
-      $this->useFooBar = true;
-   }
-
-
-Anyone can submit a patch to remove deprecated elements.
+   How to handle deprecations in TYPO3 CMS is covered in the
+   Contribution Guide: :ref:`t3contrib:deprecations`.


### PR DESCRIPTION
How do deprecate classes, methods etc. in the TYPO3 core is handled in
the contribution guide. The section in the CGL chapter covers basically
the same thing. This text is removed and a link to the contribution guide
added.

The chapter "deprecation" handles the topic deprecation from the point
of view of people who use TYPO3. It covers how to disable deprecation
notices, how the deprecation log works and how to find calls to deprecated
functions in extensions.

Resolves: #910