### PR TITLE
Add getContext method and description

### DIFF
--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -97,8 +97,8 @@ Returns the path and filename to the current PHP script.
 getContext()
 ------------
 
-Delivers an `ApplicationContext` object, usually defined in `TYPO3_CONTEXT` environment variables.
-May be one of "Production", "Testing", or "Development" or any additional information like "Production/Staging".
+Returns the current :ref:`application-context`, usually defined via the `TYPO3_CONTEXT` environment variable.
+May be one of `Production`, `Testing`, or `Development` with optional sub-contexts like `Production/Staging`.
 
 .. _Environment-configuring-paths:
 

--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -92,6 +92,14 @@ getCurrentScript()
 
 Returns the path and filename to the current PHP script.
 
+.. _Environment-context:
+
+getContext()
+------------
+
+Delivers an `ApplicationContext` object, usually defined in `TYPO3_CONTEXT` environment variables.
+May be one of "Production", "Testing", or "Development" or any additional information like "Production/Staging".
+
 .. _Environment-configuring-paths:
 
 Configuring Environment Paths


### PR DESCRIPTION
I suggest to add a description of the `getContext()` method. The text is inspired by the corresponding API description. While it exists in the API, it might be hard to find there without knowing the class.