### PR TITLE
[TASK] Replace link to `typo3/tailor` documentation

### DIFF
--- a/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/PublishExtension/PublishToTER/Index.rst
@@ -82,8 +82,8 @@ releasing an extension:
    Use the PHP CLI application `Tailor <https://github.com/TYPO3/tailor>`__
    which lets you register new extension keys and helps you maintain
    your extensions, update extension information and publish new extension
-   versions. You can find full documentation and examples on its
-   `homepage <https://github.com/TYPO3/tailor>`__.
+   versions. For complete instructions and examples, see the official
+   :doc:`Tailor documentation <t3tailor:Index>`.
 
    Besides manual publishing, *Tailor* is the perfect complement for
    automatic publishing via CI / CD pipelines. On the application's homepage

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -32,6 +32,7 @@ t3extbasebook = https://docs.typo3.org/m/typo3/book-extbasefluid/master/en-us/
 t3install     = https://docs.typo3.org/m/typo3/guide-installation/master/en-us/
 t3sitepackage = https://docs.typo3.org/m/typo3/tutorial-sitepackage/master/en-us/
 t3start       = https://docs.typo3.org/m/typo3/tutorial-getting-started/master/en-us/
+t3tailor      = https://docs.typo3.org/other/typo3/tailor/master/en-us/
 t3tca         = https://docs.typo3.org/m/typo3/reference-tca/master/en-us/
 t3tsconfig    = https://docs.typo3.org/m/typo3/reference-tsconfig/master/en-us/
 t3tsref       = https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/


### PR DESCRIPTION
The documentation of the latest development version of TYPO3 Tailor
is published at https://docs.typo3.org/other/typo3/tailor/master/en-us/.

See https://github.com/TYPO3-Documentation/T3DocTeam/issues/160
for further details.