### PR TITLE
Add warning for Flash messages in Extbase

### DIFF
--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -142,6 +142,12 @@ in the controller. Code from the "examples" extension::
 
    $this->addFlashMessage('This is a simple success message');
 
+.. warning::
+
+   You cannot call this function in the constructor of a Controller
+   or in an initialize Action as it needs some internal data 
+   structures to be initialized.
+
 
 The full API of this function is::
 


### PR DESCRIPTION
If addFlashMessage() is called in an initialize action (e.g. initializeShowAction()),
an exception is thrown due to $this->controllerContext not beeing initialized.