### PR TITLE
[TASK] avoid duplicate content on extensions.typo3.org and docs.typo3…

### DIFF
--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -112,3 +112,11 @@ step 4 (request redirects) which is not necessary for new documentation.
 * Your extension documentation will be rendered on `docs.typo3.org <https://docs.typo3.org/>`__
 * The documentation link will be added automatically if your extension is
   registered on extensions.typo3.org (TER).
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+   :glob:
+
+   PublishToTER/Index
+   PublishViaTaylor/Index

--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -69,7 +69,7 @@ TER
 
 Publish your extension on TER.
 
-See `Publish an Extension <https://extensions.typo3.org/faq/publish-an-extension/>`__
+See :ref:`Publish an Extension <publishExtensionTer>`
 for more information on how to publish an extension and check out the
 `FAQ <https://extensions.typo3.org/faq/>`__ as well.
 
@@ -89,7 +89,7 @@ for more information on how to publish an extension and check out the
 .. _publishExtensionDocumentation:
 
 Documentation
-============
+=============
 
 Publish your documentation on docs.typo3.org.
 
@@ -119,4 +119,3 @@ step 4 (request redirects) which is not necessary for new documentation.
    :glob:
 
    PublishToTER/Index
-   PublishViaTaylor/Index

--- a/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
@@ -12,20 +12,20 @@ Before publishing extension, think about
 
 First of all ask yourself some questions before publishing or even putting some effort in coding:
 
-* What additional benefit does your extension have for the TYPO3 community?
-* Does your extension key describe the extension? See the extension key requirements.
-* Are there any extensions in the TER yet which have the same functionalities?
-* If yes, why do we need your one? Wouldn't it be an option to contribute to other extensions?
-* Did you read and understand the `TYPO3 Extension Security Policy <https://typo3.org/community/teams/security/extension-security-policy>`__?
-* Does your extension include or need external libraries? Watch for the license! Learn more about the `right licensing <https://typo3.org/project/licenses/>`__.
-* Do you have a public repository on e.g. GitHub, Gitlab or Bitbucket?
-* Do you have the resources to maintain this extension?
-* This means that you should
+*  What additional benefit does your extension have for the TYPO3 community?
+*  Does your extension key describe the extension? See the extension key requirements.
+*  Are there any extensions in the TER yet which have the same functionalities?
+*  If yes, why do we need your one? Wouldn't it be an option to contribute to other extensions?
+*  Did you read and understand the `TYPO3 Extension Security Policy <https://typo3.org/community/teams/security/extension-security-policy>`__?
+*  Does your extension include or need external libraries? Watch for the license! Learn more about the `right licensing <https://typo3.org/project/licenses/>`__.
+*  Do you have a public repository on e.g. GitHub, Gitlab or Bitbucket?
+*  Do you have the resources to maintain this extension?
+*  This means that you should
 
-  * support users and integrators using your extension
-  * review and test contributions
-  * test your extension for new TYPO3 releases
-  * provide and update a documentation for your extension
+   *  support users and integrators using your extension
+   *  review and test contributions
+   *  test your extension for new TYPO3 releases
+   *  provide and update a documentation for your extension
 
 Use semantic versions
 =====================
@@ -34,9 +34,9 @@ We would like you to stick to semantic versions.
 
 Given a version number **MAJOR.MINOR.PATCH**, increment the:
 
-* **MAJOR** version when you make incompatible API changes (known as "**breaking changes**"), 
-* **MINOR** version when you **add functionality in a backwards-compatible manner**, and
-* **PATCH** version when you **make backwards-compatible bug fixes**.
+*  **MAJOR** version when you make incompatible API changes (known as "**breaking changes**"), 
+*  **MINOR** version when you **add functionality in a backwards-compatible manner**, and
+*  **PATCH** version when you **make backwards-compatible bug fixes**.
 
 Additional labels for pre-release and build metadata are available as extensions to the **MAJOR.MINOR.PATCH format**.
 
