### PR TITLE
Remove vague phrase

### DIFF
--- a/Documentation/ApiOverview/Internationalization/TranslationServer/Crowdin/ExtensionIntegration.rst
+++ b/Documentation/ApiOverview/Internationalization/TranslationServer/Crowdin/ExtensionIntegration.rst
@@ -27,7 +27,7 @@ Get in contact with the team in the TYPO3 slack channel *cig-crowdin-localizatio
 Integration
 ===========
 
-You need to handle the integration yourself as you got the permissions on GitHub.
+You need to handle the integration yourself.
 
 Go to the url of your project at Crowdin (e.g. `<https://crowdin.com/project/typo3-extension-ttaddress>`_) and switch to **Settings** & then switch to the tab **Integrations**. Click on the button **Setup integration**.
 


### PR DESCRIPTION
Remove vague phrase which can be confusing.

----

Following is not in commit message.

"as you got permissions on GitHub"

* why GitHub? Above it is mentioned GitHub, Gitlab and bitbucket are supported.
* what is meant by "as you got"? "Because you have"?
 
Since the phrase is not really necessary and just serves to confuse (IMHO), I think it is better to remove it. Also, removing of any fluff (unnecessary words or phrases, duplicate information etc.) helps to read and skim faster and more easily. 