### PR TITLE
Clarify extension-key section in composer.json

### DIFF
--- a/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
+++ b/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
@@ -205,21 +205,23 @@ extra
 
 (*required*)
 
-The extra `typo3/cms` section is used to provide a TYPO3 extension_key for the package.
-If not provided, the package-key will be used with all dashes (`-`)
-replaced by underscores (`_`) to follow TYPO3 and Packagist conventions.
+Not providing this property will emit a deprecation notice and will fail in
+future versions.
 
-Not providing this property will emit a deprecation notice and will fail in future versions.
+.. hint::
 
-So, the following section can be provided, but the default will result in
-the same thing:
+   The property "extension-key" means the **literal string** "extension-key",
+   not your actual extension key. The value on the right side should be your
+   actual extension key.
+
+Example for extension key **bootstrap_package**:
 
 .. code-block:: json
 
    {
       "extra": {
          "typo3/cms": {
-            "extension-key": "my_extension"
+            "extension-key": "bootstrap_package"
          }
       }
    }
@@ -235,11 +237,13 @@ replaced by this package. This means that packages with different
 vendor name or package name will be treated as the same package by
 Composer.
 
+Example for extension key **bootstrap_package**:
+
 .. code-block:: json
 
    {
       "replace": {
-         "typo3-ter/my-extension": "self.version"
+         "typo3-ter/bootstrap-package": "self.version"
       }
    }
 


### PR DESCRIPTION
Some text is obsolete, because specifying the extension
key is now mandatory.

Additionally, the example was not clear, because you might easily
interpret is as meaning the extension key with underscore replaced
by dash instead of the actual string "extension-key".

We now use the same example as in
https://github.com/TYPO3/CmsComposerInstallers

Releases: master, 10.4, 9.5