### PR TITLE
Add hint about comprehensive list in API class reference

### DIFF
--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -22,6 +22,10 @@ be called to adjust the information.
 Environment PHP API
 ===================
 
+.. tip::
+   A comprehensive list of methods can be found in the
+   `Class Reference <https://api.typo3.org/master/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_core_1_1_environment.html>`__.
+
 .. index::
    Environment; getProjectPath
    File; composer.json

--- a/Documentation/ApiOverview/Environment/Index.rst
+++ b/Documentation/ApiOverview/Environment/Index.rst
@@ -24,7 +24,7 @@ Environment PHP API
 
 .. tip::
    A comprehensive list of methods can be found in the
-   `Class Reference <https://api.typo3.org/master/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_core_1_1_environment.html>`__.
+   `Class Reference <https://api.typo3.org/main/class_t_y_p_o3_1_1_c_m_s_1_1_core_1_1_core_1_1_environment.html>`__.
 
 .. index::
    Environment; getProjectPath


### PR DESCRIPTION
As not all methods are documented [here](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Environment/Index.html), I added a tip with a link to the API class reference:

![image](https://user-images.githubusercontent.com/54318829/144234751-a5c5b6d5-d210-4a10-85ac-58b5d576979a.png)

Releases: main, 11.5