### PR TITLE
Wrong use of onChange reload

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -318,7 +318,7 @@ can do that with:
    </config>
        
 
-This element is optional and must go above the `<config>` element.
+The :xml:`onChange` element is optional and must be placed on the same level as the :xml:`<config>` element.
 
 
 .. index:: pair: Flexforms; Extbase
@@ -497,4 +497,3 @@ and `bootstrap_package <https://extensions.typo3.org/extension/bootstrap_package
 (by Benjamin Kott).
 
 Further enhancements by the TYPO3 community are welcome!
-

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -312,11 +312,13 @@ can do that with:
 
 .. code-block:: xml
 
+   <onChange>reload</onChange>
    <config>
        <!-- ... -->
-       <onChange>reload</onChange>
+   </config>
+       
 
-This element is optional and must go inside the `<config>` element.
+This element is optional and must go above the `<config>` element.
 
 
 .. index:: pair: Flexforms; Extbase


### PR DESCRIPTION
"onChange reload" is not working inside config. If it is used then it must be above the config element.

Releases: master, 10.4, 9.5