### PR TITLE
Do not forbid extension key prefix "tt_"

### DIFF
--- a/Documentation/ExtensionArchitecture/ExtensionKey/Index.rst
+++ b/Documentation/ExtensionArchitecture/ExtensionKey/Index.rst
@@ -23,7 +23,6 @@ The extension key must comply with the following rules:
   * **tx**
   * **user_**
   * **pages**
-  * **tt_**
   * **sys_**
   * **ts_language**
   * **csh_**


### PR DESCRIPTION
It should be allowed to have an extension key "tt_news_foo" and "tt_news_bar".