### PR TITLE
remove createDirs from example

### DIFF
--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -304,24 +304,6 @@ $_EXTKEY is set globally and contains the extension key.
 Deprecated Configuration
 ========================
 
-The following fields are deprecated or have been removed. They have no effect in the latest TYPO3 version.
+The following fields have become deprecated since this TYPO3 version. They have no effect any more.
 
-- dependencies
-- conflicts
-- suggests
-- docPath
-- CGLcompliance
-- CGLcompliance_note
-- private
-- download_password
-- shy
-- loadOrder
-- priority
-- internal
-- modify_tables
-- module
-- lockType
-- TYPO3_version
-- PHP_version
-- uploadfolder
-- createDirs
+- (No new entries are listed here. For formerly deprecated fiels: see older versions of this page).

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -304,7 +304,7 @@ $_EXTKEY is set globally and contains the extension key.
 Deprecated Configuration
 ========================
 
-The following fields are deprecated and should not be used anymore:
+The following fields are deprecated or have been removed. They have no effect in the latest TYPO3 version.
 
 - dependencies
 - conflicts

--- a/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
+++ b/Documentation/ExtensionArchitecture/DeclarationFile/Index.rst
@@ -34,7 +34,6 @@ values in the :php:`$EM_CONF` array if needed.
        'author_email' => 'john@example.org',
        'author_company' => 'some company',
        'state' => 'stable',
-       'createDirs' => '',
        'clearCacheOnLoad' => 0,
        'version' => '1.0.0',
        'constraints' => [


### PR DESCRIPTION
createDirs has been [removed in TYPO3 10](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.0/Breaking-88525-RemoveCreateDirsDirectiveOfExtensionInstallationEm_confphp.html).

Releases: master, 10.4