### PR TITLE
[TASK] Routing: Remove "requirements" if there is a corresponding "aspect"

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -234,8 +234,6 @@ And generate the following URLs
        defaultController: 'News::list'
        defaults:
          page: '0'
-       requirements:
-         page: '\d+'
        aspects:
          news_title:
            type: PersistedAliasMapper
@@ -511,8 +509,6 @@ and to explicitly define a range for a value, which is recommended for all kinds
        defaultController: 'News::list'
        defaults:
          page: '0'
-       requirements:
-         page: '\d+'
        aspects:
          page:
            type: StaticRangeMapper


### PR DESCRIPTION
This removes superfluous "requirements" if the route variable has a corresponding "aspect".

See https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/blob/master/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst#aspect-precedence