### PR TITLE
Add naming conventions for upgrade wizard identifier

### DIFF
--- a/Documentation/ApiOverview/UpdateWizards/Creation.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation.rst
@@ -180,8 +180,7 @@ The wizard identifier is used:
 Since all upgrade wizards of TYPO3 core and extensions are registered using the
 identifier as key in the global array
 :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']`, it
-is recommended to prepend the identifier with something unique to the extension
-to make it unique.
+is recommended to prepend the wizard identifier with a prefix based on the extension key.
 
 You SHOULD use the following naming convention for the identifier:
 

--- a/Documentation/ApiOverview/UpdateWizards/Creation.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation.rst
@@ -53,7 +53,7 @@ methods::
         */
        public function getIdentifier(): string
        {
-         return 'exampleUpdateWizard';
+         return 'myExtension_exampleUpdateWizard';
        }
 
        /**
@@ -159,12 +159,57 @@ Registering wizards
 Once the wizard is created, it needs to be registered. Registration is done in
 :file:`ext_localconf.php`::
 
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['exampleUpdateWizard']
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['myExtension_exampleUpdateWizard']
       = \Vendor\ExtName\Updates\ExampleUpdateWizard::class;
 
-**Important:** Use the same identifier as key (here: `exampleUpdateWizard`), which
+**Important:** Use the same identifier as key (here: `myExtension_exampleUpdateWizard`), which
 is returned by :php:`UpgradeWizardInterface::getIdentifier()` in your wizard
 class.
+
+.. index:: Upgrade wizards; Identifier
+.. _upgrade-wizards-identifier:
+
+Wizard identifier
+=================
+
+The wizard identifier is used:
+
+*  when calling the wizard from the :ref:`command line <upgrade_wizard_execute>`.
+*  when marking the wizard as done in the table `sys_registry`
+
+Since all upgrade wizards of TYPO3 core and extensions are registered using the
+identifier as key in the global array
+:php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']`, it
+is recommended to prepend the identifier with the extension key to make it unique.
+
+You SHOULD use the following naming convention for the identifier:
+
+`extKey_wizardName`, for example `bootstrapPackage_addNewDefaultTypes`
+
+*  extension key and wizard name in lowerCamelCase, separated by underscore
+*  existing underscores in extension keys are replaced by capitalizing the
+   following letter
+
+.. important::
+
+   Any identifier will still work, using these naming conventions is
+   not enforced. In fact, it is not recommended to change already
+   existing wizard identiers, as the information, that the wizard ran is
+   stored using the identifier in the `sys_registry` table and this
+   information would then be lost.
+
+Some examples:
+
++-------------------+-------------------------------------+
+| extension key     | wizard identifer                    |
++===================+=====================================+
+| container         | container_upgradeColumnPositions    |
++-------------------+-------------------------------------+
+| news_events       | newsEvents_migrateEvents            |
++-------------------+-------------------------------------+
+| bootstrap_package | bootstrapPackage_addNewDefaultTypes |
++-------------------+-------------------------------------+
+
 
 .. index:: Upgrade wizards; Marking wizard as done
 .. _upgrade-wizards-mark-as-done:
@@ -251,6 +296,8 @@ We are showing a simplified example here, based on this class::
 
 .. index:: Upgrade wizards; Execution
 
+.. _upgrade_wizard_execute:
+
 Executing the wizard
 ====================
 
@@ -261,8 +308,18 @@ It is also possible to execute the wizard from the command line.
 
 .. code-block:: bash
 
-   # Run using our identifier 'exampleUpdateWizard' which was specified when registering
-   vendor/bin/typo3 upgrade:run exampleUpdateWizard
+   # Run using our identifier 'myExtension_exampleUpdateWizard'
+   vendor/bin/typo3 upgrade:run myExtension_exampleUpdateWizard
+
+
+.. tip::
+
+   Some existing wizards use the convention of using the fully qualified class
+   name as identifer. You may have to quote the backslashes in the shell, e.g.
+
+   .. code-block:: bash
+
+      vendor/bin/typo3 upgrade:run '\\Vendor\\ExtKey\\Upgrade\\ExampleUpgradeWizard'
 
 You can find more information about running upgrade wizards in the
 :ref:`Upgrade wizard section <t3install:use-the-upgrade-wizard>` of the

--- a/Documentation/ApiOverview/UpdateWizards/Creation.rst
+++ b/Documentation/ApiOverview/UpdateWizards/Creation.rst
@@ -53,7 +53,7 @@ methods::
         */
        public function getIdentifier(): string
        {
-         return 'myExtension_exampleUpdateWizard';
+         return 'extName_exampleUpdateWizard';
        }
 
        /**
@@ -159,10 +159,10 @@ Registering wizards
 Once the wizard is created, it needs to be registered. Registration is done in
 :file:`ext_localconf.php`::
 
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['myExtension_exampleUpdateWizard']
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['extName_exampleUpdateWizard']
       = \Vendor\ExtName\Updates\ExampleUpdateWizard::class;
 
-**Important:** Use the same identifier as key (here: `myExtension_exampleUpdateWizard`), which
+**Important:** Use the same identifier as key (here: `extName_exampleUpdateWizard`), which
 is returned by :php:`UpgradeWizardInterface::getIdentifier()` in your wizard
 class.
 
@@ -175,16 +175,17 @@ Wizard identifier
 The wizard identifier is used:
 
 *  when calling the wizard from the :ref:`command line <upgrade_wizard_execute>`.
-*  when marking the wizard as done in the table `sys_registry`
+*  when marking the wizard as done in the table :sql:`sys_registry`
 
 Since all upgrade wizards of TYPO3 core and extensions are registered using the
 identifier as key in the global array
 :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']`, it
-is recommended to prepend the identifier with the extension key to make it unique.
+is recommended to prepend the identifier with something unique to the extension
+to make it unique.
 
 You SHOULD use the following naming convention for the identifier:
 
-`extKey_wizardName`, for example `bootstrapPackage_addNewDefaultTypes`
+`extName_wizardName`, for example `bootstrapPackage_addNewDefaultTypes`
 
 *  extension key and wizard name in lowerCamelCase, separated by underscore
 *  existing underscores in extension keys are replaced by capitalizing the
@@ -195,7 +196,7 @@ You SHOULD use the following naming convention for the identifier:
    Any identifier will still work, using these naming conventions is
    not enforced. In fact, it is not recommended to change already
    existing wizard identiers, as the information, that the wizard ran is
-   stored using the identifier in the `sys_registry` table and this
+   stored using the identifier in the :sql:`sys_registry` table and this
    information would then be lost.
 
 Some examples:
@@ -308,8 +309,8 @@ It is also possible to execute the wizard from the command line.
 
 .. code-block:: bash
 
-   # Run using our identifier 'myExtension_exampleUpdateWizard'
-   vendor/bin/typo3 upgrade:run myExtension_exampleUpdateWizard
+   # Run using our identifier 'extName_exampleUpdateWizard'
+   vendor/bin/typo3 upgrade:run extName_exampleUpdateWizard
 
 
 .. tip::

--- a/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
+++ b/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
@@ -331,11 +331,11 @@ Extbase has some of its own conventions.
 Upgrade wizard identifier
 =========================
 
-You SHOULD use the following identifier:
+You SHOULD use the following naming convention for the identifier:
 
 `extKey_wizardName`
 
-This is not enforced
+This is not enforced.
 
 Please see :ref:`upgrade-wizards-identifier` in the Upgrade Wizard chapter
 for further explanations.

--- a/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
+++ b/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
@@ -328,6 +328,18 @@ Extbase has some of its own conventions.
 
     * :ref:`Extbase CGL <t3extbasebook:extbase-cgl>`.
 
+Upgrade wizard identifier
+=========================
+
+You SHOULD use the following identifier:
+
+`extKey_wizardName`
+
+This is not enforced
+
+Please see :ref:`upgrade-wizards-identifier` in the Upgrade Wizard chapter
+for further explanations.
+
 
 .. _extension-old-extensions:
 


### PR DESCRIPTION
Note: This convention does not depend on a specific core version. It
can be used as of now, in core and third party extensions for TYPO3 11
and older versions alike. But other identifiers which do not adhere to
this convention will still work and continue to work in the future.

Resolves: #1334
Releases: master, 10.4