### PR TITLE
Do not use Command::SUCCESS in version 9.5 and 10.4

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -99,7 +99,7 @@ Example taken from :php:`ListSysLogCommand` in the core and simplified::
 
             // ...
             $io->writeln('Write something');
-            return Command::SUCCESS;
+            return 0;
         }
     }
 


### PR DESCRIPTION
TYPO3 9.5 uses "symfony/console" ^4.1 which
does not include Command::SUCCESS.

execute() should return 0 if everything is fine.

Releases: 9.5, 10.4