### PR TITLE
Add change breaking registerModule() usage

### DIFF
--- a/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
+++ b/Documentation/ExtensionArchitecture/ConfigurationFiles/Index.rst
@@ -241,7 +241,7 @@ You can register a new backend module for your extension via :php:`ExtensionUtil
    // use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
    ExtensionUtility::registerModule(
-      'Vendor.ExtensionName', // Vendor dot Extension Name in CamelCase
+      'ExtensionName', // Extension Name in CamelCase
       'web', // the main module
       'mysubmodulekey', // Submodule key
       'bottom', // Position


### PR DESCRIPTION
This changes a missing occurence of VendorName in the documentation. Using the VendorName prefix was required before v10, deprecated in v10 and is beaking in v11.
This should maybe also be merged in the `10.4` branch.

See also
- [Task #92609 Remove controller alias support](https://forge.typo3.org/issues/92609)
- https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/1096
- https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082
- [Breaking: #92609 - Use controller classes when registering plugins/modules](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/11.0/Breaking-92609-UseControllerClassesWhenRegisteringPluginsmodules.html#breaking-92609-use-controller-classes-when-registering-plugins-modules)