### PR TITLE
TASK: Add missing exception variable

### DIFF
--- a/Documentation/ApiOverview/Enumerations/Enumeration.rst
+++ b/Documentation/ApiOverview/Enumerations/Enumeration.rst
@@ -90,7 +90,7 @@ Example::
 
    try {
       $foo = LikeWildcard::cast($valueFromPageTs);
-   } catch (\TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException) {
+   } catch (\TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException $exception) {
       $foo = LikeWildcard::cast(LikeWildcard::NONE);
    }
 


### PR DESCRIPTION
The example try-catch block is missing the variable name for the exception.