### PR TITLE
Restructure: Links and references

### DIFF
--- a/Documentation/ApiOverview/LinkBrowser/Index.rst
+++ b/Documentation/ApiOverview/LinkBrowser/Index.rst
@@ -1,16 +1,14 @@
 .. include:: /Includes.rst.txt
 
-.. _Linkbrowser:
 
-
-===========
-Linkbrowser
-===========
-
-**Contents:**
+==================
+Links & references
+==================
 
 .. toctree::
+   :caption: Table of contents:
    :titlesonly:
 
    LinkBrowserApi/Index
    Linkhandler/Index
+   ../SoftReferences/Index

--- a/Documentation/ApiOverview/LinkBrowser/LinkBrowserApi/Index.rst
+++ b/Documentation/ApiOverview/LinkBrowser/LinkBrowserApi/Index.rst
@@ -1,6 +1,7 @@
 .. include:: /Includes.rst.txt
 .. highlight:: php
 
+.. _Linkbrowser:
 .. _linkbrowser-api:
 
 ===============

--- a/Documentation/ApiOverview/LinkBrowser/Linkhandler/Index.rst
+++ b/Documentation/ApiOverview/LinkBrowser/Linkhandler/Index.rst
@@ -4,7 +4,7 @@
 .. _linkhandler:
 
 ===============
-LinkHandler Api
+LinkHandler API
 ===============
 
 .. versionadded:: 8.6

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -161,7 +161,6 @@ address the task at hand.
    ApiOverview/Services/Index
    ApiOverview/SessionStorageFramework/Index
    ApiOverview/SiteHandling/Index
-   ApiOverview/SoftReferences/Index
    ApiOverview/CommandControllers/Index
    ApiOverview/SymfonyExpressionLanguage/Index
    ApiOverview/Categories/Index


### PR DESCRIPTION
Links and references are 2 different things but there is some overlap.
This commit groups the following subchapters together:

- Linkhandler API
- LinkBrowser API
- Softreferences

into a chapter "Links & references".

As next step we could add an introduction page explaining concepts
of references in TYPO3, how links are created and stored internally,
and also possibly how the reference index works.

Related is also the FAL which is covered in its own chapter, but
a link to that could be added in the general section.

The advantage is that there are less top-level menu items and more
related topics grouped together.