### PR TITLE
Improve example PHP code for new page types

### DIFF
--- a/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
+++ b/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
@@ -100,7 +100,7 @@ need to add the new doktype as select item and associate it with the configured 
               ],
               // add all page standard fields and tabs to your new page type
               'types' => [
-                  (string) $archiveDoktype => [
+                  $archiveDoktype => [
                       'showitem' => $GLOBALS['TCA'][$table]['types'][\TYPO3\CMS\Core\Domain\Repository\PageRepository::DOKTYPE_DEFAULT]['showitem']
                   ]
               ]


### PR DESCRIPTION
Page doktypes are integers. Using them as array keys does not need a string conversion.
Numerical array keys in PHP are always converted to integers by PHP internally.