### PR TITLE
[TASK] Ease access to QueryBuilder topics

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -6,6 +6,10 @@
 QueryBuilder
 ============
 
+.. contents:: Table of Contents
+   :depth: 1
+   :local:
+
 The `QueryBuilder` is a rather huge class that takes care of the main query dealing.
 
 An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing


### PR DESCRIPTION
The QueryBuilder chapter is rather huge. To provide a quick access
to the desired topic a "table of contents" is added.