### PR TITLE
Update xliff version number in the example code, add xml declaration

### DIFF
--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -38,8 +38,8 @@ Here is a sample XLIFF file:
 .. code-block:: xml
 
    <?xml version="1.0" encoding="UTF-8"?>
-   <xliff version="1.0" xmlns="urn:oasis:names:tc:xliff:document:1.1">
-      <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2011-10-18T18:20:51Z" product-name="my_ext">
+   <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+      <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
          <header/>
          <body>
             <trans-unit id="headerComment" resname="headerComment">
@@ -76,8 +76,9 @@ Here is what the translation of our sample file could look like:
 
 .. code-block:: xml
 
-   <xliff version="1.0" xmlns="urn:oasis:names:tc:xliff:document:1.1">
-      <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2011-10-18T18:20:51Z" product-name="my_ext">
+   <?xml version="1.0" encoding="UTF-8"?>
+   <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+      <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
          <header/>
          <body>
             <trans-unit id="headerComment" resname="headerComment">


### PR DESCRIPTION
Best practices for .xlf are given in the following extension which is referenced in other parts of the documentation.
https://github.com/TYPO3-Documentation/tea/blob/main/Resources/Private/Language/locallang.xlf

Stated best practice is to use XLIFF Version 1.2. This should be reflected by the official documentation. Using a recent version also makes linting easier.

It shouldn't do harm, TYPO3 itself doesn't care about the used version.