### PR TITLE
[TASK] Improve articles of extension publishing

### DIFF
--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -59,7 +59,7 @@ about the publishing process.
 * Extension can be installed in a
   :ref:`Composer based <t3install:install-via-composer>`
   TYPO3 instance using `composer require`.
-* All advantages of being listed in Packagist, e.g.
+* All advantages of being listed in Packagist, for example
 
   * Extension can be updated easily with `composer update`
 
@@ -83,7 +83,7 @@ page `FAQ <https://extensions.typo3.org/faq/>`__.
 * Extension can be installed in a
   :ref:`non-Composer based <t3install:install-typo3-without-composer>`
   TYPO3 instance using the :ref:`Extension Manager <extension-manager>`.
-* All advantages of being listed in the TER, e.g.
+* All advantages of being listed in the TER, for example:
 
   * Easy finding of your extension
   * The community can vote for your extension

--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -6,19 +6,15 @@
 Publish your extension
 ======================
 
-By publishing an extension to the
-`TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__, we mean
-making it publicly available. Follow these steps, we recommend to do all
-of these.
+Follow these steps to release your extension publicly in the TYPO3 world:
 
-
-#. :ref:`Publish source code on a public Git hosting platform <publishExtensionGit>`
+#. :ref:`Publish the source code on a public Git hosting platform <publishExtensionGit>`
 #. :ref:`Publish your extension on Packagist <publishExtensionPackagist>`
 #. :ref:`Publish your extension on TER <publishExtensionTer>`
-#. :ref:`Add webhook for documentation <publishExtensionDocumentation>`
+#. :ref:`Publish its documentation in the official TYPO3 documentation <publishExtensionDocumentation>`
 #. :ref:`Set up translations <publishExtensionTranslation>` on Crowdin
 
-*TYPO3 - Inspiring people to share*
+– *TYPO3 - Inspiring people to share*
 
 .. index:: Extension development; Git
 
@@ -37,8 +33,9 @@ repository name, but that is not necessary.
 
 **Advantages:**
 
-* Contributors can add issues or make pull requests
-* Render the documentation on docs.typo3.org (see below) by adding a webhook
+* Contributors can add issues or make pull requests.
+* Documentation can be published in the official TYPO3 documentation
+  by using a webhook (see below).
 
 .. index:: Extension development; Packagist
 
@@ -47,9 +44,11 @@ repository name, but that is not necessary.
 Packagist
 =========
 
-Publish your extension on Packagist
+Publish your extension on `Packagist <https://packagist.org/>`__
+- the main Composer repository.
 
-This is described on `Packagist <https://packagist.org/>`__.
+See their `homepage <https://packagist.org/>`__ for more details
+about the publishing process.
 
 **Depends on:**
 
@@ -57,9 +56,12 @@ This is described on `Packagist <https://packagist.org/>`__.
 
 **Advantages:**
 
-* It is possible to install your extension using `composer require`
-* An update of the extension can be done easily by your users with
-     `composer update`
+* Extension can be installed in a
+  :ref:`Composer based <t3install:install-via-composer>`
+  TYPO3 instance using `composer require`.
+* All advantages of being listed in Packagist, e.g.
+
+  * Extension can be updated easily with `composer update`
 
 .. index:: Extension development; TER
 
@@ -68,22 +70,29 @@ This is described on `Packagist <https://packagist.org/>`__.
 TER
 ===
 
-Publish your extension on TER.
+Publish your extension in the
+`TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__
+- the central storage for public TYPO3 extensions.
 
-See :ref:`Publish an Extension <publishExtensionTer>`
-for more information on how to publish an extension and check out the
-`FAQ <https://extensions.typo3.org/faq/>`__ as well.
+See page :ref:`publish-to-ter` for more information about the
+publishing process and check out the TYPO3 community Q&A at
+page `FAQ <https://extensions.typo3.org/faq/>`__.
 
 **Advantages:**
 
