### PR TITLE
Fix typo in "RIGHT OUTER JOIN"

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -535,7 +535,7 @@ Further remarks:
 
 * :php:`->leftJoin()` creates a `LEFT JOIN` query, this is identical to a `LEFT OUTER JOIN` query.
 
-* :php:`->rightJoin()` creates a `RIGHT JOIN` query, this is identical to a `RIGT OUTER JOIN` query.
+* :php:`->rightJoin()` creates a `RIGHT JOIN` query, this is identical to a `RIGHT OUTER JOIN` query.
 
 * Calls on join() methods are only considered for :php:`->select()` and :php:`->count()` type queries. :php:`->delete()`, :php:`->insert()`
   and :php:`update()` do not support joins, those query parts are ignored and do not end up in the final statement.


### PR DESCRIPTION
Releases: master, 10.4, 9.5, 8.7