### PR TITLE
Example should go to AdditionalConfiguration.php

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -100,10 +100,11 @@ These indicators can be used for all previously existing sub-properties
 :php:`cachedParametersWhiteList`, :php:`excludedParameters`, :php:`excludedParametersIfEmpty`
 and :php:`requireCacheHashPresenceParameters`.
 
-Example (excerpt of `LocalConfiguration.php`)
----------------------------------------------
+Example (excerpt of `AdditionalConfiguration.php`)
+--------------------------------------------------
 
 .. code-block:: php
+   :caption: typo3conf/AdditionalConfiguration.php
 
    $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash'] = [
      'excludedParameters' => [
@@ -120,6 +121,7 @@ Example (excerpt of `LocalConfiguration.php`)
 For instance instead of having exclude items like
 
 .. code-block:: php
+   :caption: typo3conf/AdditionalConfiguration.php
 
    'excludedParameters' => [
       'tx_my[data][uid]',
@@ -133,6 +135,7 @@ partial matches allow to simplify the configuration and consider all items havin
 :php:`tx_my[data]` (or :php:`tx_my[data][` to be more specific) as prefix like
 
 .. code-block:: php
+   :caption: typo3conf/AdditionalConfiguration.php
 
    'excludedParameters' => [
       '^tx_my[data][',


### PR DESCRIPTION
As the LocalConfiguration.php is one great array and copy pasting the code there wouldn't work.  Also AdditionalConfiguratation.php should be used for manual configurations like this one.

releases: main, 11.5