### PR TITLE
Add information about CGL for missing file types

### DIFF
--- a/Documentation/CodingGuidelines/Index.rst
+++ b/Documentation/CodingGuidelines/Index.rst
@@ -10,6 +10,23 @@ This chapter contains description of the formal requirements or standards
 regarding coding that you should adhere to when you develop TYPO3
 extensions or core parts.
 
+.. tip::
+
+   You can find an
+   `.editorconfig <https://github.com/TYPO3/TYPO3.CMS/blob/master/.editorconfig>`__
+   file in the TYPO3 core repository.
+   `Some editors and IDEs <https://editorconfig.org/>`__ can use this
+   file and the rules defined within.
+
+In the .editorconfig some basic rules are defined, such as the charset and
+the indenting style. By default, indenting with 4 spaces is
+used, but there are a few exceptions (e.g. for YAML or JSON
+files).
+
+For the files that are not specifically covered in the subchapters (e.g.
+Fluid, .json, or .sql), the information in the .editorconfig file
+should be sufficient.
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:

--- a/Documentation/CodingGuidelines/Index.rst
+++ b/Documentation/CodingGuidelines/Index.rst
@@ -18,7 +18,7 @@ extensions or core parts.
    `Some editors and IDEs <https://editorconfig.org/>`__ can use this
    file and the rules defined within.
 
-In the .editorconfig some basic rules are defined, such as the charset and
+Some basic rules are defined in the .editorconfig, such as the charset and
 the indenting style. By default, indenting with 4 spaces is
 used, but there are a few exceptions (e.g. for YAML or JSON
 files).
@@ -40,4 +40,3 @@ should be sufficient.
    CglXliff/Index
    CglYaml
    CglRest/Index
-


### PR DESCRIPTION
There are some file types missing in the CGL, e.g. .json, Fluid or .sql.

For these, the information in the .editorconfig (or just using the
.editorconfig) and looking in the source code of the core should be
sufficient.

A note about .editorconfig is added.

Resolves: #342