### PR TITLE
Correct method name getTca()

### DIFF
--- a/Documentation/ApiOverview/Hooks/Events/Core/Configuration/AfterTcaCompilationEvent.rst
+++ b/Documentation/ApiOverview/Hooks/Events/Core/Configuration/AfterTcaCompilationEvent.rst
@@ -23,7 +23,7 @@ API
 
 .. rst-class:: dl-parameters
 
-getTCA()
+getTca()
    :sep:`|` :aspect:`ReturnType:` array
    :sep:`|`
 


### PR DESCRIPTION
See: https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Classes/Configuration/Event/AfterTcaCompilationEvent.php#L38

Releases: master, 10.4