### PR TITLE
[DOCS] Update section on Global variables

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
@@ -24,159 +24,133 @@ $GLOBALS
    - "PackageManager" = :php:`\TYPO3\CMS\Core\Package\PackageManager`
 
 
-.. t3-field-list-table::
- :header-rows: 1
+.. confval:: TYPO3_CONF_VARS
 
- - :Variable,20: Global variable
-   :Defined,20: Defined in
-   :Description,50: Description
-   :FE,10: Avail. in FE
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`
+   :Frontend: yes
 
+   TYPO3 configuration array. Please refer to the chapter :ref:`typo3ConfVars`
+   where each option is described in detail.
 
- - :Variable:
-         $GLOBALS['TYPO3\_CONF\_VARS']
-   :Defined:
-         :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`
-   :Description:
-         TYPO3 configuration array. Please refer to file
-         :file:`typo3/sysext/core/Configuration/DefaultConfigurationDescription.php`
-         where each option is described in detail in the comments. The same comments
-         are also available in the *Install Tool* when you choose "All Configuration".
-   :FE:
-         Yes
+   Most values in this array can be accessed through the tool
+   :guilabel:`Admin Tools > Settings > Configure Installation-Wide Options`.
 
 
- - :Variable:
-         $GLOBALS['TYPO3\_LOADED\_EXT']
-   :Defined:
-         :php:`PackageManager::loadPackageManagerStatesFromCache()`
-         :php:`PackageManager::initializeCompatibilityLoadedExtArray()`
-   :Description:
-         Array with all loaded extensions listed with a set of paths. You can
-         check if an extension is loaded by the function
-         :php:`\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded($key)` where :php:`$key` is the extension key.
-   :FE:
-         Yes
+.. confval:: EXEC_TIME
+
+   :Path: $GLOBALS
+   :type: int
+   :Defined: :php:`SystemEnvironmentBuilder::initializeGlobalTimeTrackingVariables()`
+   :Frontend: yes
+
+   Is set to :php:`time()` so that the rest of the script has a common value
+   for the script execution time.
+
+   .. note::
+
+      Should not be used anymore, rather use the
+      :ref:`DateTime Aspect <context_api_aspects_datetime>`.
 
 
- - :Variable:
-         $GLOBALS['EXEC\_TIME']
-   :Defined:
-         :php:`SystemEnvironmentBuilder::initializeGlobalTimeTrackingVariables()`
-   :Description:
-         Is set to :php:`time()` so that the rest of the script has a common value
-         for the script execution time.
+.. confval:: SIM_EXEC_TIME
 
-         .. note::
+   :Path: $GLOBALS
+   :type: int
+   :Defined: :php:`SystemEnvironmentBuilder::initializeGlobalTimeTrackingVariables()`
+   :Frontend: yes
 
-           Should not be used anymore, rather use the :ref:`DateTime Aspect <context_api_aspects_datetime>`.
+   Is set to :php:`$GLOBALS['EXEC_TIME']` but can be altered later in the script if we
+   want to simulate another execution-time when selecting from e.g. a
+   database (used in the frontend for preview of future and past dates)
 
+   .. note::
 
-   :FE:
-         Yes
-
-
- - :Variable:
-         $GLOBALS['SIM\_EXEC\_TIME']
-   :Defined:
-         :php:`SystemEnvironmentBuilder::initializeGlobalTimeTrackingVariables()`
-   :Description:
-         Is set to :php:`$GLOBALS['EXEC_TIME']` but can be altered later in the script if we
-         want to simulate another execution-time when selecting from e.g. a
-         database (used in the frontend for preview of future and past dates)
-
-         .. note::
-
-           Should not be used anymore, rather use the :ref:`DateTime Aspect <context_api_aspects_datetime>`.
+      Should not be used anymore, rather use the
+      :ref:`DateTime Aspect <context_api_aspects_datetime>`.
 
 
-   :FE:
-         Yes
+.. confval:: PAGES_TYPES
 
