### PR TITLE
[FEATURE] Reference the SEO manual

### DIFF
--- a/Documentation/ApiOverview/CanonicalApi/Index.rst
+++ b/Documentation/ApiOverview/CanonicalApi/Index.rst
@@ -12,6 +12,11 @@ A brief explanation happens in :ref:`seo`.
 In general the system will generate the canonical using the same logic as for
 cHash.
 
+.. note::
+   The canonical API is provided by the optional system extension
+   EXT:seo. You can find information about how to install and use it in the
+   :ref:`EXT:seo manual <t3seo:start>`.
+
 Excluding arguments from the generation
 =======================================
 

--- a/Documentation/ApiOverview/Seo/Index.rst
+++ b/Documentation/ApiOverview/Seo/Index.rst
@@ -9,7 +9,14 @@
 Search engine optimization (SEO)
 ================================
 
-TYPO3 contains various SEO related functionality out of the box. The following provides an introduction in those features.
+TYPO3 contains various SEO related functionality out of the box.
+
+.. note::
+   Most of these features are provided by the optional system extension
+   EXT:seo. You can find information about how to install and use it in the
+   :ref:`EXT:seo manual <t3seo:start>`.
+
+The following provides an introduction in those features.
 
 Site title
     The site title is basically a variable that describes the current web site. It is used
@@ -19,7 +26,7 @@ Site title
     The site title can be configured in the sites module and is translatable.
 
 Hreflang Tags
-    "hreflang" tags are added automatically for multilanguage websites based on the one-tree principle.
+    "hreflang" tags are added automatically for multi-language websites based on the one-tree principle.
 
     The href is relative as long as the domain is the same. If the domain differs the href becomes absolute.
     The x-default href is the first supported language. The value of "hreflang" is the one set in the sites module
@@ -30,7 +37,7 @@ Hreflang Tags
 Canonical Tags
     TYPO3 provides built-in support for the :html:`<link rel="canonical" href="">` tag.
 
-    If the Core extension "seo" is installed, it will automatically add the canonical link to the page.
+    If the Core extension EXT:seo is installed, it will automatically add the canonical link to the page.
 
     The canonical link is basically the same absolute link as the link to the current hreflang and is meant
     to indicate where the original source of the content is. It is a tool to prevent duplicate content

--- a/Documentation/ApiOverview/XmlSitemap/Index.rst
+++ b/Documentation/ApiOverview/XmlSitemap/Index.rst
@@ -15,6 +15,11 @@ When enabled, this new feature will create a sitemapindex with one or more sitem
 Out-of-the-box it will have one sitemap containing all the pages of the current site and
 language. Per site and per language you have the possibility to render a different sitemap.
 
+.. note::
+   The XML sitemap is provided by the optional system extension
+   EXT:seo. You can find information about how to install and use it in the
+   :ref:`EXT:seo manual <t3seo:start>`.
+
 Installation
 ============
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -41,6 +41,7 @@ t3viewhelper  = https://docs.typo3.org/other/typo3/view-helper-reference/main/en
 
 
 # TYPO3 system extensions
+t3seo  = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
 
 # example for linking to changelog: :doc:`t3core:Changelog/8.1/Deprecation-75625-DeprecatedCacheClearingOptions`
 t3core        = https://docs.typo3.org/c/typo3/cms-core/main/en-us/


### PR DESCRIPTION
EXT:seo has had its own manual since v9 explaining how to install the system extension etc

releases: main, 11.5, 10.4