@@ -61,5 +61,3 @@ Now we come to the process of publishing. You have two possibilites to release a
 #. Via the web form on extensions.typo3.org (click on "Publish" next to your extension key in the `extension key management <https://extensions.typo3.org/my-extensions>`__).
 #. Via `Tailor <https://github.com/TYPO3/tailor>`__: Tailor is a CLI application to help you maintain your extensions. Tailor talks with the TER REST API and enables you to register new keys, update extension information and publish new versions to the extension repository. (recommended)
 #. Via the SOAP interface using a tool like the `TYPO3 Repository Client <https://github.com/NamelessCoder/typo3-repository-client>`__ (`Documentation <https://github.com/NamelessCoder/typo3-repository-client#typo3-repository-client-apicli>`__) or the `TER client <https://github.com/helhum/ter-client>`__ (`Documentation <https://github.com/helhum/ter-client#ter-client>`__) (deprecated)
-
-

--- a/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
@@ -1,0 +1,65 @@
+.. include:: /Includes.rst.txt
+.. index:: Extension development; Publishing
+.. _publish-extension:
+
+========================================================
+Publish your extension to the Extension Repository (TER)
+========================================================
+
+
+Before publishing extension, think about
+========================================
+
+First of all ask yourself some questions before publishing or even putting some effort in coding:
+
+* What additional benefit does your extension have for the TYPO3 community?
+* Does your extension key describe the extension? See the extension key requirements.
+* Are there any extensions in the TER yet which have the same functionalities?
+* If yes, why do we need your one? Wouldn't it be an option to contribute to other extensions?
+* Did you read and understand the `TYPO3 Extension Security Policy <https://typo3.org/community/teams/security/extension-security-policy>`__?
+* Does your extension include or need external libraries? Watch for the license! Learn more about the `right licensing <https://typo3.org/project/licenses/>`__.
+* Do you have a public repository on e.g. GitHub, Gitlab or Bitbucket?
+* Do you have the resources to maintain this extension?
+* This means that you should
+
+  * support users and integrators using your extension
+  * review and test contributions
+  * test your extension for new TYPO3 releases
+  * provide and update a documentation for your extension
+
+Use semantic versions
+=====================
+
+We would like you to stick to semantic versions.
+
+Given a version number **MAJOR.MINOR.PATCH**, increment the:
+
+* **MAJOR** version when you make incompatible API changes (known as "**breaking changes**"), 
+* **MINOR** version when you **add functionality in a backwards-compatible manner**, and
+* **PATCH** version when you **make backwards-compatible bug fixes**.
+
+Additional labels for pre-release and build metadata are available as extensions to the **MAJOR.MINOR.PATCH format**.
+
+More you can see at `https://semver.org <https://semver.org>`__
+
+Offer feedback options
+======================
+
+Before you publish an extension you should be aware of what happens after it. Users and integrators will give you
+feedback (contributions, questions, bug reports). In this case you should have
+
+#. A possibility to get in contact with you (link to an issue tracker like forge, GitHub, etc.)
+#. A possibility to look into the code (link to a public repository)
+
+You can edit these options in the `extension key management <https://extensions.typo3.org/my-extensions>`__ (after login)
+
+How to publish an extension
+===========================
+
+Now we come to the process of publishing. You have two possibilites to release an extension:
+
+#. Via the web form on extensions.typo3.org (click on "Publish" next to your extension key in the `extension key management <https://extensions.typo3.org/my-extensions>`__).
+#. Via `Tailor <https://github.com/TYPO3/tailor>`__: Tailor is a CLI application to help you maintain your extensions. Tailor talks with the TER REST API and enables you to register new keys, update extension information and publish new versions to the extension repository. (recommended)
+#. Via the SOAP interface using a tool like the `TYPO3 Repository Client <https://github.com/NamelessCoder/typo3-repository-client>`__ (`Documentation <https://github.com/NamelessCoder/typo3-repository-client#typo3-repository-client-apicli>`__) or the `TER client <https://github.com/helhum/ter-client>`__ (`Documentation <https://github.com/helhum/ter-client#ter-client>`__) (deprecated)
+
+


### PR DESCRIPTION
….org

Update page "Publish an Extension"

Add links from extensions.typo3.org to docs.typo3.org and moved content

resolves: https://gitlab.typo3.org/services/t3o-sites/extensions.typo3.org/ter/-/issues/383