### PR TITLE
The php command is not working.

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling.rst
@@ -40,8 +40,8 @@ errorCode
     int
 
 :aspect:`Description`
-    The HTTP (Error) Status Code to handle. The predefined list contains the most common errors,
-    a free definition of other error codes is also possible. Special value `0` will take care of
+    The HTTP (Error) Status Code to handle. The predefined list contains the most common errors.
+    A free definition of other error codes is also possible. The special value `0` will take care of
     all errors.
 
 :aspect:`Example`
@@ -69,7 +69,7 @@ errorFluidTemplate
     string
 
 :aspect:`Description`
-    **Only if errorHandler == `fluid`**: Path to fluid template file. Path may be
+    **Only if errorHandler is of type Fluid**: Path to fluid template file. Path may be
 
     * absolute
     * relative to site root
@@ -86,7 +86,7 @@ errorFluidTemplatesRootPath
     string [optional]
 
 :aspect:`Description`
-    **Only if errorHandler == `Fluid`**: Paths to Fluid Templates, Partials and Layouts in
+    **Only if errorHandler is of type Fluid**: Paths to Fluid Templates, Partials and Layouts in
     case more flexibility is needed.
 
 :aspect:`Example`
@@ -100,7 +100,7 @@ errorFluidPartialsRootPath
     string [optional]
 
 :aspect:`Description`
-    **Only if errorHandler == `Fluid`**: Paths to Fluid Templates, Partials and Layouts in
+    **Only if errorHandler is of type Fluid**: Paths to Fluid Templates, Partials and Layouts in
     case more flexibility is needed.
 
 :aspect:`Example`
@@ -114,7 +114,7 @@ errorFluidLayoutsRootPath
     string [optional]
 
 :aspect:`Description`
-    **Only if errorHandler == `Fluid`**: Paths to Fluid Templates, Partials and Layouts in
+    **Only if errorHandler is of type Fluid**: Paths to Fluid Templates, Partials and Layouts in
     case more flexibility is needed.
 
 :aspect:`Example`
@@ -128,7 +128,7 @@ errorContentSource
     string
 
 :aspect:`Description`
-    **Only if `errorHandler: Page`**: May be either an External URL or TYPO3 Page that will be fetched with curl and displayed
+    **Only if errorHandler is of type Page**: May be either an External URL or TYPO3 Page that will be fetched with curl and displayed
     in case of an error.
 
 :aspect:`Example`
@@ -142,7 +142,7 @@ errorPhpClassFQCN
     string
 
 :aspect:`Description`
-    **Only if `errorHandler: PHP`**: Fully qualified class name of a custom error handler implementing `PageErrorHandlerInterface`.
+    **Only if errorHandler is of type PHP**: Fully qualified class name of a custom error handler implementing `PageErrorHandlerInterface`.
 
 :aspect:`Example`
     `My\Site\Error\Handler`


### PR DESCRIPTION
If emphasis are used, then the PHP coding quotes seem not to work.

![image](https://user-images.githubusercontent.com/5037116/106714276-e6e69580-65fb-11eb-92f5-79f66d3c0a04.png)

Releases: master, 10.4, 9.5
