### PR TITLE
Use new fetch functions for Doctrine

### DIFF
--- a/Documentation/ApiOverview/Database/BasicCrud/Index.rst
+++ b/Documentation/ApiOverview/Database/BasicCrud/Index.rst
@@ -62,7 +62,7 @@ Straight fetch of a single row from `tt_content` table:
             'tt_content', // from
             [ 'uid' => (int)$uid ] // where
         )
-        ->fetch();
+        ->fetchAssociative();
 
 
 Result in $row:
@@ -124,7 +124,7 @@ Advanced query using the `QueryBuilder` and manipulating the default restriction
             )
         )
         ->execute()
-        ->fetchAll();
+        ->fetchAllAssociative();
 
 Result in $rows:
 

--- a/Documentation/ApiOverview/Database/ClassOverview/Index.rst
+++ b/Documentation/ApiOverview/Database/ClassOverview/Index.rst
@@ -43,6 +43,6 @@ Restriction ...
 
 Statement
    :php:`Doctrine\DBAL\Driver\Statement`: :ref:`Result object <database-statement>` retrieved if a `SELECT`
-   or `COUNT` query has been executed. Single rows are returned as array by calling `->fetch()` until
+   or `COUNT` query has been executed. Single rows are returned as array by calling `->fetchAssociative()` until
    the method returns `false`.
 

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -265,7 +265,7 @@ quoted::
 Remarks:
 
 * In contrast to the other short-hand methods, :php:`->select()` returns a :ref:`Statement <database-statement>` object
-  ready to :php:`->fetch()` single rows or to :php:`->fetchAll()`
+  ready to :php:`->fetchAssociative()` single rows or to :php:`->fetchAllAssociative()`
 
 * The method accepts a series of further arguments to specify `GROUP BY`, `ORDER BY`, `LIMIT` and `OFFSET` query parts.
 
@@ -324,5 +324,5 @@ The method can be helpful in loops to save some precious code characters, too::
          ->from('whatever')
          ->where(...)
          ->execute()
-         ->fetchAll();
+         ->fetchAllAssociative();
    }

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -35,7 +35,7 @@ to use it within the code flow of the `QueryBuilder` context directly::
          $queryBuilder->expr()->eq('header', $queryBuilder->createNamedParameter('peter'))
       )
       ->execute()
-      ->fetchAll();
+      ->fetchAllAssociative();
 
 .. warning::
 
@@ -211,7 +211,7 @@ Examples::
       )
       ->from('tt_content')
       ->execute()
-      ->fetch();
+      ->fetchAssociative();
 
    // Distinct list of all existing endtime values from tt_content
    // SELECT `uid`, MAX(`endtime`) AS `maxendtime` FROM `tt_content` GROUP BY `endtime`

--- a/Documentation/ApiOverview/Database/Migration/Index.rst
+++ b/Documentation/ApiOverview/Database/Migration/Index.rst
@@ -188,7 +188,7 @@ Result Set Iteration
 ====================
 
 The `exec_*` calls return a resource object that is typically iterated over using :php:`sql_fetch_assoc()`.
-This is typically changed to :php:`->fetch()` on the `Statement` object::
+This is typically changed to :php:`->fetchAssociative()` on the `Statement` object::
 
    // Before:
    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery(...);
@@ -198,7 +198,7 @@ This is typically changed to :php:`->fetch()` on the `Statement` object::
 
    // After:
    $statement = $queryBuilder->execute();
-   while ($row = $statement->fetch()) {
+   while ($row = $statement->fetchAssociative()) {
       // Do something
    }
 

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -117,8 +117,8 @@ A useful combination of :php:`->select()` and :php:`->addSelect()` can be::
       $queryBuilder->addSelect(...$additionalFields);
    }
 
-Calling :php:`->execute()` on a :php:`->select()` query returns a `Statement` object. To receive single rows a :php:`->fetch()`
-loop on that object is used, or :php:`->fetchAll()` to return a single array with all rows. A typical code flow
+Calling :php:`->execute()` on a :php:`->select()` query returns a `Statement` object. To receive single rows a :php:`->fetchAssociative()`
+loop on that object is used, or :php:`->fetchAllAssociative()` to return a single array with all rows. A typical code flow
 of a `SELECT` query looks like::
 
    // use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -131,7 +131,7 @@ of a `SELECT` query looks like::
          $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus'))
       )
       ->execute();
-   while ($row = $statement->fetch()) {
+   while ($row = $statement->fetchAssociative()) {
       // Do something with that single row
       debug($row);
    }
@@ -167,7 +167,7 @@ Create a `COUNT` query, a typical usage::
          $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus'))
        )
       ->execute()
-      ->fetchColumn(0);
+      ->fetchOne();
 
 
 Remarks:
@@ -177,7 +177,7 @@ Remarks:
   defined in `TCA`.
 
 * Similar to :php:`->select()` query types, :php:`->execute()` with :php:`->count()` returns a `Statement` object. To
-  fetch the number of rows directly, use :php:`->fetchColumn(0)`.
+  fetch the number of rows directly, use :php:`->fetchOne()`.
 
 * First argument to :php:`->count()` is required, typically :php:`->count(*)` or :php:`->count('uid')` is used, the field
   name is automatically quoted.
@@ -574,7 +574,7 @@ argument::
       ->from('sys_language')
       ->orderBy('sorting')
       ->execute()
-      ->fetchAll();
+      ->fetchAllAssociative();
 
 
 Remarks:

