### PR TITLE
Drop ancient version from error handling intro

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Index.rst
@@ -6,10 +6,9 @@
 Error and Exception Handling
 ================================
 
-As of version 4.3.0 TYPO3 has come with a built-in error and exception
-handling system. Administrators can configure how errors and exceptions are
-displayed in both the backend and the frontend.
-See the examples below.
+TYPO3 has a built-in error and exception handling system. Administrators can
+configure how errors and exceptions are displayed in both the backend and the
+frontend.
 
 .. rst-class:: compact-list
 .. toctree::


### PR DESCRIPTION
Also drop mention of "examples" which do not exist on this page (anymore)