### PR TITLE
Remove former deprecated example code

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -211,16 +211,6 @@ This can be disabled by setting ``schedulable`` to ``false`` in :file:`Configura
            schedulable: false
 
 
-Or inside :file:`Configuration/Commands.php`.
-Deprecated since v10 and will be removed in v11::
-
-   return [
-       'yourext:dothings' => [
-           'class' => \Vendor\Extension\Command\DoThingsCommand::class,
-           'schedulable' => false,
-       ],
-   ];
-
 Hide a command
 --------------
 


### PR DESCRIPTION
Since this is no longer working in 11 I removed the Commands.php example. It was removed several lines before, too. So it looks like this occurrence was just forgotten.