### PR TITLE
Fix single quotes in code example

### DIFF
--- a/Documentation/ApiOverview/PageTitleApi/Index.rst
+++ b/Documentation/ApiOverview/PageTitleApi/Index.rst
@@ -59,7 +59,7 @@ Usage example e.g. in an Extbase controller:
 .. code-block:: php
 
    $titleProvider = GeneralUtility::makeInstance(MyOwnPageTitleProvider::class);
-   $titleProvider->setTitle(‘Title from controller action’);
+   $titleProvider->setTitle('Title from controller action');
 
 
 .. index:: PageTitle; Priority


### PR DESCRIPTION
We currently use the wrong type of single quotes in one code example. Thus, it is not possible to copy&paste the code snippet.