--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -198,7 +198,7 @@ backend module::
       ->from('tt_content')
       ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, \PDO::PARAM_INT)))
       ->execute()
-      ->fetchAll();
+      ->fetchAllAssociative(();
 
 The `DeletedRestriction` should be kept in almost all cases. Usually, the only extension that dismiss
 that flag is the recycler module to list and resurrect deleted records. Any object implementing the

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -11,8 +11,20 @@ Statement
 A `Statement` object is returned by :php:`QueryBuilder->execute()` for :php:`->select()` and :php:`->count()`
 query types and by :php:`Connection->select()` and :php:`Connection->count()` calls.
 
-The object represents a query result set and comes with methods to :php:`->fetch()` single rows
-or to :php:`->fetchAll()` of them. Additionally, it can also be used to execute a single prepared
+.. todo: remove this note after requirement to doctrine/dbal 3, probably TYPO3 v12
+
+.. note::
+
+   The functions :php:`->fetch()`, :php:`->fetchAll()` and :php:`fetchColumn()` were
+   `deprecated in doctrine/dbal 2.13 <https://www.doctrine-project.org/2021/03/29/dbal-2.13.html>`__
+   and will be removed in DBAL3. It is recommended to use
+   :php:`->fetchAssociative()`, :php:`->fetchAllAssociative()` or
+   :php:`fetchOne()` respectively.
+
+
+The object represents a query result set and comes with methods to fetch single rows
+with :php:`->fetch()` or to fetch all rows with :php:`->fetchAllAssociative()`.
+Additionally, it can also be used to execute a single prepared
 statement with different values multiple times. This part is however not widely used within
 the TYPO3 Core yet, and thus not fully documented here.
 
@@ -35,8 +47,8 @@ the TYPO3 Core yet, and thus not fully documented here.
    `DBMS` compatibility.
 
 
-fetch()
-=======
+fetchAssociative()
+==================
 
 Fetch next row from a result statement. Usually used in while() loops. Typical example::
 
@@ -49,17 +61,17 @@ Fetch next row from a result statement. Usually used in while() loops. Typical e
       ->from('tt_content')
       ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT)))
       ->execute();
-   while ($row = $statement->fetch()) {
+   while ($row = $statement->fetchAssociative()) {
       // Do something useful with that single $row
    }
 
 
-:php:`->fetch()` returns arrays with single field / values pairs until the end of the result set is reached
+:php:`->fetchAssociative()` returns arrays with single field / values pairs until the end of the result set is reached
 which then returns false and thus breaks the while loop.
 
 
-fetchAll()
-==========
+fetchAllAssociative()
+=====================
 
 Returns an array containing all of the result set rows by implementing the same while loop as above internally.
 Using that method saves some precious code characters but is more memory intensive if the result set is large
@@ -74,11 +86,11 @@ with lots of rows and lot of data since big arrays are carried around in `PHP`::
       ->from('tt_content')
       ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT)))
       ->execute()
-      ->fetchAll();
+      ->fetchAllAssociative();
 
 
-fetchColumn()
-=============
+fetchOne()
+==========
 
 Returns a single column from the next row of a result set, other columns from that result row are discarded.
 This method is especially handy for :php:`QueryBuilder->count()` queries. The :php:`Connection->count()` implementation
@@ -93,14 +105,14 @@ does exactly that to return the number of rows directly::
       ->from('tt_content')
       ->where($queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT)))
       ->execute()
-      ->fetchColumn(0);
+      ->fetchOne();
 
 
 rowCount()
 ==========
 
 Returns the number of rows affected by the last execution of this statement. Use that method
-instead of counting the number of records in a :php:`->fetch()` loop manually.
+instead of counting the number of records in a :php:`->fetchAssociative()` loop manually.
 
 .. warning::
 
@@ -130,11 +142,11 @@ and executes it twice with different arguments::
         ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createPositionalParameter(0, \PDO::PARAM_INT)))
         ->getSQL();
     $statement = $connection->executeQuery($sqlStatement, [ 24 ]);
-    $result1 = $statement->fetch();
+    $result1 = $statement->fetchAssociative();
     $statement->closeCursor(); // free the resources for this result
     $statement->bindValue(1, 25);
     $statement->execute();
-    $result2 = $statement->fetch();
+    $result2 = $statement->fetchAssociative();
     $statement->closeCursor(); // free the resources for this result
 
 

--- a/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
+++ b/Documentation/ApiOverview/Database/TipsAndTricks/Index.rst
@@ -33,6 +33,6 @@ Various Tips and Tricks
   query errors. Note this is not good habit and often indicates an architectural flaw of the application
   at a different layer.
 
-* :php:`count()` query types using the `QueryBuilder` typically call :php:`->fetchColumn(0)` to receive the count
+* :php:`count()` query types using the `QueryBuilder` typically call :php:`->fetchOne()` to receive the count
   value. The :php:`count()` method of `Connection` object does that automatically and returns the count value
   result directly.


### PR DESCRIPTION
In the package doctrine/dbal 2.13, the functions fetch(), fetchAll()
and fetchColumn() have been deprecated. They will be removed in v3.
TYPO3 has replaced the function calls with the calls
fetchAssociative(), fetchAssociativeAll() and fetchOne() in TYPO3
v11.

Releases: master, 11.5

-----

Not part of commit message:

see 
* https://www.doctrine-project.org/2021/03/29/dbal-2.13.html
* https://review.typo3.org/c/Packages/TYPO3.CMS/+/70125
* 