### PR TITLE
Log fixes

### DIFF
--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -140,7 +140,7 @@ Emergency
 
 .. _logging-logger-log:
 
-Log() Method
+log() Method
 ============
 
 :code:`\TYPO3\CMS\Core\Log\Logger` provides a central point for submitting log messages,

--- a/Documentation/ApiOverview/Logging/Processors/Index.rst
+++ b/Documentation/ApiOverview/Logging/Processors/Index.rst
@@ -8,7 +8,7 @@ Log processors
 
 The purpose of a log processor is (usually) to modify a log record or add more detailed information to it.
 
-Log processors allow for the manipulation of log records without changing the code
+Log processors allow the manipulation of log records without changing the code
 where the log method actually is called (inversion of control).
 This enables you to add any information from outside the scope of the actual calling function,
 for example webserver environment variables. The TYPO3 Core  ships some basic log processors,

--- a/Documentation/ApiOverview/Logging/Processors/Index.rst
+++ b/Documentation/ApiOverview/Logging/Processors/Index.rst
@@ -8,7 +8,7 @@ Log processors
 
 The purpose of a log processor is (usually) to modify a log record or add more detailed information to it.
 
-Log processors allow to manipulate log records without changing the code
+Log processors allow for the manipulation of log records without changing the code
 where the log method actually is called (inversion of control).
 This enables you to add any information from outside the scope of the actual calling function,
 for example webserver environment variables. The TYPO3 Core  ships some basic log processors,

--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -55,16 +55,14 @@ Log a simple message::
    $this->logger->warning('Something went awry, check your configuration!');
 
 
-Provide additional information with the log message::
+Provide additional context information with the log message::
 
-   $this->logger->error(
-     'This was not a good idea',
-     array(
-       'foo' => $bar,
-       'bar' => $foo,
-     )
-   );
+   $this->logger->error('Passing {value} was unwise.', [
+       'value' => $value,
+       'other_data' => $foo,
+   ]);
 
+Values in the message string that should vary based on the error (such as specifying what an invalid value was) should use placeholders, denoted by `{ }`.  Provide the value for that placeholder in the context array.
 
 :php:`$this->logger->warning()` etc. are only shorthands - you can also call :php:`$this->logger->log()` directly
 and pass the severity level::

--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -62,7 +62,9 @@ Provide additional context information with the log message::
        'other_data' => $foo,
    ]);
 
-Values in the message string that should vary based on the error (such as specifying what an invalid value was) should use placeholders, denoted by `{ }`.  Provide the value for that placeholder in the context array.
+Values in the message string that should vary based on the error (such as
+specifying what an invalid value was) should use placeholders, denoted by
+`{ }`.  Provide the value for that placeholder in the context array.
 
 :php:`$this->logger->warning()` etc. are only shorthands - you can also call :php:`$this->logger->log()` directly
 and pass the severity level::


### PR DESCRIPTION
A few small-ish changes to the log docs.  Note that this is for v11 only, as the v10 loggers don't actually handle {} placeholders correctly.  That's getting fixed for v11 in https://review.typo3.org/c/Packages/TYPO3.CMS/+/69425