-* Easy finding of your extension in the central Extension Repository
-* The community can vote for your extension
-* Users can subscribe to notifications on new releases
-* Composer package is announced (optional)
-* Sponsoring link (optional)
-* Link to the documentation (optional)
-* Link to the source code (optional)
-* Link to the issue tracker (optional)
+* Extension can be installed in a
+  :ref:`non-Composer based <t3install:install-typo3-without-composer>`
+  TYPO3 instance using the :ref:`Extension Manager <extension-manager>`.
+* All advantages of being listed in the TER, e.g.
+
+  * Easy finding of your extension
+  * The community can vote for your extension
+  * Users can subscribe to notifications on new releases
+  * Composer package is announced (optional)
+  * Sponsoring link (optional)
+  * Link to the documentation (optional)
+  * Link to the source code (optional)
+  * Link to the issue tracker (optional)
 
 .. index:: Extension development; webhook for documentation
 
@@ -92,34 +101,23 @@ for more information on how to publish an extension and check out the
 Documentation
 =============
 
-Publish your documentation on docs.typo3.org.
+Publish the documentation of your extension in the
+`official TYPO3 documentation <https://docs.typo3.org/>`__.
 
-In order for this to work, you must have a :file:`composer.json` and push
-some changes after you registered the webhook.
-
-All the necessary steps are outlined in :ref:`h2document:migrate` except for
-step 4 (request redirects) which is not necessary for new documentation.
+Please follow the instructions on page :ref:`h2document:migrate` to set up
+an appropriate webhook.
 
 **Depends on:**
 
 * Public Git repository
-* Extension published to TER (This is not strictly necessary for documentation
-  rendering. But it makes the workflow easier for the Documentation Team,
-  specifically for the approval process if your extension is already registered
-  on extensions.typo3.org).
+* Extension published in TER (optional).
+  This is not mandatory, but makes the webhook approval easier for the TYPO3
+  Documentation Team.
 
 **Advantages:**
 
-* Your extension documentation will be rendered on `docs.typo3.org <https://docs.typo3.org/>`__
-* The documentation link will be added automatically if your extension is
-  registered on extensions.typo3.org (TER).
-
-.. toctree::
-   :maxdepth: 3
-   :titlesonly:
-   :glob:
-
-   PublishToTER/Index
+* Easily find your extension documentation, which serves as a good companion
+  for getting started with your extension.
 
 .. _publishExtensionTranslation:
 
@@ -132,3 +130,13 @@ you may want to configure the translation setup on https://crowdin.com.
 Crowdin is the official translation server for TYPO3.
 
 This is documented on :ref:`crowdin-extension-integration`.
+
+Further reading
+===============
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+   :glob:
+
+   PublishToTER/Index

--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -33,9 +33,9 @@ repository name, but that is not necessary.
 
 **Advantages:**
 
-* Contributors can add issues or make pull requests.
-* Documentation can be published in the official TYPO3 documentation
-  by using a webhook (see below).
+*  Contributors can add issues or make pull requests.
+*  Documentation can be published in the official TYPO3 documentation
+   by using a webhook (see below).
 
 .. index:: Extension development; Packagist
 
@@ -52,16 +52,16 @@ about the publishing process.
 
 **Depends on:**
 
-* Public Git repository
+*  Public Git repository
 
 **Advantages:**
 
-* Extension can be installed in a
-  :ref:`Composer based <t3install:install-via-composer>`
-  TYPO3 instance using `composer require`.
-* All advantages of being listed in Packagist, for example
+*  Extension can be installed in a
+   :ref:`Composer based <t3install:install-via-composer>`
+   TYPO3 instance using `composer require`.
+*  All advantages of being listed in Packagist, for example
 
-  * Extension can be updated easily with `composer update`
+   *  Extension can be updated easily with `composer update`
 
 .. index:: Extension development; TER
 
@@ -80,19 +80,19 @@ page `FAQ <https://extensions.typo3.org/faq/>`__.
 
 **Advantages:**
 
