### PR TITLE
Change example on Flexform page

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -40,6 +40,10 @@ for the carousel content element.
    :class: with-shadow
 
 
+Another extensions that utilize FlexForms and can be used as example is:
+
+* `georgringer/news <https://github.com/georgringer/news>`__
+
 How it works
 ============
 

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -39,11 +39,6 @@ for the carousel content element.
 .. figure:: /Images/ManualScreenshots/FlexForms/FlexFormCarousel.png
    :class: with-shadow
 
-Some more extensions that utilize FlexForms are:
-
-* `blog <https://github.com/TYPO3GmbH/blog>`__: This has a very small and
-  basic FlexForm, so it might be a good starting point to look at.
-
 
 How it works
 ============


### PR DESCRIPTION
~~The Flexform page refers to EXT:blog as an example, but this extension is not using Flexforms in the latest version.~~

Replace example for Flexforms
    
Refer to EXT:news instead of EXT:blog as example because EXT:blog no longer uses FlexForms.
