### PR TITLE
Remove extra text on QueryBuilder page

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -10,7 +10,7 @@ QueryBuilder
    :depth: 1
    :local:
 
-The `QueryBuilder` is a rather huge class that takes care of the main query dealing.
+The `QueryBuilder` takes care of the main query dealing.
 
 An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing
 over the table. Never instantiate and initialize the `QueryBuilder` directly via :php:`makeInstance()`! ::
@@ -21,9 +21,7 @@ over the table. Never instantiate and initialize the `QueryBuilder` directly via
 
 
 This documentation does not mention every single available method but sticks to those
-used in casual queries and normal code flow. There are a couple of not mentioned methods,
-most of them are either very seldom used or marked as internal. Extension authors typically
-don't have to deal with anything not mentioned here.
+commonly used.
 
 .. warning::
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -20,8 +20,7 @@ over the table. Never instantiate and initialize the `QueryBuilder` directly via
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
 
 
-This documentation does not mention every single available method but sticks to those
-commonly used.
+This documentation provides examples for the most commonly used queries.
 
 .. warning::
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -10,7 +10,7 @@ QueryBuilder
    :depth: 1
    :local:
 
-The `QueryBuilder` takes care of the main query dealing.
+The `QueryBuilder` provides a set of methods that allow queries to be built programmatically.
 
 An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing
 over the table. Never instantiate and initialize the `QueryBuilder` directly via :php:`makeInstance()`! ::


### PR DESCRIPTION
Remove text that does not add extra value or is redundant. This makes
the introduction shorter and makes it easier to skim and scroll.