### PR TITLE
Fix PHP syntax error

### DIFF
--- a/Documentation/ApiOverview/RequestHandling/Index.rst
+++ b/Documentation/ApiOverview/RequestHandling/Index.rst
@@ -447,7 +447,7 @@ as constructor dependencies:
                 $res = $this->client->sendRequest($req);
                 // Process data
                 $data = [
-                    'content' => json_decode((string)$res->getBody());
+                    'content' => json_decode((string)$res->getBody())
                 ];
                 $response = $this->responseFactory->createResponse()
                     ->withHeader('Content-Type', 'application/json; charset=utf-8');


### PR DESCRIPTION
Fix PHP syntax error in 'Example usage' code block.