### PR TITLE
Section database / dbal

### DIFF
--- a/Documentation/ApiOverview/Database/BasicCrud/Index.rst
+++ b/Documentation/ApiOverview/Database/BasicCrud/Index.rst
@@ -4,9 +4,9 @@
    Database; Create, read, update, and delete operations
 .. _database-basic-crud:
 
-==========
+========================================================
 Basic create, read, update, and delete operations (CRUD)
-==========
+========================================================
 
 A list of basic usage examples of the query API. This is just a kickstart.
 Details on the single methods are found in the following chapters, especially

--- a/Documentation/ApiOverview/Database/BasicCrud/Index.rst
+++ b/Documentation/ApiOverview/Database/BasicCrud/Index.rst
@@ -1,9 +1,11 @@
 .. include:: /Includes.rst.txt
-
+.. index::
+   Database; CRUD
+   Database; Create, read, update, and delete operations
 .. _database-basic-crud:
 
 ==========
-Basic CRUD
+Basic create, read, update, and delete operations (CRUD)
 ==========
 
 A list of basic usage examples of the query API. This is just a kickstart.
@@ -14,6 +16,7 @@ Details on the single methods are found in the following chapters, especially
 
     The examples use the shorthand syntax for class names. Please refer to :ref:`Class overview <database-class-overview>` for the full namespace.
 
+.. index:: Database; INSERT
 
 INSERT a Row
 ============
@@ -38,6 +41,8 @@ A straight insert to a table:
 
     INSERT INTO `tt_content` (`pid`, `bodytext`) VALUES ('42', 'bernd')
 
+
+.. index:: Database; SELECT
 
 SELECT a Single Row
 ===================
@@ -145,6 +150,7 @@ The executed query looks like:
         WHERE ((`bodytext` = 'klaus') OR (`uid` = 4))
             AND (`tt_content`.`deleted` = 0)
 
+.. index:: Database; UPDATE
 
 UPDATE Multiple Rows
 ====================

--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -1,12 +1,15 @@
 .. include:: /Includes.rst.txt
-
+.. index::
+   Doctrine; Configuration
+   File; typo3conf/LocalConfiguration.php
+   TYPO3_CONF_VARS; DB
 .. _database-configuration:
 
 =============
 Configuration
 =============
 
-Configuring `Doctrine DBAL` for `TYPO3 CMS` is all about specifying the single database endpoints
+Configuring the Doctrine DBAL for `TYPO3 CMS` is all about specifying the single database endpoints
 and handing over connection credentials. The framework supports the parallel usage of multiple
 database connections, a specific connection is mapped depending on its table name. The table space
 can be seen as a transparent layer that determines which specific connection is chosen for a query
@@ -46,7 +49,7 @@ Remarks:
   connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
   must be used as `host` value.
 
-* The connect options are hand over to `Doctrine DBAL` without much manipulation from `TYPO3 CMS` side.
+* The connect options are hand over to Doctrine DBAL without much manipulation from `TYPO3 CMS` side.
   Please refer to the
   `doctrine connection docs <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
   for a full overview of settings.
@@ -55,7 +58,7 @@ Remarks:
 
 * The option `wrapperClass` is used by TYPO3 to insert the extended
   :ref:`Connection <database-connection>` class :php:`TYPO3\CMS\Database\Connection` as main facade
-  around `Doctrine DBAL`.
+  around Doctrine DBAL.
 
 
 A slightly more complex example with two connections, mapping the `sys_log` table to a different endpoint::

--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -6,7 +6,7 @@
 Configuration
 =============
 
-Configuring `doctrine-dbal` for `TYPO3 CMS` is all about specifying the single database endpoints
+Configuring `Doctrine DBAL` for `TYPO3 CMS` is all about specifying the single database endpoints
 and handing over connection credentials. The framework supports the parallel usage of multiple
 database connections, a specific connection is mapped depending on its table name. The table space
 can be seen as a transparent layer that determines which specific connection is chosen for a query
@@ -46,7 +46,7 @@ Remarks:
   connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
   must be used as `host` value.
 
-* The connect options are hand over to `doctrine-dbal` without much manipulation from `TYPO3 CMS` side.
+* The connect options are hand over to `Doctrine DBAL` without much manipulation from `TYPO3 CMS` side.
   Please refer to the
   `doctrine connection docs <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
   for a full overview of settings.
