### PR TITLE
Fix changelog link

### DIFF
--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -9,7 +9,7 @@ Pagination
 .. note::
 
    Pagination via Fluid widgets was removed, see
-   :doc:`t3core:Changelog/master/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
+   :doc:`t3core:Changelog/11.0/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
    Use the API documented here to implement your own pagination.
 
 The TYPO3 Core provides an interface to implement the native pagination of lists like arrays or


### PR DESCRIPTION
Since the 11.0 changelog was moved from "master" to "11.0", this link was no longer working.

Releases: master, 10.4