- - :Variable:
-         $GLOBALS['PAGES\_TYPES']
-   :Defined:
-         :file:`typo3/sysext/core/ext_tables.php`
-   :Description:
-         See :ref:`page-types`
-   :FE:
-         (occasionally)
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
 
 
- - :Variable:
-         $GLOBALS['TCA']
-   :Defined:
-         :php:`Bootstrap::loadExtensionTables()`
-   :Description:
-         See :ref:`TCA Reference<t3tca:start>`
-   :FE:
-         Yes, partly
+.. confval:: TCA
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :php:`Bootstrap::loadExtensionTables()`
+   :Frontend: Yes, partly
+
+   See :ref:`TCA Reference<t3tca:start>`
 
 
- - :Variable:
-         $GLOBALS['TBE\_MODULES']
-   :Defined:
-         :file:`typo3/sysext/core/ext_tables.php`
-   :Description:
-         The backend main/sub-module structure. See section elsewhere plus
-         source code of class :php:`\TYPO3\CMS\Backend\Module\ModuleLoader` which also includes some
-         examples.
-   :FE:
-         (occasionally)
+.. confval:: TBE_MODULES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
+
+   The backend main/sub-module structure. See section elsewhere plus
+   source code of class :php:`\TYPO3\CMS\Backend\Module\ModuleLoader` which also includes some
+   examples.
+
+.. confval:: TBE_STYLES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
+
+   Contains information related to BE skinning.
 
 
- - :Variable:
-         $GLOBALS['TBE\_STYLES']
-   :Defined:
-         :file:`typo3/sysext/core/ext_tables.php`
-   :Description:
-         Contains information related to BE skinning.
-   :FE:
-         (occasionally)
+.. confval:: T3_SERVICES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :php:`SystemEnvironmentBuilder::initializeGlobalVariables()`
+   :Frontend: Yes
+
+   Global registration of :ref:`services <services-introduction>`.
 
 
- - :Variable:
-         $GLOBALS['T3\_SERVICES']
-   :Defined:
-         :php:`SystemEnvironmentBuilder::initializeGlobalVariables()`
-   :Description:
-         Global registration of services.
-   :FE:
-         Yes
+
+.. confval:: BE_USER
+
+   :Path: $GLOBALS
+   :type: TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+   :Defined: :php:`Bootstrap::initializeBackendUser()`
+   :Frontend: (depends)
+
+   Backend user object. See :ref:`be-user`.
 
 
- - :Variable:
-         $GLOBALS['BE\_USER']
-   :Defined:
-         :php:`Bootstrap::initializeBackendUser()`
-   :Description:
-         Backend user object. See :ref:`be-user`.
-   :FE:
-         (depends)
+.. confval:: TBE_MODULES_EXT
 
+   :Path: $GLOBALS
+   :type: array
+   :Defined: [In :file:`ext_tables.php` files of extensions]
+   :Frontend: (occasionally)
 
- - :Variable:
-         *$GLOBALS['TBE\_MODULES\_EXT']*
-   :Defined:
-         [In :file:`ext_tables.php` files of extensions]
-   :Description:
-         Used to store information about modules from extensions that should be
-         included in "function menus" of real modules. See the Extension API
-         for details.
-   :FE:
-         (occasionally)
+   Used to store information about modules from extensions that should be
+   included in "function menus" of real modules. See the Extension API
+   for details.
 
+.. confval:: TCA_DESCR
 
- - :Variable:
-         *$GLOBALS['TCA\_DESCR']*
-   :Defined:
-         [:file:`tables.php` files]
-   :Description:
-         Can be set to contain file references to local lang files containing
-         :php:`TCA_DESCR` labels. See section about Context Sensitive Help.
-   :FE:
-         No
+   :Path: $GLOBALS
+   :type: array
+   :Defined: [:file:`tables.php` files]
+   :Frontend: No
 
+   Can be set to contain file references to local lang files containing
+   :php:`TCA_DESCR` labels. See section about :ref:`Context Sensitive Help <csh>`.
 
 .. index:: $GLOBALS; Admin Tools
 .. _globals-exploring:
@@ -184,8 +158,8 @@ $GLOBALS
 Exploring global variables
 ==========================
 
-Many of the global variables described above can be inspected using the
-**ADMIN TOOLS > Configuration** module.
+Many of the global variables described above can be inspected using the module
+:guilabel:`System > Configuration`.
 
 .. warning::
    This module is always viewed in the BE context. Variables defined
@@ -196,7 +170,7 @@ Many of the global variables described above can be inspected using the
    This module is purely a browser. It does not let you change
    values.
 
-   It also lets you browse a number of other global arrays.
-   Just be curious and investigate!
+   It also lets you browse a number of other global arrays as well as values
+   defined in other syntax like YAML.
 
 .. include:: /Images/AutomaticScreenshots/BackendModules/GlobalValuesConfiguration.rst.txt