@@ -55,7 +55,7 @@ Remarks:
 
 * The option `wrapperClass` is used by TYPO3 to insert the extended
   :ref:`Connection <database-connection>` class :php:`TYPO3\CMS\Database\Connection` as main facade
-  around `doctrine-dbal`.
+  around `Doctrine DBAL`.
 
 
 A slightly more complex example with two connections, mapping the `sys_log` table to a different endpoint::

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -10,7 +10,7 @@ An instance of class :php:`TYPO3\CMS\Core\Database\Connection` is retrieved from
 :ref:`ConnectionPool <database-connection-pool>` by calling `->getConnectionForTable()`
 and handing over the table name a query should executed on.
 
-The class extends the basic `doctrine-dbal` `Doctrine\DBAL\Connection` class and is mainly
+The class extends the basic `Doctrine DBAL` `Doctrine\DBAL\Connection` class and is mainly
 used internally within the `TYPO3 CMS` framework to establish, maintain and terminate
 connections to single database endpoints. Those internal methods are not scope of this
 documentation since an extension developer usually doesn't have to deal with that.

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -10,7 +10,7 @@ An instance of class :php:`TYPO3\CMS\Core\Database\Connection` is retrieved from
 :ref:`ConnectionPool <database-connection-pool>` by calling `->getConnectionForTable()`
 and handing over the table name a query should executed on.
 
-The class extends the basic `Doctrine DBAL` `Doctrine\DBAL\Connection` class and is mainly
+The class extends the basic Doctrine DBAL `Doctrine\DBAL\Connection` class and is mainly
 used internally within the `TYPO3 CMS` framework to establish, maintain and terminate
 connections to single database endpoints. Those internal methods are not scope of this
 documentation since an extension developer usually doesn't have to deal with that.

--- a/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
+++ b/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
@@ -6,7 +6,7 @@
 ConnectionPool
 ==============
 
-TYPO3's interface to execute queries via `doctrine-dbal` typically starts by asking
+TYPO3's interface to execute queries via `Doctrine DBAL` typically starts by asking
 the `ConnectionPool` for a `QueryBuilder` or a `Connection` object, handing over the table name to be queried::
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
+++ b/Documentation/ApiOverview/Database/ConnectionPool/Index.rst
@@ -6,7 +6,7 @@
 ConnectionPool
 ==============
 
-TYPO3's interface to execute queries via `Doctrine DBAL` typically starts by asking
+TYPO3's interface to execute queries via Doctrine DBAL typically starts by asking
 the `ConnectionPool` for a `QueryBuilder` or a `Connection` object, handing over the table name to be queried::
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -63,7 +63,7 @@ There are certain requirements for such managed tables:
    consistency it is recommended to name them that way.
 
 
-.. index:: Tables; Pages
+.. index:: Tables; pages
 .. _database-structure-pages:
 
 The "pages" table

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -1,6 +1,7 @@
 .. include:: /Includes.rst.txt
-
-
+.. index::
+   Database; Structure
+   Tables
 .. _database-structure:
 .. _database-structure-requirements:
 
@@ -14,7 +15,7 @@ rough categories:
 - Tables that are used by the system internally and are invisible to backend
   users (eg. `be_sessions`, `sys_registry`, cache related tables). There are
   often dedicated PHP API's in the core extension to manage entries of these
-  tables, for instance the :ref:`Cache framework API <caching>`.
+  tables, for instance the :ref:`Caching framework API <caching>`.
 
 - Tables that can be managed via the TYPO3 CMS backend, are shown in the List
   module and can be edited using :ref:`FormEngine <FormEngine>`.
@@ -62,9 +63,10 @@ There are certain requirements for such managed tables:
    consistency it is recommended to name them that way.
 
 
+.. index:: Tables; Pages
 .. _database-structure-pages:
 
-The "pages" Table
+The "pages" table
 =================
 
 The `pages` table has a special status: It is the backbone of TYPO3 CMS, as it provides
