### PR TITLE
Remove the "One level higher" from the paths

### DIFF
--- a/Documentation/ApiOverview/JavaScript/RequireJS/Shim/Index.rst
+++ b/Documentation/ApiOverview/JavaScript/RequireJS/Shim/Index.rst
@@ -23,7 +23,7 @@ be defined in the :php:`PageRenderer`::
       [
          'paths' => [
             'jquery' => 'sysext/core/Resources/Public/JavaScript/Contrib/jquery/',
-            'plupload' => '../typo3conf/ext/your_extension/node_modules/plupload/js/plupload.full.min',
+            'plupload' => '/typo3conf/ext/your_extension/node_modules/plupload/js/plupload.full.min',
          ],
          'shim' => [
             'deps' => ['jquery'],

--- a/Documentation/ApiOverview/JavaScript/RequireJS/Shim/Index.rst
+++ b/Documentation/ApiOverview/JavaScript/RequireJS/Shim/Index.rst
@@ -23,7 +23,7 @@ be defined in the :php:`PageRenderer`::
       [
          'paths' => [
             'jquery' => 'sysext/core/Resources/Public/JavaScript/Contrib/jquery/',
-            'plupload' => '/typo3conf/ext/your_extension/node_modules/plupload/js/plupload.full.min',
+            'plupload' => \TYPO3\CMS\Core\Utility\PathUtility::getPublicResourceWebPath('EXT:your_extension/node_modules/plupload/js/plupload.full.min'),
          ],
          'shim' => [
             'deps' => ['jquery'],


### PR DESCRIPTION
When using an own extension to acquire the JS files, we do not need to go one one level higher to get the file. If we add the two dots **(../)** then the path looks like this:

`<script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="leaflet" src="./../typo3conf/ext/my_ext/Resources/Public/JavaScript/leaflet.js?bust=1641223806"></script> `

and this redirects to the main Backend page because it does not find the file and as a result it response with an HTML header instead of a JavaScript program. 

If we remove the two dots and keep the tracing slash, TYPO3 responds with the right header and the JavaScript works again. It looks like this:

`<script type="text/javascript" charset="utf-8" async="" data-requirecontext="_" data-requiremodule="leaflet" src="/typo3conf/ext/my_ext/Resources/Public/JavaScript/leaflet.js?bust=1641223806"></script>`