### PR TITLE
[BUGFIX] fix and extend FlexForm access access in Fluid

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -410,7 +410,8 @@ If you defined your :typoscript:`FLUIDTEMPLATE` in TypoScript, you can assign si
      } 
    }
 
-In order to have all FlexForm settings available, you can add a custom DataProcessor:
+In order to have all FlexForm fields available, you can add a custom DataProcessor. 
+This example would make your FlexForm data available as Fluid variable :html:`{flexform}`:
 
 .. code-block:: typoscript
 
@@ -456,12 +457,7 @@ In order to have all FlexForm settings available, you can add a custom DataProce
        }
    }
 
-.. code-block:: yaml
-   # Configuration/Services.yaml
-   services:
-     Your\Ext\DataProcessing\FlexFormProcessor:
-       autowire: true
-       autoconfigure: true
+You will need to setup the dependency injection with a :yaml:`autowire` directive. See :ref:`configure-dependency-injection-in-extensions`.
 
 
 Steps to Perform (Editor)

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -457,7 +457,8 @@ This example would make your FlexForm data available as Fluid variable :html:`{f
        }
    }
 
-You will need to setup the dependency injection with a :yaml:`autowire` directive. See :ref:`configure-dependency-injection-in-extensions`.
+.. seealso::
+   :ref:`configure-dependency-injection-in-extensions`.
 
 
 Steps to Perform (Editor)

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -430,28 +430,38 @@ In order to have all FlexForm settings available, you can add a custom DataProce
    
    class FlexFormProcessor implements DataProcessorInterface
    {
+       /**
+        * @var FlexFormService
+        */
+       protected $flexFormService;
+       
+       public function __construct(FlexFormService $flexFormService) {
+           $this->flexFormService = $flexFormService;
+       }
+       
        public function process(
            ContentObjectRenderer $cObj,
            array $contentObjectConfiguration,
            array $processorConfiguration,
            array $processedData
        ): array {
-           $flexFormService = GeneralUtility::makeInstance(FlexFormService::class); // or use Dependency Injection
-   
            $originalValue = $processedData['data']['pi_flexform'];
            if (!is_string($originalValue)) {
                return $processedData;
            }
    
-           $flexformData = $flexFormService->convertFlexFormContentToArray($originalValue);
+           $flexformData = $this->flexFormService->convertFlexFormContentToArray($originalValue);
            $processedData['flexform'] = $flexformData;
            return $processedData;
        }
    }
 
-
-
-
+.. code-block:: yaml
+   # Configuration/Services.yaml
+   services:
+     Your\Ext\DataProcessing\FlexFormProcessor:
+       autowire: true
+       autoconfigure: true
 
 
 Steps to Perform (Editor)

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -395,8 +395,63 @@ The key `flexform` is followed by the field which holds the Flexform data (`pi_f
 How to Access FlexForms From Fluid
 ----------------------------------
 
-Flexform settings can be read from within a Fluid template using
-:html:`{settings}`.
+If you are using an Extbase controller, FlexForm settings can be read from within a Fluid template using
+:html:`{settings}`. See the note on naming restrictions in :ref:`How to Read Flexforms From an Extbase Controller Action <_read-flexforms-extbase>`.
+
+If you defined your :typoscript:`FLUIDTEMPLATE` in TypoScript, you can assign single variables like that:
+
+.. code-block:: typoscript
+
+   my_content = FLUIDTEMPLATE
+   my_content {
+     variables {
+       categories = TEXT
+       categories.data = flexform: pi_flexform:categories
+     } 
+   }
+
+In order to have all FlexForm settings available, you can add a custom DataProcessor:
+
+.. code-block:: typoscript
+
+   my_content = FLUIDTEMPLATE
+   my_content {
+     dataProcessing {
+       10 = Your\Ext\DataProcessing\FlexFormProcessor
+     }
+   }
+
+.. code-block:: php
+   namespace Your\Ext\DataProcessing;
+   
+   use TYPO3\CMS\Core\Service\FlexFormService;
+   use TYPO3\CMS\Core\Utility\GeneralUtility;
+   use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+   
+   class FlexFormProcessor implements DataProcessorInterface
+   {
+       public function process(
+           ContentObjectRenderer $cObj,
+           array $contentObjectConfiguration,
+           array $processorConfiguration,
+           array $processedData
+       ): array {
+           $flexFormService = GeneralUtility::makeInstance(FlexFormService::class); // or use Dependency Injection
+   
+           $originalValue = $processedData['data']['pi_flexform'];
+           if (!is_string($originalValue)) {
+               return $processedData;
+           }
+   
+           $flexformData = $flexFormService->convertFlexFormContentToArray($originalValue);
+           $processedData['flexform'] = $flexformData;
+           return $processedData;
+       }
+   }
+
+
+
+
 
 
 Steps to Perform (Editor)


### PR DESCRIPTION
This adds examples for using FLUIDTEMPLATE.variables and a custom FlexForm DataProcessor

Let's keep an eye on https://review.typo3.org/c/Packages/TYPO3.CMS/+/62108 - if merged we don't need the custom thingie here.