@@ -84,7 +86,10 @@ a row in the `pages` table, only admin-users can access records on it and these 
 to be :ref:`explicitly configured to reside in the root page <t3tca:ctrl-reference-rootlevel>` - usually
 table records may only be created on a real page.
 
-
+.. index::
+   Tables; MM relations
+   Tables; Cache
+   Tables; System information
 .. _database-structure-other-tables:
 
 Other Tables
@@ -102,10 +107,10 @@ roles. Some of the most common are:
   because it does actually appear in the backend, although only
   as part of :ref:`inline records <t3tca:columns-inline>`.
 
-- cache: when a cache is defined as using the database as a cache backend,
+- Cache: when a cache is defined as using the database as a cache backend,
   TYPO3 CMS will automatically create and manage the relevant cache tables.
 
-- system information: there exist tables storing information about sessions,
+- System information: there exist tables storing information about sessions,
   both frontend and backend ("fe\_sessions" and "be\_sessions" respectively),
   a table for a central registry ("sys\_registry") and quite a few others.
 

--- a/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
@@ -55,7 +55,7 @@ the :ref:`Installation and Upgrade Guide <t3install:upgrade>`.
 
 .. index::
    File; EXT:{extkey}/ext_tables.sql
-   Database; CREATE TABLE statement
+   Database; CREATE TABLE
 .. _database-exttables-sql:
 
 The ext\_tables.sql files

--- a/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
@@ -1,23 +1,22 @@
 .. include:: /Includes.rst.txt
-
-
+.. index:: Database; Upgrade
 .. _database-upgrade:
 
 ===================================
-Upgrade Table and Field Definitions
+Upgrade table and field definitions
 ===================================
 
 Each extension in TYPO3 CMS can bring the file :file:`ext_tables.sql` that
 defines which tables and fields the extension needs. Gathering all
 :file:`ext_tables.sql` thus defines the full set of tables, fields and
 indexes of a TYPO3 instance to unfold its full feature set. Some functionality
-in the Install Tool can compare the defined set with the current active
+in the install tool can compare the defined set with the current active
 database schema and shows options to align those two by adding fields,
 removing fields and so on.
 
-When you upgrade to newer versions of TYPO3 CMS or upgrade an extension,
+When you upgrade to newer versions of the TYPO3 CMS or upgrade an extension,
 the data definition of tables and fields might have changed.
-The TYPO3 CMS Install Tool will detect such changes.
+The TYPO3 CMS install tool will detect such changes.
 
 When you install a new extension, any change to the database
 is automatically performed. When you upgrade to a new major
@@ -28,7 +27,7 @@ changes:
 .. figure:: ../../../Images/DatabaseUpgradeWizard.png
    :alt: The Upgrade Wizard indicating that the database needs updates
 
-   The Upgrade Wizard indicating that the database needs updates
+   The upgrade wizard indicating that the database needs updates
 
 
 When performing smaller updates, after updating extensions or - in
@@ -36,9 +35,9 @@ general - if you want to check the sanity of your system,
 you can go to **ADMIN TOOLS > Maintenance > Analyze Database Structure**:
 
 .. figure:: ../../../Images/DatabaseDatabaseAnalyzer.png
-   :alt: Analyze Database Structure of the Install Tool
+   :alt: Analyze database structure of the install tool
 
-   The Database analyzer is part of the Maintenance area
+   The Database analyzer is part of the maintenance area
 
 
 What this tool does is collating the information from all
@@ -54,10 +53,12 @@ very likely break your installation.
 More information about the process of upgrading TYPO3 CMS can be found in
 the :ref:`Installation and Upgrade Guide <t3install:upgrade>`.
 
-
+.. index::
+   File; EXT:{extkey}/ext_tables.sql
+   Database; CREATE TABLE statement
 .. _database-exttables-sql:
 
-The ext\_tables.sql Files
+The ext\_tables.sql files
 =========================
 
 As mentioned before, all data definition statements are stored in

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -12,7 +12,7 @@ for `WHERE` and `JOIN ON` conditions, functions like :php:`->min()` may also be 
 
 It takes care of building query conditions while ensuring table and column names
 are quoted within the created expressions / SQL fragments. It is a facade to
