### PR TITLE
Use iconIdentifier for `registerModule` instead of icon

### DIFF
--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -47,6 +47,7 @@ using the following API:
         ]
     );
 
+.. index:: icon, iconIdentifier
 `'iconIdentifier'` versus `'icon'`
    `'iconIdentifier'` is the better and more modern way to go. It should always be used
    for core icons. Other icons however need to be registered first at the IconRegistry to

--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -47,6 +47,15 @@ using the following API:
         ]
     );
 
+`'iconIdentifier'` versus `'icon'`
+   `'iconIdentifier'` is the better and more modern way to go. It should always be used
+   for core icons. Other icons however need to be registered at the IconRegistry to
+   obtain an identifier for them. Note that - the easier to use - `'icon'` still works 
+   and may be used within custom packages. Example::
+   
+      'icon' => 'EXT:extkey/Resources/Public/Icons/smile.svg',
+   
+
 Here the module ``tx_Beuser`` is declared as a submodule of the already existing
 main module ``system``.
 

--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -40,7 +40,7 @@ using the following API:
         ],
         [
             'access' => 'admin',
-            'icon' => 'EXT:beuser/Resources/Public/Icons/module-beuser.svg',
+            'iconIdentifier' => 'module-beuser',
             'labels' => 'LLL:EXT:beuser/Resources/Private/Language/locallang_mod.xlf',
             'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
             'inheritNavigationComponentFromMainModule' => false,
@@ -79,7 +79,7 @@ Parameters:
      * ``user``: the module can be made accessible per user
      * ``group``: the module can be made accessible per usergroup
 
-   * Module ``icon``
+   * Module ``iconIdentifier``
    * A language file containing ``labels`` like the module title and description,
      for building the module menu and for the display of information in the
      **About Modules** module (found in the main help menu in the top bar).
@@ -107,7 +107,7 @@ Toplevel modules like "Web" or "File" are registered with the same API:
         [],
         [
             'access' => '...',
-            'icon' => '...',
+            'iconIdentifier' => '...',
             'labels' => '...',
         ]
     );

--- a/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
+++ b/Documentation/ApiOverview/BackendModules/BackendModuleApi/Index.rst
@@ -49,9 +49,9 @@ using the following API:
 
 `'iconIdentifier'` versus `'icon'`
    `'iconIdentifier'` is the better and more modern way to go. It should always be used
-   for core icons. Other icons however need to be registered at the IconRegistry to
-   obtain an identifier for them. Note that - the easier to use - `'icon'` still works 
-   and may be used within custom packages. Example::
+   for core icons. Other icons however need to be registered first at the IconRegistry to
+   create identifiers. Note that `'icon'` still works. Within custom packages it is easier
+   to use. Example::
    
       'icon' => 'EXT:extkey/Resources/Public/Icons/smile.svg',
    


### PR DESCRIPTION
Using the absolute icon path might break during TYPO3 Updates, if images are moved:
https://forge.typo3.org/issues/92689#note-13