### PR TITLE
Drop pointless link to cache tags section

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
@@ -102,8 +102,6 @@ an arbitrary number of tags can be assigned to an entry and one specific tag
 can be assigned to multiple cache entries. All tags a cache entry has are given to
 the cache when the entry is stored ("set").
 
-Also see :ref:`clear cache in DataHandler using cache tags <caching-architecture-tags>`.
-
 
 .. _caching-architecture-core:
 


### PR DESCRIPTION
The section should not link to itself.