### PR TITLE
[DOCS] Add links to further TypoScript manuals in abstract

### DIFF
--- a/Documentation/ApiOverview/TypoScriptSyntax/Index.rst
+++ b/Documentation/ApiOverview/TypoScriptSyntax/Index.rst
@@ -18,11 +18,16 @@ for backend users.
 While the underlying TypoScript syntax is described in this chapter, both usages
 and their details are found in standalone manuals:
 
-- The :doc:`TypoScript Reference <t3tsref:Index>` goes into details about `Frontend TypoScript`.
+-  The :doc:`TypoScript Reference <t3tsref:Index>` goes into details about the
+   usage of TypoScript in the frontend.
 
-- The :doc:`TSconfig Reference <t3tsconfig:Index>` goes into details about configuring the
-  TYPO3 backend for backend users.
+-  The :doc:`TSconfig Reference <t3tsconfig:Index>` goes into details about
+   configuring the TYPO3 backend for backend users.
 
+In addition, you can find a quick reference guide to TypoScript templates in
+:doc:`t3ts45:Index`.
+
+**Table of Contents:**
 
 .. toctree::
    :titlesonly:

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -48,7 +48,7 @@ t3tca          = https://docs.typo3.org/m/typo3/reference-tca/8.7/en-us/
 t3translate    = https://docs.typo3.org/m/typo3/guide-frontendlocalization/8.7/en-us/
 t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/8.7/en-us/
 t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/8.7/en-us/
-# t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
+t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/8.7/en-us/
 # t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 


### PR DESCRIPTION
Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/185