### PR TITLE
Link to correct core version

### DIFF
--- a/Documentation/ApiOverview/BackendRouting/Index.rst
+++ b/Documentation/ApiOverview/BackendRouting/Index.rst
@@ -158,5 +158,5 @@ handles backend routing in your TYPO3 version.
 * `Scripting-Base: "PSR-7 for backend modules" <https://scripting-base.de/blog/psr-7-for-backend-modules>`__
 * `Scripting-Base: "AJAX with PSR-7" <https://scripting-base.de/blog/ajax-with-psr-7.html>`__
 * `PSR-7 <https://www.php-fig.org/psr/psr-7/>`__
-* TYPO3 Core : `backend : AjaxRoutes.php <https://github.com/typo3/typo3/blob/9.5/typo3/sysext/backend/Configuration/Backend/AjaxRoutes.php>`__ (GitHub)
-* TYPO3 Core : `backend : Routes.php <https://github.com/typo3/typo3/blob/9.5/typo3/sysext/backend/Configuration/Backend/Routes.php>`__ (GitHub)
+* TYPO3 Core : `backend : AjaxRoutes.php <https://github.com/typo3/typo3/blob/master/typo3/sysext/backend/Configuration/Backend/AjaxRoutes.php>`__ (GitHub)
+* TYPO3 Core : `backend : Routes.php <https://github.com/typo3/typo3/blob/master/typo3/sysext/backend/Configuration/Backend/Routes.php>`__ (GitHub)


### PR DESCRIPTION
Releases: master, 11, 10

Must be adapted when backported.

I don't know if there is some generic way to link to core which will automatically use the current version, that might be useful. 