### PR TITLE
Remove link to Service API Migration section

### DIFF
--- a/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
+++ b/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
@@ -258,7 +258,7 @@ Migration
 
 .. deprecated:: 11.3
    The abstract class :php:`\TYPO3\CMS\Core\Service\AbstractService` has been
-   deprecated. See :ref:`services-developer-service-api-migration`.
+   deprecated.
 
 Remove any usage of the class :php:`\TYPO3\CMS\Core\Service\AbstractService` in
 your extension. In case you currently


### PR DESCRIPTION
The section contained a link to itself which is removed with this change.