### PR TITLE
[BUGFIX] Do not set default TSconfig directly in TYPO3_CONF_VARS

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
@@ -653,6 +653,20 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
 
    Contains the default user TSconfig.
 
+   Never set this configuration variable directly. Use the API method instead:
+
+   .. code-block:: php
+      :caption: my_sitepackage/ext_localconf.php
+
+      /**
+       * Adding the default User TSconfig
+       */
+      \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
+         @import 'EXT:my_sitepackage/Configuration/TSconfig/User/default.tsconfig'
+      ');
+
+   Read more about
+   :ref:`Setting default User TSconfig <t3tsref:usersettingdefaultusertsconfig>`.
 
 .. index::
    TYPO3_CONF_VARS BE; defaultPageTSconfig
@@ -668,6 +682,19 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
 
    Contains the default page TSconfig.
 
+   Never set this configuration variable directly. Use the API method instead:
+
+   .. code-block:: php
+      :caption:`EXT:my_sitepackage/ext_localconf.php`
+
+      use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+      ExtensionManagementUtility::addPageTSConfig('
+         @import 'EXT:my_sitepackage/Configuration/TSconfig/Page/default.tsconfig'
+      ');
+
+   Read more about
+   :ref:`Setting the Page TSconfig globally <t3tsref:pagesettingdefaultpagetsconfig>`.
 
 .. index::
    TYPO3_CONF_VARS BE; defaultPermissions

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
@@ -653,7 +653,8 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
 
    Contains the default user TSconfig.
 
-   Never set this configuration variable directly. Use the API method instead:
+   This variable should not be changed directly but by the following API function. 
+   This makes your code less likely to change in the future.
 
    .. code-block:: php
       :caption: my_sitepackage/ext_localconf.php
@@ -682,7 +683,8 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
 
    Contains the default page TSconfig.
 
-   Never set this configuration variable directly. Use the API method instead:
+   This variable should not be changed directly but by the following API function. 
+   This makes your code less likely to change in the future.
 
    .. code-block:: php
       :caption:`EXT:my_sitepackage/ext_localconf.php`


### PR DESCRIPTION
Hint at API methods and chapters in TSref instead.

Will be followed by a PR for https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96614-AutomaticInclusionOfPageTsConfigOfExtensions.html which then will only be merged into main.

releases: main, 11.5