### PR TITLE
[DOCS] Update feature toggle examples

### DIFF
--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -25,7 +25,8 @@ Examples for features are:
 Naming of feature toggles
 =========================
 
-Feature names should NEVER be named "enable" or have a negation, or contain versions or years and should be :php:`loweCamelCase`d.
+Feature names should NEVER be named "enable" or have a negation, or contain versions or years.
+It is recommended to use `lowerCamelCase` notation for the feature names.
 
 Bad examples:
 

--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -25,7 +25,7 @@ Examples for features are:
 Naming of feature toggles
 =========================
 
-Feature names should NEVER be named "enable" or have a negation, or contain versions or years.
+Feature names should NEVER be named "enable" or have a negation, or contain versions or years and should be :php:`loweCamelCase`d.
 
 Bad examples:
 

--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -114,11 +114,11 @@ With the new function :typoscript:`feature()` the feature toggle can be checked.
 
 .. code-block:: typoscript
 
-   [feature("TypoScript.strictSyntax")]
-   # This condition matches if the feature toggle "TypoScript.strictSyntax" is true
+   [feature("unifiedPageTranslationHandling")]
+   # This condition matches if the feature toggle "unifiedPageTranslationHandling" is true
    [END]
 
-   [feature("TypoScript.strictSyntax") === false]
-   # This condition matches if the feature toggle "TypoScript.strictSyntax" is false
+   [feature("unifiedPageTranslationHandling") === false]
+   # This condition matches if the feature toggle "unifiedPageTranslationHandling" is false
    [END]
 

--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -38,11 +38,11 @@ Bad examples:
 
 Good examples:
 
-- `ExtendedRichtextFormat`
-- `NativeYamlParser`
-- `InlinePageTranslations`
-- `TypoScriptParserIncludesAsXml`
-- `NativeDoctrineQueries`
+- `extendedRichtextFormat`
+- `nativeYamlParser`
+- `inlinePageTranslations`
+- `typoScriptParserIncludesAsXml`
+- `nativeDoctrineQueries`
 
 .. _feature-toggles-api:
 
@@ -53,11 +53,11 @@ For extension authors, the API can be used for any custom feature provided by an
 
 To register a feature and set the default state, add the following to the :file:`ext_localconf.php`: of your extension::
 
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['MyFeatureName'] ??= true; // or false;
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['myFeatureName'] ??= true; // or false;
 
 To check if a feature is enabled use this code::
 
-   if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('MyFeatureName')) {
+   if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('myFeatureName')) {
       // do custom processing
    }
 
@@ -70,7 +70,7 @@ To check if a feature is enabled use this code::
 
    .. code-block:: php
 
-      $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['MyFeatureName'] = true;
+      $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['myFeatureName'] = true;
 
 The name can be any arbitrary string, but an extension author should prefix the feature with the
 extension name as the features are global switches which otherwise might lead to naming conflicts.
@@ -83,7 +83,7 @@ Core feature toggles
 Some examples for feature toggles in the TYPO3 Core:
 
 - `redirects.hitCount`: Enables hit statistics in the redirects backend module
-- `TypoScript.strictSyntax`: If on, TypoScript is parsed in strict syntax modes.
+- `typoScript.strictSyntax`: If on, TypoScript is parsed in strict syntax modes.
   Enabling this feature means old condition syntax (which is deprecated) will
   trigger deprecation messages.
 

--- a/Documentation/ApiOverview/FeatureToggles/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggles/Index.rst
@@ -53,11 +53,11 @@ For extension authors, the API can be used for any custom feature provided by an
 
 To register a feature and set the default state, add the following to the :file:`ext_localconf.php`: of your extension::
 
-   $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['myFeatureName'] ??= true; // or false;
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['MyFeatureName'] ??= true; // or false;
 
 To check if a feature is enabled use this code::
 
-   if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('myFeatureName')) {
+   if (TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(TYPO3\CMS\Core\Configuration\Features::class)->isFeatureEnabled('MyFeatureName')) {
       // do custom processing
    }
 
@@ -70,7 +70,7 @@ To check if a feature is enabled use this code::
 
    .. code-block:: php
 
-      $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['myFeatureName'] = true;
+      $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['MyFeatureName'] = true;
 
 The name can be any arbitrary string, but an extension author should prefix the feature with the
 extension name as the features are global switches which otherwise might lead to naming conflicts.


### PR DESCRIPTION
The documentation clearly states that feature names should start with an uppercase letter, the examples clearly don't follow this, therefore I suggest to fix it :-)