### PR TITLE
Site Configuration field should be named flag

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -187,7 +187,7 @@ typo3Language
     `en`
 
 
-flagIdentifier
+flag
 --------------
 
 :aspect:`Datatype`

--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -188,7 +188,7 @@ typo3Language
 
 
 flag
---------------
+----
 
 :aspect:`Datatype`
     string


### PR DESCRIPTION
Was wrong as `flagIdentifier`, all other releases (10, master) are fixed already