### PR TITLE
Replace undefined method call with call to defined method

### DIFF
--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -218,7 +218,7 @@ These would be the shortest steps to get the list of files in a given
 folder: get the storage, get a folder object for some path in that
 storage (path relative to storage root), finally retrieve the files::
 
-   $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
+   $resourceFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
    $defaultStorage = $resourceFactory->getDefaultStorage();
    $folder = $defaultStorage->getFolder('/some/path/in/storage/');
    $files = $defaultStorage->getFilesInFolder($folder);

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -79,7 +79,7 @@ Adding a File
 This example adds a new file in the root folder of the default
 Storage::
 
-   $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
+   $resourceFactory = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\ResourceFactory::class);
    $storage = $resourceFactory->getDefaultStorage();
    $newFile = $storage->addFile(
          '/tmp/temporary_file_name.ext',

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -79,8 +79,8 @@ Adding a File
 This example adds a new file in the root folder of the default
 Storage::
 
-   $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\StorageRepository::class);
-   $storage = $storageRepository->getDefaultStorage();
+   $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
+   $storage = $resourceFactory->getDefaultStorage();
    $newFile = $storage->addFile(
          '/tmp/temporary_file_name.ext',
          $storage->getRootLevelFolder(),
@@ -218,8 +218,8 @@ These would be the shortest steps to get the list of files in a given
 folder: get the storage, get a folder object for some path in that
 storage (path relative to storage root), finally retrieve the files::
 
-   $storageRepository = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\StorageRepository::class);
-   $defaultStorage = $storageRepository->getDefaultStorage();
+   $resourceFactory = \TYPO3\CMS\Core\Resource\ResourceFactory::getInstance();
+   $defaultStorage = $resourceFactory->getDefaultStorage();
    $folder = $defaultStorage->getFolder('/some/path/in/storage/');
    $files = $defaultStorage->getFilesInFolder($folder);
 


### PR DESCRIPTION
`StorageRepository::getDefaultStorage` ist not defined in `10.4`. [(see on Github)](https://github.com/TYPO3/TYPO3.CMS/blob/10.4/typo3/sysext/core/Classes/Resource/StorageRepository.php)
In the master branch, it exists. 
I replaced the call to the undefined method with the suggested implementation from documentation of `9.5`.