-the actual `doctrine-dbal` `ExpressionBuilder`.
+the actual `Doctrine DBAL` `ExpressionBuilder`.
 
 The `ExpressionBuilder` is used within the context of the :ref:`QueryBuilder <database-query-builder>`
 to ensure queries are being build based on the requirements of the database platform in use.

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -12,7 +12,7 @@ for `WHERE` and `JOIN ON` conditions, functions like :php:`->min()` may also be 
 
 It takes care of building query conditions while ensuring table and column names
 are quoted within the created expressions / SQL fragments. It is a facade to
-the actual `Doctrine DBAL` `ExpressionBuilder`.
+the actual Doctrine DBAL `ExpressionBuilder`.
 
 The `ExpressionBuilder` is used within the context of the :ref:`QueryBuilder <database-query-builder>`
 to ensure queries are being build based on the requirements of the database platform in use.

--- a/Documentation/ApiOverview/Database/Index.rst
+++ b/Documentation/ApiOverview/Database/Index.rst
@@ -1,9 +1,9 @@
 .. include:: /Includes.rst.txt
-
+.. index:: ! Database
 .. _database:
 
 ========================
-Database (doctrine-dbal)
+Database (Doctrine DBAL)
 ========================
 
 **Contents:**

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -1,11 +1,18 @@
 .. include:: /Includes.rst.txt
+.. index::
+   Relational database management system
+   see: RDBMS; Relational database management system
+   MySQL
+   MariaDB
+   PostgreSQL
+   SQLServer
 .. _Database_Introduction:
 
 ============
 Introduction
 ============
 
-TYPO3 CMS relies on storing its data in a Relational database management
+TYPO3 CMS relies on storing its data in a relational database management
 system (RDBMS). The Doctrine DBAL component is used to enable connecting to
 different database management systems. Most used is still MySQL / MariaDB, but
 thanks to Doctrine others like PostgreSQL and SQLServer are also an option.
@@ -21,10 +28,12 @@ by some information on upgrading and maintaining table and field consistency, an
 deep dives into the programming API.
 
 .. index::
-   Doctrine
+   ! Doctrine
+   Doctrine; DBAL
    Database; Abstraction layer
    Database; DBAL
    $GLOBALS; TYPO3_DB
+   DBMS
 
 Doctrine DBAL
 =============
@@ -43,16 +52,16 @@ queries created with this API are translated to the specific database engine by
 doctrine without an extension developer taking care of that specifically.
 
 The API provided by the core is basically a pretty small and lightweight facade
-in front of `Doctrine DBAL` that adds some convenient methods as well as some
+in front of Doctrine DBAL that adds some convenient methods as well as some
 `TYPO3 CMS` specific sugar. The facade additionally provides methods to retrieve
 specific connection objects per configured database connection based on the table
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.
 
-`Doctrine DBAL` has been introduced with TYPO3 CMS version 8 and substitutes the
+Doctrine DBAL has been introduced with TYPO3 CMS version 8 and substitutes the
 old API based on :php:`$GLOBALS['TYPO3_DB']`. Extension authors are encouraged to switch
 away from TYPO3_DB to the new API. A :ref:`dedicated chapter <database-migration>` helps
-with typical migration questions. With database abstraction being built in `Doctrine DBAL`
+with typical migration questions. With database abstraction being built in Doctrine DBAL
 the old and optional extensions `dbal` and `adodb` are obsolete.
 
 This document does *not* outline each and every single method the API provides. It
@@ -60,25 +69,29 @@ sticks to those that are commonly used in extensions and some parts like the rew
 schema migrator are left out since they are usually of little to no interest for
 extensions.
 
+.. index:: Doctrine; ORM
 
 Understanding Doctrine DBAL and Doctrine ORM
 ============================================
 
 Doctrine is a two-fold project with `Doctrine DBAL <http://www.doctrine-project.org/projects/dbal.html>`__
 being the low-level database abstraction and query building interface to specific database engines, while
