### PR TITLE
[TASK] Use instance of YamlFileLoader

### DIFF
--- a/Documentation/ApiOverview/Yaml/Index.rst
+++ b/Documentation/ApiOverview/Yaml/Index.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-.. index:: 
+.. index::
    ! YAML
    pair: API; YAML
 .. _yaml-api:
@@ -46,7 +46,7 @@ to make use of the loader in your extensions::
 
    // ...
 
-   YamlFileLoader::load(string $fileName, int $flags = self::PROCESS_PLACEHOLDERS | self::PROCESS_IMPORTS)
+   (new YamlFileLoader())->load(string $fileName, int $flags = self::PROCESS_PLACEHOLDERS | self::PROCESS_IMPORTS)
 
 Configuration files can make use of import functionality to reference to the contents of different files.
 


### PR DESCRIPTION
A static call to a non-static method should be avoided as this
throws a deprecation notice in PHP 7.4.