### PR TITLE
Breaking: #96041 - Toolbar items: Register by tag

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
@@ -816,6 +816,12 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']
    :Default: []
 
    Registered toolbar items classes
+   
+.. note::
+   This configuration variable will be removed with version 12.0. Extensions who want to 
+   support both LTS 11 and 12 can set this variable and depend on Services to load the 
+   toolbar in LTS 12.  Using this configuration variable is **not deprecated** in 
+   LTS 11.
 
 
 .. index::


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96041-ToolbarItemsRegisterByTag.html

references: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624

releases: 11.5 (only)