-`doctrine-orm <http://www.doctrine-project.org/projects/orm.html>`__
-is a high-level object relational mapping on top of `Doctrine DBAL`.
+`Doctrine ORM <http://www.doctrine-project.org/projects/orm.html>`__
+is a high-level object relational mapping on top of Doctrine DBAL.
 
-The TYPO3 CMS core - only - implements the dbal part. `doctrine-orm` is neither required nor
+The TYPO3 CMS core - only - implements the dbal part. `Doctrine ORM` is neither required nor
 implemented nor used at the time of this writing.
 
+.. index::
+   Database;  Low-level calls
+   DataHandler
 
-Low-level and High-Level Database Calls
+Low-level and high-level database calls
 =======================================
 
 This documentation is about low-level database calls. In many cases it is better
 to use higher level API's like the :ref:`DataHandler <tce-database-basics>` or
-:ref:`extbase repositories <t3extbasebook:persistence>`
+:ref:`Extbase repositories <t3extbasebook:persistence>`
 and to let the framework handle persistence details internally.
 
 .. tip::
@@ -89,7 +102,7 @@ and to let the framework handle persistence details internally.
 Credits
 =======
 
-Implementing the `Doctrine DBAL` API into `TYPO3` has been a *huge project in 2016.*
+Implementing the Doctrine DBAL API into `TYPO3` has been a *huge project in 2016.*
 Special thanks goes to awesome Mr. **Morton Jonuschat** for the initial design, integration
 and support and to more than **40 different people** who actively contributed to migrate
 more than 1700 calls from `TYPO3_DB`-style to Doctrine within half a year.

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -1,5 +1,4 @@
 .. include:: /Includes.rst.txt
-
 .. _Database_Introduction:
 
 ============
@@ -7,7 +6,7 @@ Introduction
 ============
 
 TYPO3 CMS relies on storing its data in a Relational database management
-system (RDBMS). The doctrine-dbal component is used to enable connecting to
+system (RDBMS). The Doctrine DBAL component is used to enable connecting to
 different database management systems. Most used is still MySQL / MariaDB, but
 thanks to Doctrine others like PostgreSQL and SQLServer are also an option.
 
@@ -21,34 +20,39 @@ This chapter gives an overview of the basic TYPO3 database table structure, foll
 by some information on upgrading and maintaining table and field consistency, and then
 deep dives into the programming API.
 
+.. index::
+   Doctrine
+   Database; Abstraction layer
+   Database; DBAL
+   $GLOBALS; TYPO3_DB
 
-Doctrine-Dbal
+Doctrine DBAL
 =============
 
 Database queries in TYPO3 are done with an API based on
-`doctrine-dbal <http://www.doctrine-project.org/projects/dbal.html>`__.
+`Doctrine DBAL <http://www.doctrine-project.org/projects/dbal.html>`__.
 The API is provided by the system extension `core` which is always loaded and
 thus always available.
 
 Extension authors can use this low-level `API` to manage query operations
 directly on the configured `DBMS`.
 
-Doctrine-dbal is feature rich. Drivers for various target systems enable
+Doctrine DBAL is feature rich. Drivers for various target systems enable
 TYPO3 to run on a long list of `ANSI SQL` compatible `DBMS`. If used properly,
 queries created with this API are translated to the specific database engine by
 doctrine without an extension developer taking care of that specifically.
 
 The API provided by the core is basically a pretty small and lightweight facade
-in front of `doctrine-dbal` that adds some convenient methods as well as some
+in front of `Doctrine DBAL` that adds some convenient methods as well as some
 `TYPO3 CMS` specific sugar. The facade additionally provides methods to retrieve
 specific connection objects per configured database connection based on the table
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.
 
-`doctrine-dbal` has been introduced with TYPO3 CMS version 8 and substitutes the
+`Doctrine DBAL` has been introduced with TYPO3 CMS version 8 and substitutes the
 old API based on :php:`$GLOBALS['TYPO3_DB']`. Extension authors are encouraged to switch
 away from TYPO3_DB to the new API. A :ref:`dedicated chapter <database-migration>` helps
-with typical migration questions. With database abstraction being built in `doctrine-dbal`
+with typical migration questions. With database abstraction being built in `Doctrine DBAL`
 the old and optional extensions `dbal` and `adodb` are obsolete.
 
 This document does *not* outline each and every single method the API provides. It
