### PR TITLE
Changes to section on QueryBuilder instantiation

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -12,14 +12,6 @@ QueryBuilder
 
 The `QueryBuilder` is a rather huge class that takes care of the main query dealing.
 
-An instance can get hold of by calling the :php:`ConnectionPool->getQueryBuilderForTable()` and handing
-over the table. Never instantiate and initialize the `QueryBuilder` directly via :php:`makeInstance()`! ::
-
-   // use TYPO3\CMS\Core\Utility\GeneralUtility;
-   // use TYPO3\CMS\Core\Database\ConnectionPool;
-   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
-
-
 This documentation does not mention every single available method but sticks to those
 used in casual queries and normal code flow. There are a couple of not mentioned methods,
 most of them are either very seldom used or marked as internal. Extension authors typically
@@ -53,6 +45,26 @@ Most methods of the `QueryBuilder` return `$this` and can be chained::
    // use TYPO3\CMS\Core\Database\Connection;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('pages')->createQueryBuilder();
    $queryBuilder->select('uid')->from('pages');
+
+.. _database-query-builder-instantiation:
+
+Instantiation
+=============
+
+To get an instance of QueryBuilder, you can call
+:php:`ConnectionPool->getQueryBuilderForTable()` and pass the table as argument.
+Never instantiate and initialize the `QueryBuilder` directly via
+:php:`makeInstance()`!
+
+::
+
+   // use TYPO3\CMS\Core\Utility\GeneralUtility;
+   // use TYPO3\CMS\Core\Database\ConnectionPool;
+   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
+
+Please also see the section on
+:ref:`dependency injection arguments <DependencyInjectionArguments>`
+for an example of how to inject a QueryBuilder instance.
 
 .. note::
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -51,15 +51,15 @@ Most methods of the `QueryBuilder` return `$this` and can be chained::
 Instantiation
 =============
 
-To create an instance of the QueryBuilder, call
-:php:`ConnectionPool->getQueryBuilderForTable()` and pass the table as an argument.
-Never instantiate and initialize the `QueryBuilder` using :php:`makeInstance()`.
-
-::
+To create an instance of the :php:`QueryBuilder`, call
+:php:`ConnectionPool::getQueryBuilderForTable()` and pass the table as an argument::
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
+
+.. attention::
+   Never instantiate and initialize the `QueryBuilder` manually using :php:`GeneralUtility::makeInstance()` since you'll miss essential dependencies and runtime setup.
 
 The :ref:`dependency injection arguments <DependencyInjectionArguments>` section
 contains information on how to inject a QueryBuilder instance.

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -51,10 +51,9 @@ Most methods of the `QueryBuilder` return `$this` and can be chained::
 Instantiation
 =============
 
-To get an instance of QueryBuilder, you can call
-:php:`ConnectionPool->getQueryBuilderForTable()` and pass the table as argument.
-Never instantiate and initialize the `QueryBuilder` directly via
-:php:`makeInstance()`!
+To create an instance of the QueryBuilder, call
+:php:`ConnectionPool->getQueryBuilderForTable()` and pass the table as an argument.
+Never instantiate and initialize the `QueryBuilder` using :php:`makeInstance()`.
 
 ::
 
@@ -62,9 +61,8 @@ Never instantiate and initialize the `QueryBuilder` directly via
    // use TYPO3\CMS\Core\Database\ConnectionPool;
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('aTable');
 
-Please also see the section on
-:ref:`dependency injection arguments <DependencyInjectionArguments>`
-for an example of how to inject a QueryBuilder instance.
+The :ref:`dependency injection arguments <DependencyInjectionArguments>` section
+contains information on how to inject a QueryBuilder instance.
 
 .. note::
 

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -125,6 +125,7 @@ For example autoconfiguration ensures that classes which implement
 :php:`\TYPO3\CMS\Core\SingletonInterface` will be publicly available from the
 Symfony container.
 
+.. _DependencyInjectionArguments:
 
 Arguments
 ---------


### PR DESCRIPTION
This change creates a section for the instantiation part and
references between the dependency injection and QueryBuilder
pages.

- Create a section for QueryBuilder instantiation. This way we can
  link to it and makes it easier to find the relevant parts when
  skimming over the page.
- Mention dependency injection as method for instantiating a
  QueryBuilder object and link to it.