### PR TITLE
Fix spelling of LinkBrowser

### DIFF
--- a/Documentation/ApiOverview/LinkBrowser/LinkBrowserApi/Index.rst
+++ b/Documentation/ApiOverview/LinkBrowser/LinkBrowserApi/Index.rst
@@ -4,7 +4,7 @@
 .. _linkbrowser-api:
 
 ===============
-Linkbrowser API
+LinkBrowser API
 ===============
 
 .. versionadded:: 7.6


### PR DESCRIPTION
LinkBrowser is a class name and should be spelled correctly in the title.

See: Spelling reference:

title:
> The first word is capitalized. All other words are spelled as they would be spelled elsewhere

> If a word has special spelling, e.g. a special TYPO3 word like TypoScript or an acronym like PHP,
this spelling is applied."

That goes for the title as well.

* https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/ContentStyleGuide.html#capitalization-rules-plain-text
* https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/ContentStyleGuide.html#rules-for-titles-section-headers