@@ -57,13 +61,13 @@ schema migrator are left out since they are usually of little to no interest for
 extensions.
 
 
-Understanding Doctrine-Dbal and Doctrine-Orm
+Understanding Doctrine DBAL and Doctrine ORM
 ============================================
 
-Doctrine is a two-fold project with `doctrine-dbal <http://www.doctrine-project.org/projects/dbal.html>`__
+Doctrine is a two-fold project with `Doctrine DBAL <http://www.doctrine-project.org/projects/dbal.html>`__
 being the low-level database abstraction and query building interface to specific database engines, while
 `doctrine-orm <http://www.doctrine-project.org/projects/orm.html>`__
-is a high-level object relational mapping on top of `doctrine-dbal`.
+is a high-level object relational mapping on top of `Doctrine DBAL`.
 
 The TYPO3 CMS core - only - implements the dbal part. `doctrine-orm` is neither required nor
 implemented nor used at the time of this writing.
@@ -85,7 +89,7 @@ and to let the framework handle persistence details internally.
 Credits
 =======
 
-Implementing the `doctrine-dbal` API into `TYPO3` has been a *huge project in 2016.*
+Implementing the `Doctrine DBAL` API into `TYPO3` has been a *huge project in 2016.*
 Special thanks goes to awesome Mr. **Morton Jonuschat** for the initial design, integration
 and support and to more than **40 different people** who actively contributed to migrate
 more than 1700 calls from `TYPO3_DB`-style to Doctrine within half a year.

--- a/Documentation/ApiOverview/Database/Migration/Index.rst
+++ b/Documentation/ApiOverview/Database/Migration/Index.rst
@@ -7,7 +7,7 @@ Migrating from TYPO3_DB
 =======================
 
 This chapter is for those poor souls who want to migrate old and busted :php:`$GLOBALS['TYPO3_DB']`
-calls to new hotness `doctrine-dbal` based API.
+calls to new hotness `Doctrine DBAL` based API.
 
 It tries to give some hints on typical pitfalls and areas a special eye should be kept on.
 

--- a/Documentation/ApiOverview/Database/Migration/Index.rst
+++ b/Documentation/ApiOverview/Database/Migration/Index.rst
@@ -7,7 +7,7 @@ Migrating from TYPO3_DB
 =======================
 
 This chapter is for those poor souls who want to migrate old and busted :php:`$GLOBALS['TYPO3_DB']`
-calls to new hotness `Doctrine DBAL` based API.
+calls to new hotness Doctrine DBAL based API.
 
 It tries to give some hints on typical pitfalls and areas a special eye should be kept on.
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -629,7 +629,7 @@ Remarks:
 * It's allowed to call :php:`->setMaxResults()` but not to call :php:`->setFirstResult()`.
 
 * It is possible to call :php:`->setFirstResult()` without calling :php:`setMaxResults()`: This equals to "Fetch everything, but
-  leave out the first n records". Internally, `LIMIT` will be added by `doctrine-dbal` and set to a very high value.
+  leave out the first n records". Internally, `LIMIT` will be added by `Doctrine DBAL` and set to a very high value.
 
 
 .. _database-query-builder-add:
@@ -684,7 +684,7 @@ Remarks:
 
 * The method is a simple way to see which restrictions the `RestrictionBuilder` added.
 
-* `doctrine-dbal` always creates prepared statements: Any value that is added via :php:`->createNamedParameter()` creates
+* `Doctrine DBAL` always creates prepared statements: Any value that is added via :php:`->createNamedParameter()` creates
   a placeholder that is later substituted when the real query is fired via :php:`->execute()`. :php:`->getSQL()` does not show
   those values, instead the placeholder names are displayed, usually with a string like `:dcValue1`. There is no
   simple solution to show the fully replaced query from within the framework, but you can go for :php:`->getParameters()` to see the
@@ -711,7 +711,7 @@ Remarks:
 
 * The method is typically called directly before :php:`->execute()` to output the final values for the statement.
 
