### PR TITLE
Fix Syntax error on page EventDispatcher (PSR-14 Events).

### DIFF
--- a/Documentation/ApiOverview/Hooks/EventDispatcher/Index.rst
+++ b/Documentation/ApiOverview/Hooks/EventDispatcher/Index.rst
@@ -42,10 +42,10 @@ Dispatching an event
    properties and setters for mutable properties. It contains a constructor for all properties::
 
       final class DoingThisAndThatEvent {
-         private string mutableProperty;
-         private int immutableProperty;
+         private string $mutableProperty;
+         private int $immutableProperty;
 
-         public function __construct(string mutableProperty, int immutableProperty) {
+         public function __construct(string $mutableProperty, int $immutableProperty) {
             // ...
          }
 


### PR DESCRIPTION
Fix missing $ on PHP variable declarations.