### PR TITLE
Fix index entry

### DIFF
--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-.. index:: TypoScript; Conditions!
+.. index:: ! TypoScript; Conditions
 .. _typoscript-syntax-conditions:
 
 ==========


### PR DESCRIPTION

Possible: `! TypoScript; Conditions`, not possible: `TypoScript; ! Conditions` (tested).

The proposed change works and will give
![269](https://user-images.githubusercontent.com/307057/103789721-9dc51500-5040-11eb-8741-e32850914fb5.png)
