### PR TITLE
Update TCA override doc

### DIFF
--- a/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
@@ -52,7 +52,8 @@ Storing in the overrides folder
 -------------------------------
 
 Since TYPO3 CMS 6.2 (6.2.1 to be precise) changes to :php:`$GLOBALS['TCA']`
-must be stored inside a folder called :file:`Configuration/TCA/Overrides`. For clarity files should be named along the pattern
+must be stored inside a folder called :file:`Configuration/TCA/Overrides`.
+For clarity files should be named along the pattern
 :file:`<tablename>.php`.
 
 Thus if you want to customize the TCA of :code:`tx_foo_domain_model_bar`,

--- a/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtendingTca/StoringChanges/Index.rst
@@ -52,8 +52,7 @@ Storing in the overrides folder
 -------------------------------
 
 Since TYPO3 CMS 6.2 (6.2.1 to be precise) changes to :php:`$GLOBALS['TCA']`
-must be stored inside a folder called :file:`Configuration/TCA/Overrides`
-with one file per modified table. These files are named along the pattern
+must be stored inside a folder called :file:`Configuration/TCA/Overrides`. For clarity files should be named along the pattern
 :file:`<tablename>.php`.
 
 Thus if you want to customize the TCA of :code:`tx_foo_domain_model_bar`,


### PR DESCRIPTION
Contrary to the original sentence, changes to a tables' TCA configuration don't have to be in a file named `tablename.php` as all files in the `Overrides` folder are loaded automatically as described in the note box that follows below.

Releases: master, 10.4