### PR TITLE
Expand string description

### DIFF
--- a/Documentation/CodingGuidelines/CglYaml.rst
+++ b/Documentation/CodingGuidelines/CglYaml.rst
@@ -18,13 +18,24 @@ Format
 
 * Use spaces, not tabs
 * Indent with 2 spaces per indent level
-* Use single (' ') for defining string values. Double quotes can be used for
-  quotes inside of quotes:
+* Favor single-quoted strings (' ') over double-quoted or multi-line strings where
+  possible
+* Double quoted strings should only be used when more complex escape
+  characters are required.  String values with line breaks should use multi-line 
+  block strings in YAML.
+* The quotes on a trivial string value (a single word or similar) may be omitted.
 
 .. code-block:: yaml
 
-   description: 'This is a "salt" used for various kinds of encryption ...'
-
+   trivial: aValue
+   simple: 'This is a "salt" used for various kinds of encryption ...'
+   complex: "This string has unicode escaped characters, like \x0d\x0a"
+   multi: |
+      This is a multi-line string.
+      
+      Line breaks are preserved in this value. It's good for including
+      
+      <em>HTML snippets</em>.
 
 More Information
 ================


### PR DESCRIPTION
Elaborate on when to use the 4 string types in YAML, and why.  I also normalized the requirements to follow actual practice, both in TYPO3 and elsewhere.  (I checked and could find no examples of YAML conventions that didn't allow bare strings for simple cases.)

cf:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/74326
https://forge.typo3.org/issues/86896