### PR TITLE
Add extension-key to composer.json (10.4)

### DIFF
--- a/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
+++ b/Documentation/ExtensionArchitecture/ComposerJson/Index.rst
@@ -61,6 +61,11 @@ Subsequently:
            "psr-4": {
                "Vendorname\\MyExtension\\": "Classes/"
            }
+       },
+       "extra": {
+          "typo3/cms": {
+             "extension-key": "my_extension"
+          }
        }
    }
 
@@ -110,6 +115,11 @@ Extended composer.json
            "psr-4": {
                "Vendorname\\MyExtension\\": "Classes/"
            }
+       },
+       "extra": {
+          "typo3/cms": {
+             "extension-key": "my_extension"
+          }
        },
        "require-dev": {
           "nimut/testing-framework": "^4.2 || ^5.1"


### PR DESCRIPTION
This is required but was missing in < v11.