### PR TITLE
[TASK] Avoid warnings on PHP 8 in examples

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
@@ -30,9 +30,7 @@ the cache system falls back to the default backend and default frontend settings
 
 .. code-block:: php
 
-   if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
-   }
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] ??= [];
 
 Extensions like **Extbase** define default caches this way, giving administrators full freedom for specific and
 possibly quicker setups (eg. a memory driven cache for the Extbase reflection cache).

--- a/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
@@ -52,8 +52,9 @@ should hint an integrator about specific caching needs or setups in this case.
 
 .. code-block:: php
 
+   // use \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend;
    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] ??= [];
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] ??= \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] ??= TransientMemoryBackend::class;
 
 
 .. _caching-developer-example:

--- a/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
@@ -29,14 +29,12 @@ and the :ref:`database backend <caching-backend-db>` by default.
 
 .. code-block:: php
 
-   if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
-   }
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] ??= [];
 
 .. tip::
 
-   The :code:`is_array()` check is done to enable administrators to overwrite configuration of caches
-   in :file:`LocalConfiguration.php`. During bootstrap, any :file:`ext_localconf.php` is loaded **after**
+   The null coalescing assignment operator (:code:`??=`) check is used to enable administrators to overwrite configuration of caches in
+   :file:`LocalConfiguration.php`. During bootstrap, any :file:`ext_localconf.php` is loaded **after**
    :file:`DefaultConfiguration.php` and :file:`AdditionalConfiguration.php` are loaded, so it is
    important to make sure that the administrator did not already set any configuration of the
    extensions cache.
@@ -47,19 +45,15 @@ should hint an integrator about specific caching needs or setups in this case.
 
 .. tip::
 
-   Extensions should not force specific settings, therefore the selection is again encapsulated in a
-   :code:`if (!isset())` check to allow administrators to overwrite those settings.
+   Extensions should not force specific settings, therefore the null coalescing
+   assignment operator (:code:`??=`) is used to allow administrators to overwrite those settings.
    It is recommended to set up a cache configuration with sane defaults,
    but administrators should always be able to overwrite them for whatever reason.
 
 .. code-block:: php
 
-   if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] = [];
-   }
-   if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'])) {
-       $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] = \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
-   }
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache'] ??= [];
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['myext_mycache']['backend'] ??= \TYPO3\CMS\Core\Cache\Backend\TransientMemoryBackend::class;
 
 
 .. _caching-developer-example:
@@ -90,9 +84,9 @@ Both can be anything you like, just make sure they are unique and clearly hint a
 Here is some example code which retrieves the cache via dependency injection::
 
    namespace Acme\MyExt;
-   
+
    use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
-   
+
    class MyClass
    {
        /**
@@ -118,7 +112,7 @@ Here is some example code which retrieves the cache via dependency injection::
                // Save value in cache
                $this->cache->set($cacheIdentifier, $value, $tags, $lifetime);
            }
-           
+
            return $value;
        }
 


### PR DESCRIPTION
Additionally, use ??= operator as TYPO3 v11 uses PHP 7.4+,
which simplifies the code.