### PR TITLE
[TASK] Remove references to the `ignore-as-root` switch

### DIFF
--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -237,9 +237,6 @@ hook. This one is interesting. That class of the testing framework links the mai
 extension `.Build/Web/typo3conf/ext/enetcache` in our extension specific TYPO3 instance. It needs the
 two additional properties `web-dir` and `extension-key` to do that.
 
-The `ignore-as-root` entry allows our project to be recognized as an extension
-even though it is the root project (which is disabled by default in TYPO3 11.4 and up).
-
 Now, before we start playing around with this setup, we instruct `git` to ignore runtime
 on-the-fly files. The :file:`.gitignore` looks like this::
 


### PR DESCRIPTION
This switch in the `composer.json` was very short-lived and
was never released in a LTS version of the core.

This reverts commit a3e82245ac97d721c83cae2375417a3061073394.