### PR TITLE
Correction of keyword

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -212,9 +212,9 @@ make sure the paths are setup as described in :ref:`mail-configuration-fluid`:
 
 .. code-block:: php
 
-   use Symfony\Component\Mailer\Mailer;
    use Symfony\Component\Mime\Address;
    use TYPO3\CMS\Core\Mail\FluidEmail;
+   use TYPO3\CMS\Core\Mail\Mailer;
 
    $email = GeneralUtility::makeInstance(FluidEmail::class);
    $email


### PR DESCRIPTION
In the section "Send email with FluidEmail"

This keyword is wrong: use Symfony\Component\Mailer\Mailer;
This keyword is correct : use TYPO3\CMS\Core\Mail\Mailer;