### PR TITLE
[TASK] Add placeholder page for extending TCA (7.6)

### DIFF
--- a/Documentation/ExtensionArchitecture/ExtendingTca/Examples/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Examples/Index.rst
@@ -1,0 +1,31 @@
+:orphan:
+
+.. This page is not in the menu!
+
+.. This page is a placeholder for 7.6 version for TCA customization examples
+.. 1. make it possible to switch to 7.6 from higher versions without 404
+..    and point to documentation in TCA reference from here
+.. 2. make it possible to link to this page from 7.6 TCA reference with :ref:
+
+.. INTENTION: Direct users to correct information, avoid 404 pages.
+
+
+.. include:: /Includes.rst.txt
+
+.. _extending-examples:
+.. _extending-examples-ttcontent:
+.. _extending-examples-feusers:
+
+============================
+Customization Examples (TCA)
+============================
+
+For **newer** TYPO3 versions, please use the **version selector** to
+switch to the correct version of this manual and find information about
+extending TCA.
+
+For **TYPO3 7.6** (and below). this content can be found in:
+
+.. rst-class:: horizbuttons-note-m
+
+   * TCA Reference: :ref:`t3tca:extending-examples`

--- a/Documentation/ExtensionArchitecture/ExtendingTca/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Index.rst
@@ -1,0 +1,30 @@
+:orphan:
+
+.. This page is not in the menu!
+
+.. This page is a placeholder for 7.6 version for TCA customization
+.. 1. make it possible to switch to 7.6 from higher versions without 404
+..    and point to documentation in TCA reference from here
+.. 2. make it possible to link to this page from 7.6 TCA reference with :ref:
+
+.. INTENTION: Direct users to correct information, avoid 404 pages.
+
+
+.. include:: /Includes.rst.txt
+
+.. _extending:
+.. _extending-tca:
+
+========================
+Extending the TCA Array
+========================
+
+For **newer** TYPO3 versions, please use the **version selector** to
+switch to the correct version of this manual and find information about
+extending TCA.
+
+For **TYPO3 7.6** (and below). this content can be found in:
+
+.. rst-class:: horizbuttons-note-m
+
+   * TCA Reference: :ref:`t3tca:extending`

--- a/Documentation/ExtensionArchitecture/ExtendingTca/Verifying/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/Verifying/Index.rst
@@ -1,0 +1,29 @@
+:orphan:
+
+.. This page is not in the menu!
+
+.. This page is a placeholder for 7.6 version for TCA customization
+.. 1. make it possible to switch to 7.6 from higher versions without 404
+..    and point to documentation in TCA reference from here
+.. 2. make it possible to link to this page from 7.6 TCA reference with :ref:
+
+.. INTENTION: Direct users to correct information, avoid 404 pages.
+
+
+.. include:: /Includes.rst.txt
+
+.. _verifying:
+
+=================
+Verifying the TCA
+=================
+
+For **newer** TYPO3 versions, please use the **version selector** to
+switch to the correct version of this manual and find information about
+extending TCA.
+
+For **TYPO3 7.6** (and below). this content can be found in:
+
+.. rst-class:: horizbuttons-note-m
+
+   * TCA Reference: :ref:`t3tca:verifying`


### PR DESCRIPTION
This creates placeholder pages which are not in the menu and should guide
users to find this information either for newer versions (in this guide)
or in TCA reference (for older versions).

Purposes:

1. Avoid 404 when using version selector to switch to older version
2. Direct users to TCA reference for version 7.6 and 6.2
3. Make it possible to link to this information in this manual using :ref:
   (and not absolute links) from TCA reference

The Extending TCA information moved from TCA reference to TYPO3
Explained since version 8.7. Now you often have one of several problems:

* 7.6 documentation is highest result for search, but you can't switch to
  higher version (via version selector) and there is no link to the newer
  information

This change is an attempt, to ease navigation and find the correct information
- both via links and via version selector.

Releases: 7.6, 6.2