### PR TITLE
[BUGFIX] Use ResourceFactory for retrieving default storage

### DIFF
--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -54,8 +54,8 @@ Copying a file
    $someFileIdentifier = 'templates/images/banner.jpg';
    $someFolderIdentifier = 'website/images/';
 
-   $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\StorageRepository::class);
-   $storage = $storageRepository->getStorageObject($storageUid);
+   $resourceFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
+   $storage = $resourceFactory->getStorageObject($storageUid);
 
    // $file returns a TYPO3\CMS\Core\Resource\File object
    $file = $storage->getFile($someFileIdentifier);

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -74,8 +74,8 @@ Adding a file
 This example adds a new file in the root folder of the default
 storage::
 
-   $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\StorageRepository::class);
-   $storage = $storageRepository->getDefaultStorage();
+   $resourceFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
+   $storage = $resourceFactory->getDefaultStorage();
    $newFile = $storage->addFile(
          '/tmp/temporary_file_name.ext',
          $storage->getRootLevelFolder(),


### PR DESCRIPTION
The default storage can be retrieved only from the ResourceFactory, not from the StorageRepository