### PR TITLE
topic shall not start with "within"

### DIFF
--- a/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
+++ b/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
@@ -17,10 +17,10 @@ extended:
 
 
 .. index:: pair: Symfony expression language; TypoScript
-.. _sel-symfony-typoscript-conditions:
+.. _sel-within-typoscript-conditions:
 
-Symfony TypoScript conditions
-============================
+Symfony within TypoScript conditions
+====================================
 
 In order to provide custom conditions, its essential to understand how
 conditions are written. Refer to :ref:`typoscript-syntax-conditions-syntax` if

--- a/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
+++ b/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
@@ -17,9 +17,9 @@ extended:
 
 
 .. index:: pair: Symfony expression language; TypoScript
-.. _sel-within-typoscript-conditions:
+.. _sel-symfony-typoscript-conditions:
 
-Within TypoScript conditions
+Symfony TypoScript conditions
 ============================
 
 In order to provide custom conditions, its essential to understand how

--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -270,7 +270,7 @@ Custom conditions with the Symfony expression language
 ======================================================
 
 Further information about how to extend TypoScript with your own custom
-conditions can be found within :ref:`sel-within-typoscript-conditions`.
+conditions can be found within :ref:`sel-typoscript-conditions`.
 
 
 .. _typoscript-syntax-conditions-examples:
@@ -282,7 +282,7 @@ Variables and functions
 -----------------------
 
 For a detailed list of the available objects and functions refer to the
-:ref:`the TypoScript Reference <t3tsref:conditions>`.
+:ref:`TypoScript Reference <t3tsref:conditions>`.
 
 Variables::
 

--- a/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Syntax/Conditions.rst
@@ -270,7 +270,7 @@ Custom conditions with the Symfony expression language
 ======================================================
 
 Further information about how to extend TypoScript with your own custom
-conditions can be found within :ref:`sel-typoscript-conditions`.
+conditions can be found at :ref:`sel-within-typoscript-conditions`.
 
 
 .. _typoscript-syntax-conditions-examples:


### PR DESCRIPTION
The original topic which gets referenced shall contain all main nouns. And it shall always start with a noun and not a preposition. Otherwise the sentence of the reference can have duplicate words as "within within" in this case.
