### PR TITLE
Added note regarding command definitions

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -52,6 +52,11 @@ Creating a new Command in Extensions
            - name: 'console.command'
              command: 'yourext:dothings'
 
+   .. note::
+
+   Despite using :file:`autoconfigure: true` the commands 
+   have to be explicitly defined in :file:`Services.yaml` for TYPO3s custom command processing.
+
    Or register :file:`Configuration/Commands.php`.
    Deprecated since v10 and will be removed in v11::
 


### PR DESCRIPTION
I noticed that in the TYPO3 docs the commands are explicitly defined, while the Symfony docs say commands are automatically added due to `autoconfigure: true`. To avoid confusion for Symfony newbies like myself, I propose to add a little note about why `autoconfigure: true` is not enough in this case.