-* Extension can be installed in a
-  :ref:`non-Composer based <t3install:install-typo3-without-composer>`
-  TYPO3 instance using the :ref:`Extension Manager <extension-manager>`.
-* All advantages of being listed in the TER, for example:
+*  Extension can be installed in a
+   :ref:`non-Composer based <t3install:install-typo3-without-composer>`
+   TYPO3 instance using the :ref:`Extension Manager <extension-manager>`.
+*  All advantages of being listed in the TER, for example:
 
-  * Easy finding of your extension
-  * The community can vote for your extension
-  * Users can subscribe to notifications on new releases
-  * Composer package is announced (optional)
-  * Sponsoring link (optional)
-  * Link to the documentation (optional)
-  * Link to the source code (optional)
-  * Link to the issue tracker (optional)
+   *  Easy finding of your extension
+   *  The community can vote for your extension
+   *  Users can subscribe to notifications on new releases
+   *  Composer package is announced (optional)
+   *  Sponsoring link (optional)
+   *  Link to the documentation (optional)
+   *  Link to the source code (optional)
+   *  Link to the issue tracker (optional)
 
 .. index:: Extension development; webhook for documentation
 
@@ -109,15 +109,15 @@ an appropriate webhook.
 
 **Depends on:**
 
-* Public Git repository
-* Extension published in TER (optional).
-  This is not mandatory, but makes the webhook approval easier for the TYPO3
-  Documentation Team.
+*  Public Git repository
+*  Extension published in TER (optional).
+   This is not mandatory, but makes the webhook approval easier for the TYPO3
+   Documentation Team.
 
 **Advantages:**
 
-* Easily find your extension documentation, which serves as a good companion
-  for getting started with your extension.
+*  Easily find your extension documentation, which serves as a good companion
+   for getting started with your extension.
 
 .. _publishExtensionTranslation:
 

--- a/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
@@ -1,23 +1,28 @@
 .. include:: /Includes.rst.txt
 .. index:: Extension development; Publishing
-.. _publish-extension:
+.. _publish-to-ter:
 
-========================================================
-Publish your extension to the Extension Repository (TER)
-========================================================
+=================================
+Publish your extension in the TER
+=================================
 
 
 Before publishing extension, think about
 ========================================
 
-First of all ask yourself some questions before publishing or even putting some effort in coding:
+First of all ask yourself some questions before publishing or even putting some
+effort in coding:
 
 *  What additional benefit does your extension have for the TYPO3 community?
-*  Does your extension key describe the extension? See the extension key requirements.
+*  Does your extension key describe the extension? See the extension key
+   requirements.
 *  Are there any extensions in the TER yet which have the same functionalities?
-*  If yes, why do we need your one? Wouldn't it be an option to contribute to other extensions?
+*  If yes, why do we need your one? Wouldn't it be an option to contribute to
+   other extensions?
 *  Did you read and understand the `TYPO3 Extension Security Policy <https://typo3.org/community/teams/security/extension-security-policy>`__?
-*  Does your extension include or need external libraries? Watch for the license! Learn more about the `right licensing <https://typo3.org/project/licenses/>`__.
+*  Does your extension include or need external libraries? Watch for the
+   license! Learn more about the
+   `right licensing <https://typo3.org/project/licenses/>`__.
 *  Do you have a public repository on e.g. GitHub, Gitlab or Bitbucket?
 *  Do you have the resources to maintain this extension?
 *  This means that you should
@@ -34,30 +39,63 @@ We would like you to stick to semantic versions.
 
 Given a version number **MAJOR.MINOR.PATCH**, increment the:
 
-*  **MAJOR** version when you make incompatible API changes (known as "**breaking changes**"), 
-*  **MINOR** version when you **add functionality in a backwards-compatible manner**, and
+*  **MAJOR** version when you make incompatible API changes (known as
+   "**breaking changes**"), 
+*  **MINOR** version when you **add functionality in a backwards-compatible
+   manner**, and
 *  **PATCH** version when you **make backwards-compatible bug fixes**.
 
