### PR TITLE
Added missing accent-character

### DIFF
--- a/Documentation/ApiOverview/Autoloading/Index.rst
+++ b/Documentation/ApiOverview/Autoloading/Index.rst
@@ -17,7 +17,7 @@ and :ref:`XCLASS <xclasses>` handling.
 
 A developer should usually instantiate classes using :php:`makeInstance()` - it is
 the normal way to go. This has been a hard rule in the past. With younger core version
-however, there are some situations where :php:`new` is used over :php:`makeInstance(),
+however, there are some situations where :php:`new` is used over :php:`makeInstance()`,
 effectively dropping especially the direct ability to :ref:`XCLASS <xclasses>`:
 
 - When dependent services are injected via :ref:`Dependency Injection <dependencyinjection>`,


### PR DESCRIPTION
The whole next line was interpreted as code and a link could not be parsed