### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -606,7 +606,9 @@ Resources/Private/Templates
 
 Resources/Public
    Public assets of extensions (files that should be delivered by the web
-   server) must be located in Resources/Public folder of the extension.
+   server) must be located in Resources/Public folder of the extension. This folder should
+   only be used for static assets of your extension. If you need to create assets
+   during runtime, they should go into :code:`typo3temp/`.
 
    .. deprecated:: 11.5
       Having public assets in any but the folder Resources/Public has been


### PR DESCRIPTION
Improve wording for an extension's public resources. Added hint that dynamic assets should be put into `typo3temp` instead of `Public/Resources`.