-* `doctrine-dbal` always creates prepared statements: Any value that added via :php:`->createNamedParameter()` creates
+* `Doctrine DBAL` always creates prepared statements: Any value that added via :php:`->createNamedParameter()` creates
   a placeholder that is later substituted when the real query is fired via :php:`->execute()`. :php:`->getparameters()` does not show
   the statement or those placeholders, instead the values are displayed, usually within an array using keys like `:dcValue1`. There is no simple solution to show the fully replaced query from within the framework, but you can go for :php:`->getSQL()` to see the string with placeholders used as a prepared statement.
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -629,7 +629,7 @@ Remarks:
 * It's allowed to call :php:`->setMaxResults()` but not to call :php:`->setFirstResult()`.
 
 * It is possible to call :php:`->setFirstResult()` without calling :php:`setMaxResults()`: This equals to "Fetch everything, but
-  leave out the first n records". Internally, `LIMIT` will be added by `Doctrine DBAL` and set to a very high value.
+  leave out the first n records". Internally, `LIMIT` will be added by Doctrine DBAL and set to a very high value.
 
 
 .. _database-query-builder-add:
@@ -684,7 +684,7 @@ Remarks:
 
 * The method is a simple way to see which restrictions the `RestrictionBuilder` added.
 
-* `Doctrine DBAL` always creates prepared statements: Any value that is added via :php:`->createNamedParameter()` creates
+* Doctrine DBAL always creates prepared statements: Any value that is added via :php:`->createNamedParameter()` creates
   a placeholder that is later substituted when the real query is fired via :php:`->execute()`. :php:`->getSQL()` does not show
   those values, instead the placeholder names are displayed, usually with a string like `:dcValue1`. There is no
   simple solution to show the fully replaced query from within the framework, but you can go for :php:`->getParameters()` to see the
@@ -711,7 +711,7 @@ Remarks:
 
 * The method is typically called directly before :php:`->execute()` to output the final values for the statement.
 
-* `Doctrine DBAL` always creates prepared statements: Any value that added via :php:`->createNamedParameter()` creates
+* Doctrine DBAL always creates prepared statements: Any value that added via :php:`->createNamedParameter()` creates
   a placeholder that is later substituted when the real query is fired via :php:`->execute()`. :php:`->getparameters()` does not show
   the statement or those placeholders, instead the values are displayed, usually within an array using keys like `:dcValue1`. There is no simple solution to show the fully replaced query from within the framework, but you can go for :php:`->getSQL()` to see the string with placeholders used as a prepared statement.
 

--- a/Documentation/ApiOverview/Database/QueryHelper/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryHelper/Index.rst
@@ -16,7 +16,7 @@ The whole class is marked as `@internal`, **should not be used by extension
 authors** and may - if things go wrong - change at will. The class will hopefully
 vanish mid-term. However, there may be situations when the class methods can become
 handy if extension authors :ref:`migrate <database-migration>` their own extensions away
-from `TYPO3_DB` to `doctrine-dbal`. In practice, the core will *most likely* add proper
+from `TYPO3_DB` to `Doctrine DBAL`. In practice, the core will *most likely* add proper
 deprecations to single methods if they are target of removal later.
 
 Extension developers may keep this class in mind for migration, but **must not** use
@@ -107,7 +107,7 @@ stripLogicalOperatorPrefix()
 
 Removes the prefixes `AND` / `OR` from an input string.
 
-Those prefixes are added in `doctrine-dbal` via :php:`QueryBuilder->where()`, :php:`QueryBuilder->orWhere()`,
+Those prefixes are added in `Doctrine DBAL` via :php:`QueryBuilder->where()`, :php:`QueryBuilder->orWhere()`,
 :php:`ExpressionBuilder->andX()` and friends. Some parts of the `TYPO3` framework however carry SQL fragments
 prefixed with `AND` or `OR` around and it's not always possible to easily get rid of those. The method
 helps by killing those prefixes before they are handed over to the `doctrine` API::

--- a/Documentation/ApiOverview/Database/QueryHelper/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryHelper/Index.rst
@@ -16,7 +16,7 @@ The whole class is marked as `@internal`, **should not be used by extension
 authors** and may - if things go wrong - change at will. The class will hopefully
 vanish mid-term. However, there may be situations when the class methods can become
 handy if extension authors :ref:`migrate <database-migration>` their own extensions away