-Additional labels for pre-release and build metadata are available as extensions to the **MAJOR.MINOR.PATCH format**.
+Additional labels for pre-release and build metadata are available as extensions
+to the **MAJOR.MINOR.PATCH format**.
 
 More you can see at `https://semver.org <https://semver.org>`__
 
 Offer feedback options
 ======================
 
-Before you publish an extension you should be aware of what happens after it. Users and integrators will give you
-feedback (contributions, questions, bug reports). In this case you should have
+Before you publish an extension you should be aware of what happens after it.
+Users and integrators will give you feedback (contributions, questions,
+bug reports). In this case you should have
 
-#. A possibility to get in contact with you (link to an issue tracker like forge, GitHub, etc.)
+#. A possibility to get in contact with you (link to an issue tracker like
+   forge, GitHub, etc.)
 #. A possibility to look into the code (link to a public repository)
 
-You can edit these options in the `extension key management <https://extensions.typo3.org/my-extensions>`__ (after login)
+You can edit these options in the
+`extension key management <https://extensions.typo3.org/my-extensions>`__
+(after login)
 
 How to publish an extension
 ===========================
 
-Now we come to the process of publishing. You have two possibilites to release an extension:
+Now we come to the process of publishing in TER. You have three options for
+releasing an extension:
 
-#. Via the web form on extensions.typo3.org (click on "Publish" next to your extension key in the `extension key management <https://extensions.typo3.org/my-extensions>`__).
-#. Via `Tailor <https://github.com/TYPO3/tailor>`__: Tailor is a CLI application to help you maintain your extensions. Tailor talks with the TER REST API and enables you to register new keys, update extension information and publish new versions to the extension repository. (recommended)
-#. Via the SOAP interface using a tool like the `TYPO3 Repository Client <https://github.com/NamelessCoder/typo3-repository-client>`__ (`Documentation <https://github.com/NamelessCoder/typo3-repository-client#typo3-repository-client-apicli>`__) or the `TER client <https://github.com/helhum/ter-client>`__ (`Documentation <https://github.com/helhum/ter-client#ter-client>`__) (deprecated)
+#. Via the web form:
+
+   Click "Upload" next to your extension key in the
+   `extension key management <https://extensions.typo3.org/my-extensions>`__
+   and follow the instructions.
+
+#. Via the REST interface (recommended):
+
+   Use the PHP CLI application `Tailor <https://github.com/TYPO3/tailor>`__
+   which lets you register new extension keys and helps you maintain
+   your extensions, update extension information and publish new extension
+   versions. You can find full documentation and examples on its
+   `homepage <https://github.com/TYPO3/tailor>`__.
+
+   Besides manual publishing, *Tailor* is the perfect complement for
+   automatic publishing via CI / CD pipelines. On the application's homepage
+   you will find integration snippets and below recommended tools that further
+   simplify the integration into common CI / CD pipelines:
+
+   GitHub: https://github.com/tomasnorre/typo3-upload-ter
+
+#. Via the SOAP interface (deprecated):
+
+   Use the PHP CLI application
+   `TYPO3 Repository Client <https://github.com/NamelessCoder/typo3-repository-client>`__
+   , or the `TER Client <https://github.com/helhum/ter-client>`__ based on the
+   TYPO3 Repository Client.
+


### PR DESCRIPTION
Article "Publish your extension"

- reduce redundancy
- add links for further reading on essential parts of TYPO3
- fix link to article "Publish your extension in the TYPO3 Extension Repository (TER)"
- rename docs.typo3.org to "The official TYPO3 documentation"
- align the sentence structure of list items
- add info on Packagist and TER
- separate list items of "Further reading" from list items of "Documentation" advantages

Article "Publish your extension to TER"

- apply maximum line length of 80 characters
- reduce headline length by assuming "TER" is a known term (if required, an introduction text could solve the missing explanation)
- align the sentence structure in list items
- add CI / CD use case information for the Tailor application

Related to: #1420 