--- a/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
@@ -63,6 +63,14 @@ $GLOBALS
    :Defined: :file:`typo3/sysext/core/ext_tables.php`
    :Frontend: (occasionally)
 
+   $GLOBALS['PAGES_TYPES'] defines the various types of pages (:sql:`doktype`)
+   the system can handle and what restrictions may apply to them.
+
+   Here you can define which tables are allowed on a certain page types
+   (:sql:`doktype`).
+
+   The default configuration applies if the page type is not defined otherwise.
+
 
 .. confval:: TCA
 

--- a/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
@@ -11,11 +11,6 @@ $GLOBALS
 
 .. note::
 
-   Variables in italics *may* be set in a script prior to
-   the bootstrap process so they are optional.
-
-.. note::
-
    To make the table below a bit more compact, namespaces were left out. Here
    are the fully qualified class names referred to below:
 
@@ -142,6 +137,9 @@ $GLOBALS
    included in "function menus" of real modules. See the Extension API
    for details.
 
+   This variable *may* be set in a script prior to
+   the bootstrap process so it is optional.
+
 .. confval:: TCA_DESCR
 
    :Path: $GLOBALS
@@ -151,6 +149,9 @@ $GLOBALS
 
    Can be set to contain file references to local lang files containing
    :php:`TCA_DESCR` labels. See section about :ref:`Context Sensitive Help <csh>`.
+
+   This variable *may* be set in a script prior to
+   the bootstrap process so it is optional.
 
 .. index:: $GLOBALS; Admin Tools
 .. _globals-exploring:

--- a/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
@@ -9,16 +9,6 @@
 $GLOBALS
 ========
 
-.. note::
-
-   To make the table below a bit more compact, namespaces were left out. Here
-   are the fully qualified class names referred to below:
-
-   - "SystemEnvironmentBuilder" = :php:`\TYPO3\CMS\Core\Core\SystemEnvironmentBuilder`
-   - "Bootstrap" = :php:`\TYPO3\CMS\Core\Core\Bootstrap`
-   - "PackageManager" = :php:`\TYPO3\CMS\Core\Package\PackageManager`
-
-
 .. confval:: TYPO3_CONF_VARS
 
    :Path: $GLOBALS
@@ -78,7 +68,7 @@ $GLOBALS
 
    :Path: $GLOBALS
    :type: array
-   :Defined: :php:`Bootstrap::loadExtensionTables()`
+   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::loadExtensionTables()`
    :Frontend: Yes, partly
 
    See :ref:`TCA Reference<t3tca:start>`
@@ -120,7 +110,7 @@ $GLOBALS
 
    :Path: $GLOBALS
    :type: TYPO3\CMS\Core\Authentication\BackendUserAuthentication
-   :Defined: :php:`Bootstrap::initializeBackendUser()`
+   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`
    :Frontend: (depends)
 
    Backend user object. See :ref:`be-user`.

--- a/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/GlobalVariables/Index.rst
@@ -23,6 +23,111 @@ $GLOBALS
    :guilabel:`Admin Tools > Settings > Configure Installation-Wide Options`.
 
 