-from `TYPO3_DB` to `Doctrine DBAL`. In practice, the core will *most likely* add proper
+from `TYPO3_DB` to Doctrine DBAL. In practice, the core will *most likely* add proper
 deprecations to single methods if they are target of removal later.
 
 Extension developers may keep this class in mind for migration, but **must not** use
@@ -107,7 +107,7 @@ stripLogicalOperatorPrefix()
 
 Removes the prefixes `AND` / `OR` from an input string.
 
-Those prefixes are added in `Doctrine DBAL` via :php:`QueryBuilder->where()`, :php:`QueryBuilder->orWhere()`,
+Those prefixes are added in Doctrine DBAL via :php:`QueryBuilder->where()`, :php:`QueryBuilder->orWhere()`,
 :php:`ExpressionBuilder->andX()` and friends. Some parts of the `TYPO3` framework however carry SQL fragments
 prefixed with `AND` or `OR` around and it's not always possible to easily get rid of those. The method
 helps by killing those prefixes before they are handed over to the `doctrine` API::

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -24,7 +24,7 @@ dealing with low-level query stuff must take care overlayed or deleted rows
 are not in the result set of a casual query.
 
 This is where this "automatic restriction" stuff kicks in: The construct is created
-on top of native `Doctrine DBAL` as `TYPO3 CMS` specific extension. It automatically
+on top of native Doctrine DBAL as `TYPO3 CMS` specific extension. It automatically
 adds `WHERE` expressions that suppress rows which are marked as deleted or exceeded
 their "active" life cycle. All that is based on the `TCA` configuration of the affected table.
 

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -24,7 +24,7 @@ dealing with low-level query stuff must take care overlayed or deleted rows
 are not in the result set of a casual query.
 
 This is where this "automatic restriction" stuff kicks in: The construct is created
-on top of native `doctrine-dbal` as `TYPO3 CMS` specific extension. It automatically
+on top of native `Doctrine DBAL` as `TYPO3 CMS` specific extension. It automatically
 adds `WHERE` expressions that suppress rows which are marked as deleted or exceeded
 their "active" life cycle. All that is based on the `TCA` configuration of the affected table.
 

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -1,5 +1,7 @@
 .. include:: /Includes.rst.txt
-
+.. index::
+   Database; Statement
+   QueryBuilder
 .. _database-statement:
 
 =========

--- a/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
+++ b/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
@@ -27,7 +27,7 @@ Various Tips and Tricks
      debug($queryBuilder->getSql());
      $statement = $queryBuilder->execute();
 
-* In contrast to the old API based on :php:`$GLOBALS['TYPO3_DB']`, `doctrine-dbal` will throw exceptions
+* In contrast to the old API based on :php:`$GLOBALS['TYPO3_DB']`, `Doctrine DBAL` will throw exceptions
   if something goes wrong when calling :php:`execute()`. The exception type is a :php:`\Doctrine\DBAL\DBALException`
   which can be caught and transferred to a better error message if the application has to expect
   query errors. Note this is not good habit and often indicates an architectural flaw of the application

--- a/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
+++ b/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
@@ -27,7 +27,7 @@ Various Tips and Tricks
      debug($queryBuilder->getSql());
      $statement = $queryBuilder->execute();
 
-* In contrast to the old API based on :php:`$GLOBALS['TYPO3_DB']`, `Doctrine DBAL` will throw exceptions
+* In contrast to the old API based on :php:`$GLOBALS['TYPO3_DB']`, Doctrine DBAL will throw exceptions
   if something goes wrong when calling :php:`execute()`. The exception type is a :php:`\Doctrine\DBAL\DBALException`
   which can be caught and transferred to a better error message if the application has to expect
   query errors. Note this is not good habit and often indicates an architectural flaw of the application


### PR DESCRIPTION
Added indices, updated wording.
Rename doctrine-dbal Doctrine DBAL

Doctrine writes itself always in capitals, DBAL in uppercase. See https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/