### PR TITLE
Breaking: #96659 - Registration of cObjects via TYPO3_CONF_VARS

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -767,15 +767,22 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates']
 $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
 ===================================================
 
-.. confval:: ContentObjects
+.. versionchanged:: 12.0
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
-   :type: array
-   :Default: []
+   The global variable `$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']` is
+   not interpreted anymore.
 
-   Array to register ContentObjects (cObjects) like :typoscript:`TEXT` or
-   :typoscript:`HMENU` within :file:`ext_localconf.php`,
-   see :file:`EXT:frontend/ext_localconf.php`
+TypoScript ContentObjects (cObjects) like :typoscript:`TEXT` or
+:typoscript:`HMENU` now get registered via the service configuration:
+
+.. code-block:: yaml
+   :caption: EXT:my_extension/Configuration/Services.yaml
+
+    MyCompany\MyPackage\ContentObject\CustomContentObject:
+        tags:
+            - name: frontend.contentobject
+              identifier: 'MY_OBJ'
+
 
 
 .. index::

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -778,10 +778,12 @@ TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyCompany\MyPackage\ContentObject\CustomContentObject:
-        tags:
-            - name: frontend.contentobject
-              identifier: 'MY_OBJ'
+   services:
+     # ...
+     MyCompany\MyPackage\ContentObject\CustomContentObject:
+       tags:
+         - name: frontend.contentobject
+           identifier: 'MY_OBJ'
 
 
 .. index::

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -773,7 +773,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
    not interpreted anymore.
 
 TypoScript ContentObjects (cObjects) like :typoscript:`TEXT` or
-:typoscript:`HMENU` now get registered via the service configuration:
+:typoscript:`HMENU` get registered via the service configuration:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml
@@ -782,7 +782,6 @@ TypoScript ContentObjects (cObjects) like :typoscript:`TEXT` or
         tags:
             - name: frontend.contentobject
               identifier: 'MY_OBJ'
-
 
 
 .. index::

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -769,8 +769,9 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
 
 .. versionchanged:: 12.0
 
-   The global variable `$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']` is
-   not interpreted anymore.
+   The global variable `$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']` has 
+   no effect anymore in TYPO3 12.0 and above. It can be defined to achieve
+   backward compatibility with TYPO3 version 11 and below.
 
 TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
 :typoscript:`HMENU` are registered as services:

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -772,7 +772,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
    The global variable `$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']` is
    not interpreted anymore.
 
-TypoScript ContentObjects (cObjects) like :typoscript:`TEXT` or
+TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
 :typoscript:`HMENU` get registered via the service configuration:
 
 .. code-block:: yaml

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/FE.rst
@@ -773,7 +773,7 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
    not interpreted anymore.
 
 TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
-:typoscript:`HMENU` get registered via the service configuration:
+:typoscript:`HMENU` are registered as services:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96659-RegistrationOfCObjectsViaTYPO3_CONF_VARS.html

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624

releases: main