+.. confval:: TCA
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::loadExtensionTables()`
+   :Frontend: Yes, partly
+
+   See :ref:`TCA Reference<t3tca:start>`
+
+
+.. confval:: TCA_DESCR
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: [:file:`tables.php` files]
+   :Frontend: No
+
+   Can be set to contain file references to local lang files containing
+   :php:`TCA_DESCR` labels. See section about :ref:`Context Sensitive Help <csh>`.
+
+   This variable *may* be set in a script prior to
+   the bootstrap process so it is optional.
+
+
+.. confval:: T3_SERVICES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :php:`SystemEnvironmentBuilder::initializeGlobalVariables()`
+   :Frontend: Yes
+
+   Global registration of :ref:`services <services-introduction>`.
+
+
+
+.. confval:: TBE_MODULES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
+
+   The backend main/sub-module structure. See section elsewhere plus
+   source code of class :php:`\TYPO3\CMS\Backend\Module\ModuleLoader` which also includes some
+   examples.
+
+
+.. confval:: TBE_MODULES_EXT
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: [In :file:`ext_tables.php` files of extensions]
+   :Frontend: (occasionally)
+
+   Used to store information about modules from extensions that should be
+   included in "function menus" of real modules. See the Extension API
+   for details.
+
+   This variable *may* be set in a script prior to
+   the bootstrap process so it is optional.
+
+
+.. confval:: TBE_STYLES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
+
+   Contains information related to BE skinning.
+
+
+.. confval:: TYPO3_USER_SETTINGS
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/setup/ext_tables.php`
+
+   Defines the form in the :guilabel:`User Settings`.
+
+.. confval:: PAGES_TYPES
+
+   :Path: $GLOBALS
+   :type: array
+   :Defined: :file:`typo3/sysext/core/ext_tables.php`
+   :Frontend: (occasionally)
+
+   $GLOBALS['PAGES_TYPES'] defines the various types of pages (:sql:`doktype`)
+   the system can handle and what restrictions may apply to them.
+
+   Here you can define which tables are allowed on a certain page types
+   (:sql:`doktype`).
+
+   The default configuration applies if the page type is not defined otherwise.
+
+.. confval:: BE_USER
+
+   :Path: $GLOBALS
+   :type: TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`
+   :Frontend: (depends)
+
+   Backend user object. See :ref:`be-user`.
+
+
 .. confval:: EXEC_TIME
 
    :Path: $GLOBALS
@@ -55,101 +160,6 @@ $GLOBALS
       Should not be used anymore, rather use the
       :ref:`DateTime Aspect <context_api_aspects_datetime>`.
 
-
-.. confval:: PAGES_TYPES
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: :file:`typo3/sysext/core/ext_tables.php`
-   :Frontend: (occasionally)
-
-   $GLOBALS['PAGES_TYPES'] defines the various types of pages (:sql:`doktype`)
-   the system can handle and what restrictions may apply to them.
-
-   Here you can define which tables are allowed on a certain page types
-   (:sql:`doktype`).
-
-   The default configuration applies if the page type is not defined otherwise.
-
-
-.. confval:: TCA
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::loadExtensionTables()`
-   :Frontend: Yes, partly
-
-   See :ref:`TCA Reference<t3tca:start>`
-
-
-.. confval:: TBE_MODULES
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: :file:`typo3/sysext/core/ext_tables.php`
-   :Frontend: (occasionally)
-
-   The backend main/sub-module structure. See section elsewhere plus
-   source code of class :php:`\TYPO3\CMS\Backend\Module\ModuleLoader` which also includes some
-   examples.
-
-.. confval:: TBE_STYLES
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: :file:`typo3/sysext/core/ext_tables.php`
-   :Frontend: (occasionally)
-
-   Contains information related to BE skinning.
-
-
-.. confval:: T3_SERVICES
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: :php:`SystemEnvironmentBuilder::initializeGlobalVariables()`
-   :Frontend: Yes
-
-   Global registration of :ref:`services <services-introduction>`.
-
-
-
-.. confval:: BE_USER
-
-   :Path: $GLOBALS
-   :type: TYPO3\CMS\Core\Authentication\BackendUserAuthentication
-   :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`
-   :Frontend: (depends)
-
-   Backend user object. See :ref:`be-user`.
-
-
-.. confval:: TBE_MODULES_EXT
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: [In :file:`ext_tables.php` files of extensions]
-   :Frontend: (occasionally)
-
-   Used to store information about modules from extensions that should be
-   included in "function menus" of real modules. See the Extension API
-   for details.
-
-   This variable *may* be set in a script prior to
-   the bootstrap process so it is optional.
-
-.. confval:: TCA_DESCR
-
-   :Path: $GLOBALS
-   :type: array
-   :Defined: [:file:`tables.php` files]
-   :Frontend: No
-
-   Can be set to contain file references to local lang files containing
-   :php:`TCA_DESCR` labels. See section about :ref:`Context Sensitive Help <csh>`.
-
-   This variable *may* be set in a script prior to
-   the bootstrap process so it is optional.
 
 .. index:: $GLOBALS; Admin Tools
 .. _globals-exploring:


### PR DESCRIPTION
Use confval directive, remove  $GLOBALS[‘TYPO3_LOADED_EXT’] which had been deprecated with TYPO3 9 https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Deprecation-86404-GLOBALSTYPO3_LOADED_EXT.html

move the information that was marked in italic before to text in the confval.

Unify display of paths and namespaces

Add a description for $GLOBALS['PAGES_TYPES'], taken from typo3/sysext/core/ext_tables.php

Order Global variables the way they are displayed in the Configuration module add the missing confval TYPO3_USER_SETTINGS

releases: main, 11.5