### PR TITLE
Remove langDisable from example FlexForm

### DIFF
--- a/Documentation/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/DataFormats/T3datastructure/Elements/Index.rst
@@ -200,9 +200,6 @@ of FlexForms can be found in the :ref:`relevant section of the TCA reference <t3
 .. code-block:: xml
 
    <T3DataStructure>
-      <meta>
-         <langDisable>1</langDisable>
-      </meta>
       <sheets>
          <sDEF>
             <ROOT>


### PR DESCRIPTION
Removed the `meta` section of the example FlexForm which included only a `langDisable` element that has been [deprecated](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/7.6/Deprecation-70138-FlexFormLanguageHandling.html) for a while, to avoid confusion.