### PR TITLE
Update FAL documentation

### DIFF
--- a/Documentation/ApiOverview/Fal/Concepts/Index.rst
+++ b/Documentation/ApiOverview/Fal/Concepts/Index.rst
@@ -33,7 +33,8 @@ By default TYPO3 CMS provides only a local file system driver.
 
 A new TYPO3 CMS installation comes with a predefined storage,
 using the local file system driver and pointing to the
-:file:`fileadmin/` directory.
+:file:`fileadmin/` directory, located in your public folder.
+If it's missing/offline after installation you can create it yourself.
 
 
 .. index:: File abstraction layer; Metadata


### PR DESCRIPTION
In the FAL documentation there is no reference to the folder where the fileadmin folder is located, i just checked out a project and the fileadmin folder was missing for some reason.
I tried searching searching for fileadmin and got to the FAL documentation, but there is no reference to the folder where fileadmin needs to be located( it says in Start/Installation explained/The Package in Detail) but i think there should be a hint in the FAL section too, just because thats where youll most likely end up when searching for your error.
Maybe this isnt a problem for most people, but as a less experienced developer this wouldve helped me a lot.