### PR TITLE
Adjust site_identifier naming conventions

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/Basics.rst
+++ b/Documentation/ApiOverview/SiteHandling/Basics.rst
@@ -131,7 +131,7 @@ site identifier
 ---------------
 
 The site identifier is the name of the folder within `<project-root>/config/sites/` that will hold your configuration file(s). When
-choosing an identifier make sure to stick to ASCII but you may also use `-`, `_` and `.` for convenience.
+choosing an identifier make sure to stick to ASCII but you may also use `-` and `_` for convenience.
 
 
 rootPageId


### PR DESCRIPTION
When manually adding a folder in @config/sites@ the "." works but when using the site module, the "." will not be accepted as part of the identifier. Additionally the help text in the module itself states: "Mind the recommendations for directory names (only a-z,0-9,_,-)".