### PR TITLE
#94312 - Removed BE/loginSecurityLevel and FE/loginSecurityLevel options

### DIFF
--- a/Documentation/ApiOverview/Authentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/Index.rst
@@ -133,10 +133,8 @@ processLoginDataBE, processLoginDataFE
   The method to implement is :php:`processLoginData()`.
   It receives as argument the login data and the password
   transmission strategy (which corresponds to the login security
-  level, as defined in
-  :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']`
-  or :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['loginSecurityLevel']`).
-  It is expected to return a boolean value, with :php:`true`
+  level, where only 'normal' can be used.
+  It is expected to return a boolean value with :php:`true`,
   meaning that it successfully processed login data.
 
   It may also return a numerical value equal to 200 or greater,


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Important-94312-RemovedBEloginSecurityLevelAndFEloginSecurityLevelOptions.html