### PR TITLE
Breaking-97265-SimplifiedAccessModeSyste - explicitADmode removed

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
@@ -804,10 +804,10 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']
 ===================================================
 
 .. versionchanged:: 12.0
-   The handling of :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']` has been changed as
-   if it is always set to :php:`explicitAllow`. Extensions should not assume this global array
-   key being set anymore since TYPO3 Core v12. Extensions that need to stay compatible with v11
-   and v12 should fall back: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] ?? 'explicitAllow'`.
+   The handling of :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']` has been changed and
+   is now set using :php:`explicitAllow`. Extensions should not assume this global array
+   key is set anymore as of TYPO3 Core v12. Extensions that need to stay compatible with v11
+   and v12 should instead use: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] ?? 'explicitAllow'`.
 
 .. index::
    TYPO3_CONF_VARS BE; flexformForceCDATA

--- a/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
+++ b/Documentation/ApiOverview/GlobalValues/Typo3ConfVars/BE.rst
@@ -798,28 +798,16 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['interfaces']
 
    (All options: "backend,frontend")
 
-.. index::
-   TYPO3_CONF_VARS BE; explicitADmode
 .. _typo3ConfVars_be_explicitADmode:
 
 $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']
 ===================================================
 
-.. confval:: explicitADmode
-
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
-   :type: dropdown
-   :Default: 'explicitAllow'
-   :allowedValues:
-      explicitAllow:
-         Administrators have to explicitly grant access for all editors and
-         groups
-      explicitDeny:
-         Editors have access to all content types by default, access has
-         to explicitly restricted
-
-   Sets the general allow/deny mode for Content Element Types (CTypes) when
-   granting or restricting access for backend users
+.. versionchanged:: 12.0
+   The handling of :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']` has been changed as
+   if it is always set to :php:`explicitAllow`. Extensions should not assume this global array
+   key being set anymore since TYPO3 Core v12. Extensions that need to stay compatible with v11
+   and v12 should fall back: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] ?? 'explicitAllow'`.
 
 .. index::
    TYPO3_CONF_VARS BE; flexformForceCDATA


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97265-SimplifiedAccessModeSystem.html

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624