### PR TITLE
Reduce markup

### DIFF
--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -9,7 +9,7 @@
 Configuration
 =============
 
-Configuring the Doctrine DBAL for `TYPO3 CMS` is all about specifying the single database endpoints
+Configuring the Doctrine DBAL for TYPO3 CMS is all about specifying the single database endpoints
 and handing over connection credentials. The framework supports the parallel usage of multiple
 database connections, a specific connection is mapped depending on its table name. The table space
 can be seen as a transparent layer that determines which specific connection is chosen for a query
@@ -49,7 +49,7 @@ Remarks:
   connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
   must be used as `host` value.
 
-* The connect options are hand over to Doctrine DBAL without much manipulation from `TYPO3 CMS` side.
+* The connect options are hand over to Doctrine DBAL without much manipulation from TYPO3 CMS side.
   Please refer to the
   `doctrine connection docs <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
   for a full overview of settings.
@@ -112,6 +112,6 @@ Remarks:
     Connections to databases `postgres`, `maria` and `mysql` are actively tested.
     However, `mssql` is currently not actively tested.
 
-    Furthermore, the `TYPO3 CMS` installer supports only a single `mysql` or `mariadb` connection
+    Furthermore, the TYPO3 CMS installer supports only a single `mysql` or `mariadb` connection
     at the moment and the connection details can not be properly edited within the `All configuration`
     section of the Install Tool.

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -11,7 +11,7 @@ An instance of class :php:`TYPO3\CMS\Core\Database\Connection` is retrieved from
 and handing over the table name a query should executed on.
 
 The class extends the basic Doctrine DBAL `Doctrine\DBAL\Connection` class and is mainly
-used internally within the `TYPO3 CMS` framework to establish, maintain and terminate
+used internally within the TYPO3 CMS framework to establish, maintain and terminate
 connections to single database endpoints. Those internal methods are not scope of this
 documentation since an extension developer usually doesn't have to deal with that.
 
@@ -177,7 +177,7 @@ argument specifies the quoting of `WHERE` values. There is a pattern ;)
 
 .. note::
 
-    `TYPO3 CMS` uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
+    TYPO3 CMS uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
     a field - often called `deleted` - is set from 0 to 1. Executing a `DELETE` query circumvents this and really
     removes rows from a table. For most tables, it is better to use the :ref:`DataHandler <tce-database-basics>` API
     to handle deletes instead of executing such low level queries directly.

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -53,7 +53,7 @@ doctrine without an extension developer taking care of that specifically.
 
 The API provided by the Core is basically a pretty small and lightweight facade
 in front of Doctrine DBAL that adds some convenient methods as well as some
-`TYPO3 CMS` specific sugar. The facade additionally provides methods to retrieve
+TYPO3 CMS specific sugar. The facade additionally provides methods to retrieve
 specific connection objects per configured database connection based on the table
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -6,7 +6,7 @@
 RestrictionBuilder
 ==================
 
-Database tables in `TYPO3 CMS` that can be administrated in the backend come with
+Database tables in TYPO3 CMS that can be administrated in the backend come with
 :ref:`TCA <t3tca:start>` definitions that
 specify how single fields and rows of the table should be handled and displayed
 by the framework.
@@ -24,7 +24,7 @@ dealing with low-level query stuff must take care overlayed or deleted rows
 are not in the result set of a casual query.
 
 This is where this "automatic restriction" stuff kicks in: The construct is created
-on top of native Doctrine DBAL as `TYPO3 CMS` specific extension. It automatically
+on top of native Doctrine DBAL as TYPO3 CMS specific extension. It automatically
 adds `WHERE` expressions that suppress rows which are marked as deleted or exceeded
 their "active" life cycle. All that is based on the `TCA` configuration of the affected table.
 

--- a/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
+++ b/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
@@ -6,9 +6,9 @@
 Various Tips and Tricks
 =======================
 
-* Use `Find usages` of `PhpStorm` for examples! The source code of the Core is a great way to
-  learn how specific methods of the API are used. In `PhpStorm` it is extremely helpful to right
-  click on a single method and list all method usages with `Find usages`. This is especially handy
+* Use :guilabel:`Find usages` of PhpStorm for examples! The source code of the Core is a great way to
+  learn how specific methods of the API are used. In PhpStorm it is extremely helpful to right
+  click on a single method and list all method usages with :guilabel:`Find usages`. This is especially handy
   to quickly see usage examples of complex methods like :php:`join()` from the `QueryBuilder`.
 
 * `INSERT`, `UPDATE` and `DELETE` statements are often easier to read and write


### PR DESCRIPTION
- do not use inline code markup for "TYPO3 CMS" and PhpStorm
- use guilabel where it refers to GUI elements (in this case
  in PhpStorm

Related: TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument#241