### PR TITLE
Clearify dependency injection cache flushing

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -61,7 +61,8 @@ This is how a basic :file:`Services.yaml` of an extension looks like. The meanin
 .. note::
 
    Whenever service configuration or class dependencies change, the Core cache needs
-   to be flushed to rebuild the compiled Symfony container.
+   to be flushed in the Install Tool to rebuild the compiled Symfony container.
+   Flush all caches from the cache clear menu does not flush the compiled Symfony container!
 
 .. note::
 

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -62,7 +62,7 @@ This is how a basic :file:`Services.yaml` of an extension looks like. The meanin
 
    Whenever service configuration or class dependencies change, the Core cache needs
    to be flushed in the Install Tool to rebuild the compiled Symfony container.
-   Flush all caches from the cache clear menu does not flush the compiled Symfony container!
+   Flushing all caches from the cache clear menu does not flush the compiled Symfony container.
 
 .. note::
 


### PR DESCRIPTION
Flushing all caches with the cache clear menu in the TYPO3 Backend does not flush the DI container. The cache needs to be flushed with the install tool.

Related change https://forge.typo3.org/projects/typo3cms-core/repository/1749/revisions/e8d2e37199403554609d65f546f7cc76251e7a91