### PR TITLE
Remove fileadmin _migrated section

### DIFF
--- a/Documentation/ApiOverview/Fal/Architecture/Folders.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Folders.rst
@@ -31,24 +31,4 @@ It may even point to a different storage.
 .. figure:: ../Images/ArchitectureFoldersProcessedFolder.png
    :alt: Defining a location for processed files
 
-   Editing a File storage to define a location for processed files
-
-
-.. index:: File abstraction layer; Migrated files
-.. _fal-architecture-folders-migrated-files:
-
-Migrated files
-==============
-
-When upgrading from a pre-FAL installation (i.e. a TYPO3 CMS version
-older than 6.0), files will have been moved from various locations
-(but generally the :file:`uploads` folder and its sub-folders) to
-a folder named :file:`_migrated` in the default Storage (or other
-Storages if you had several). Such a folder may also be used by
-custom processes provided by extensions.
-
-This folder contains active files from your older TYPO3 CMS
-installation. It should not be deleted unless you are sure that
-you are not using any of these files anymore. It would be advisable
-to move all files out of this folder over time and into a more
-explicit structure.
+   Editing a file storage to define a location for processed files


### PR DESCRIPTION
This folder only exists from Pre-LTS6 migrations

closes #1075