### PR TITLE
Add warning not to add defined('TYPO3') or die() to this file

### DIFF
--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -49,6 +49,8 @@ $_EXTKEY is set globally and contains the extension key.
 .. important::
    Due to limitations to the TER (`TYPO3 Extension Repository <https://extensions.typo3.org>`__),
    `$_EXTKEY` should be used here and **not** a constant or a string.
+   
+   Do not use :php:`defined('TYPO3') or die();` in this file.
 
 
 .. t3-field-list-table::


### PR DESCRIPTION
In the files ext_localconf.php and ext_tables.php it is customary
to add the following line:

defined('TYPO3') or die();

This MUST NOT be added to this file or things may fail
bad.y.