### PR TITLE
[FEATURE] Add link to crowdin on publish page

### DIFF
--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -16,7 +16,7 @@ of these.
 #. :ref:`Publish your extension on Packagist <publishExtensionPackagist>`
 #. :ref:`Publish your extension on TER <publishExtensionTer>`
 #. :ref:`Add webhook for documentation <publishExtensionDocumentation>`
-#. :ref:`Configure on Crowdin <publishExtensionTranslation>` for translation
+#. :ref:`Set up translations <publishExtensionTranslation>` on Crowdin
 
 *TYPO3 - Inspiring people to share*
 

--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -8,7 +8,7 @@ Publish your extension
 
 By publishing an extension to the
 `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__, we mean
-making it publicly available. Follow these four steps, we recommend to do all
+making it publicly available. Follow these steps, we recommend to do all
 of these.
 
 
@@ -16,6 +16,7 @@ of these.
 #. :ref:`Publish your extension on Packagist <publishExtensionPackagist>`
 #. :ref:`Publish your extension on TER <publishExtensionTer>`
 #. :ref:`Add webhook for documentation <publishExtensionDocumentation>`
+#. :ref:`Configure on Crowdin <publishExtensionTranslation>` for translation
 
 *TYPO3 - Inspiring people to share*
 
@@ -119,3 +120,15 @@ step 4 (request redirects) which is not necessary for new documentation.
    :glob:
 
    PublishToTER/Index
+
+.. _publishExtensionTranslation:
+
+Crowdin
+=======
+
+If you use language labels which should get translated in your extension
+(typically in :file:`Resources/Private/Languages`),
+you may want to configure the translation setup on http://crowdin.com.
+Crowdin is the official translation server for TYPO3.
+
+This is documented on :ref:`crowdin-extension-integration`.

--- a/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/Index.rst
@@ -128,7 +128,7 @@ Crowdin
 
 If you use language labels which should get translated in your extension
 (typically in :file:`Resources/Private/Languages`),
-you may want to configure the translation setup on http://crowdin.com.
+you may want to configure the translation setup on https://crowdin.com.
 Crowdin is the official translation server for TYPO3.
 
 This is documented on :ref:`crowdin-extension-integration`.


### PR DESCRIPTION
In order to publish an extension, another step is (usually)
necessary: setup the translation on Crowdin. This is already
described in the "Localization" chapter. A small teaser text
and a link is now added to the "Publish an Extension" page.