### PR TITLE
Add missing max range length hint

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -522,6 +522,8 @@ and to explicitly define a range for a value, which is recommended for all kinds
 This limits down the pagination to max. 100 pages, if a user calls the news list with page 101, then the route enhancer
 does not match and would not apply the placeholder.
 
+A range larger than 1000 is not allowed. 
+
 
 .. index:: Routing; PersistedAliasMapper
 


### PR DESCRIPTION
There is a limit of a range of 1000 in the StaticRangeMapper 
https://github.com/TYPO3/TYPO3.CMS/blob/7b919798c8784ba3a3dd8cb82ab2d8a7e777878a/typo3/sysext/core/Classes/Routing/Aspect/StaticRangeMapper.php#L141