### PR TITLE
Add note about deprecated Fluid pagination

### DIFF
--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -7,6 +7,12 @@
 Pagination
 ===============================
 
+.. note::
+
+   Pagination via Fluid widgets is deprecated, see
+   :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
+   Use the API documented here to implement your own pagination.
+
 The TYPO3 core provides an interface to implement the native pagination of lists like arrays or
 query results of Extbase.
 

--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -9,7 +9,7 @@ Pagination
 
 .. note::
 
-   Pagination via Fluid widgets is deprecated, see
+   Pagination via Fluid widgets was removed for `master` and follows this approach for `10.0`, see
    :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
    Use the API documented here to implement your own pagination.
 

--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -9,7 +9,7 @@ Pagination
 
 .. note::
 
-   Pagination via Fluid widgets was removed for `master` and follows this approach for `10.0`, see
+   Pagination via Fluid widgets was removed, see
    :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
    Use the API documented here to implement your own pagination.
 


### PR DESCRIPTION
Adds a note to the Pagination chapter in order to discourage the use of Fluid-based pagination, until its removal in TYPO3 11.