### PR TITLE
[BUGFIX] Remove soft reference parser images

### DIFF
--- a/Documentation/ApiOverview/SoftReferences/Index.rst
+++ b/Documentation/ApiOverview/SoftReferences/Index.rst
@@ -58,22 +58,6 @@ notify
          Just report if a value is found, nothing more.
 
 
-
-.. _soft-references-default-parsers-images:
-
-images
-------
-
-.. container:: table-row
-
-   softref key
-         images
-
-   Description
-         HTML :code:`<img>` tags for RTE images / images from :file:`upload/`.
-
-
-
 .. _soft-references-default-parsers-typolink:
 
 typolink


### PR DESCRIPTION
Was already removed from array 'softRefParser', but still existed
as description.

Releases: master, 10.4