### PR TITLE
[Deprecation] #95200 - Deprecate RequireJS callbacks as inline JavaSc…

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -203,8 +203,6 @@ takes care of basic keys:
     ]
 
 CSS and language labels (which can be used in JS) are added with their file names in format :php:`EXT:extName/path/to/file`.
-JavaScript is added only via RequireJS modules, the registration allows an init method to be called if the
-module is loaded by the browser.
 
 .. note::
    The result array handled by :php:`$this->mergeChildReturnIntoExistingResult()` contains a couple of more keys, those
@@ -214,6 +212,40 @@ module is loaded by the browser.
    Nodes must never add JavaScript or CSS or similar stuff using the :php:`PageRenderer`. This fails as soon
    as this container / element / wizard is called via AJAX, for instance within inline. Instead, those resources
    must be registered via the result array only, using :php:`stylesheetFiles` and :php:`requireJsModules`.
+
+Adding RequireJS modules
+------------------------
+
+.. deprecated:: 11.5
+   Using callback functions is deprecated and shall be replaced by new 
+   JavaScriptModuleInstruction declarations. In FormEngine, loading RequireJS 
+   module via arrays is deprecated and has to be migrated as well.
+
+JavaScript is added only via RequireJS modules, the registration allows an 
+init method to be called if the module is loaded by the browser. This can 
+be done using the function :php:` JavaScriptModuleInstruction::forRequireJS`.
+
+.. code-block:: php
+   :caption: Example in a FormEngine component
+
+   $resultArray['requireJsModules'][] = JavaScriptModuleInstruction::forRequireJS(
+       'TYPO3/CMS/Backend/FormEngine/Element/InputDateTimeElement'
+   )->instance($fieldId);
+
+:php:`JavaScriptModuleInstruction` allows to declare the following
+aspects when loading RequireJS modules:
+
+*  :php:`$instruction = JavaScriptModuleInstruction::forRequireJS('TYPO3/CMS/Module')`
+   creates corresponding loading instruction that can be enriched with following declarations
+*  :php:`$instruction->assign(['key' => 'value'])` allows to assign key-value pairs
+   directly to the loaded RequireJS module object or instance
+*  :php:`$instruction->invoke('method', 'value-a', 'value-b')` allows to invoke
+   a particular method of the loaded RequireJS instance with given argument values
+*  :php:`$instruction->instance('value-a', 'value-b')` allows to invoke the
+   constructor of the loaded RequireJS class with given argument values
+
+Initializations other than the provided aspects have to be implemented in
+custom module implementations, for example triggered by corresponding on-ready handlers.
 
 
 .. _FormEngine-Rendering-NodeExpansion:


### PR DESCRIPTION
…ript

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Deprecation-95200-DeprecateRequireJSCallbacksAsInlineJavaScript.html
refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1522