### PR TITLE
Always exclude Domain/Model from DI container

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -46,6 +46,7 @@ Creating a new Command in Extensions
 
        Vendor\Extension\:
          resource: '../Classes/*'
+         exclude: '../Classes/Domain/Model/*'
 
        Vendor\Extension\Command\DoThingsCommand:
          tags:

--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -36,17 +36,9 @@ Creating a new Command in Extensions
 
    The following example will add a command named ``yourext:dothings``.
 
-   Register via DI in :file:`Configuration/Services.yaml`::
+   Register via DI in :file:`Configuration/Services.yaml` by adding the service definition for your class::
 
      services:
-       _defaults:
-         autowire: true
-         autoconfigure: true
-         public: false
-
-       Vendor\Extension\:
-         resource: '../Classes/*'
-         exclude: '../Classes/Domain/Model/*'
 
        Vendor\Extension\Command\DoThingsCommand:
          tags:

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -51,6 +51,7 @@ Alternatively :file:`Configuration/Services.php` can be used.
 
       Your\Namespace\:
         resource: '../Classes/*'
+        exclude: '../Classes/Domain/Model/*'
 
 This is how a basic :file:`Services.yaml` of an extension looks like. The meaning of :yaml:`autowire`,
 :yaml:`autoconfigure` and :yaml:`public` will be explained below.
@@ -60,6 +61,14 @@ This is how a basic :file:`Services.yaml` of an extension looks like. The meanin
 
    Whenever service configuration or class dependencies change, the Core cache needs
    to be flushed to rebuild the compiled Symfony container.
+
+.. note::
+
+   The path exclusion :yaml:`exclude: '../Classes/Domain/Model/*'` excludes
+   your Models from the DI Container, which means you can not inject them or inject
+   dependencies into them.
+   Models are not Services and should therefore not require dependency injection.
+   Also, these Objects are created by the extbase persistence layer which does not support the DI container.
 
 .. _autowire:
 
@@ -135,6 +144,7 @@ For such classes an extension can override the global :yaml:`public: false` conf
 
       Vendor\MyExtension\:
         resource: '../Classes/*'
+        exclude: '../Classes/Domain/Model/*'
 
       Vendor\MyExtension\UserFunction\ClassA:
         public: true


### PR DESCRIPTION
The symfony DI component should not scan the Model directory for following reasons:
* They are not services
* They shouldn't need DI injection
* They are almost never created using the DI container and if, problems with the extbase persistence will occurr.
* Symfony excludes Entities by default, too