### PR TITLE
Warn to keep routePaths unique

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -268,6 +268,10 @@ To understand what's happening in the `aspects` part, read on.
     For the Extbase Plugin Enhancer, it is also possible to configure the namespace directly by skipping `extension`
     and `plugin` properties and just using the `namespace` property as in the regular Plugin Enhancer.
 
+.. attention::
+    Please ensure not to register the same `routePath` more than once, for example through multiple extensions.
+    In that case, the enhancer imported last will override any duplicate routes that are in place.
+
 
 .. index:: Routing; PageType decorator
 


### PR DESCRIPTION
I had this problem with a route enhancer from another extension having the same `routePath` in my site's `config.yaml` and it took me a while to spot the error. Maybe this note will help others to beware.

If so, I suggest backporting to 10.4 as well.