### PR TITLE
Clarify section about `allowedAspectRatios`

### DIFF
--- a/Documentation/ApiOverview/CropVariants/General/Index.rst
+++ b/Documentation/ApiOverview/CropVariants/General/Index.rst
@@ -14,9 +14,17 @@ In this example we configure two crop variants, one with the id "mobile",
 one with the id "desktop". The array key defines the crop variant id, which will be used
 when rendering an image with the image view helper.
 
-The array key is used as identifier for the ratio and the label is specified with the "title"
-and the actual (floating point) ratio with the "value" key.
-The value **should** be of PHP type float, not only a string.
+For each crop variant there's at least one *ratio configuration* defined as ``allowedAspectRatios``:
+
+* its key **must not** contain the dot character (``.``):
+
+  * good examples: ``NaN``, ``4:3`` or ``other-format``
+  * bad example: ``1:1.441``
+ 
+* its value is an array consisting of two keys:
+
+  * ``title``: should be a string (or even better: a LLL reference)
+  * ``value``: **should** be a float (not a string!)
 
 .. code-block:: php
 


### PR DESCRIPTION
I just spent too much time on debugging why my keys within `allowedAspectRatios` aren't working (with TYPO3 9). As it turned out dots as part of the array keys are not supported  ;-(