### PR TITLE
Prefer usage of LoggerInterface

### DIFF
--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -7,7 +7,9 @@ Logger
 ======
 
 
-.. index:: Logging; LoggerAwareTrait
+.. index::
+   Logging; Instantiation
+   Logging; LoggerInterface
 .. _logging-logger-instantiation:
 
 Instantiation
@@ -29,6 +31,14 @@ Constructor injection can be used to automatically instantiate the logger:
            $this->logger = $logger;
        }
    }
+
+.. tip::
+
+   For examples of instantiation with :php:`LoggerAwareTrait or
+   php:`GeneralUtility::makeInstance(), switch to an older TYPO3 version for this
+   page. Instantiation with dependency injection is now the recommended
+   procedure. Also see the section on :ref:`channels <logging-channels>` for
+   information on grouping classes in channels.
 
 
 .. index::
@@ -80,7 +90,7 @@ Notice
    :sep:`|` :code:`$this->logger->notice($message, array $context = array());`
    :sep:`|`
 
-   Things you should have a look at, nothing to worry about though. 
+   Things you should have a look at, nothing to worry about though.
    Example: User log ins, SQL logs.
 
 .. _label-warning:
@@ -192,7 +202,7 @@ They can modify the log records or add extra information.
 The Logger then forwards the log records to all of its configured :ref:`Writers <logging-writers>`,
 which will then persist the log record.
 
-
+.. _logging-channels:
 
 Channels
 ========
@@ -248,21 +258,6 @@ overwrites possible class attributes:
          // do your magic
      }
    }
-
-
-Registration via class attribute for :php:`LoggerAwareInterface` services.
-
-.. code-block:: php
-
-   use Psr\Log\LoggerAwareInterface;
-   use Psr\Log\LoggerAwareTrait;
-   use TYPO3\CMS\Core\Log\Channel;
-   #[Channel('security')]
-   class MyClass implements LoggerAwareInterface
-   {
-     use LoggerAwareTrait;
-   }
-
 
 .. _logging-logger-examples:
 

--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -9,43 +9,28 @@ Quickstart
 
 .. index::
    Logging; Instantiation
-   Logging; LoggerAwareTrait
+   Logging; LoggerInterface
 .. _logging-quicksart-instantiate-logger:
 
 Instantiate a logger for the current class
 ==========================================
 
-.. versionadded:: 9.0
-   You no longer need to use makeInstance to create an
-   instance of the logger yourself. You can use LoggerAwareTrait:
-   :doc:`Changelog/9.0/Feature-82441-InjectLoggerWhenCreatingObjects`.
-   You must implement the :php:`\Psr\Log\LoggerAwareInterface` interface with your class to have the Trait taking effect.
+.. versionadded:: 11.4
+   :doc:`Changelog/11.4/Feature-95044-SupportAutowiredLoggerInterfaceInjection`
 
-Use LoggerAwareTrait in your class to automatically instantiate `$this->logger`:
+Constructor injection can be used to automatically instantiate the logger:
 
 .. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
 
-   use Psr\Log\LoggerAwareTrait;
+   use Psr\Log\LoggerInterface;
 
-   class SomeClass implements \Psr\Log\LoggerAwareInterface
-   {
-      use LoggerAwareTrait;
+   class MyClass {
+       private LoggerInterface $logger;
 
-      protected function myFunction() {
-         $this->logger->info('entered function myFunction');
-      }
+       public function __construct(LoggerInterface $logger) {
+           $this->logger = $logger;
+       }
    }
-
-Or instantiate the logger in the classic way with makeInstance:
-
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
-
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
-   use TYPO3\CMS\Core\Log\LogManager;
-
-   $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
 
 .. _logging-quickstart-log:
 

--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -178,15 +178,14 @@ All log writers can be used in your own classes. You can initialize the loggers 
 
     namespace MyDomain\MyExtension\MyFolder;
 
-    use Psr\Log\LoggerAwareInterface;
-    use Psr\Log\LoggerAwareTrait;
+    use Psr\Log\LoggerInterface;
 
-    class MyClass implements LoggerAwareInterface {
-        use LoggerAwareTrait;
+    class MyClass implements {
+       private LoggerInterface $logger;
 
-        // The logger object is already available through the LoggerAwareTrait and instantiated by TYPO3:
-        // private $logger;
-
+       public function __construct(LoggerInterface $logger) {
+           $this->logger = $logger;
+       }
         ...
         $this->logger->info('My class is executed.');
         if ($error) {


### PR DESCRIPTION
In the logging section, the LoggerInterface (available since v11)
is used in some sections, but also LoggerAwareTrait and
LoggerAwareInterface are used.

This change prefers the usage of instantiation the logger via
dependency injection and removes usage of LoggerAwareTrait.

Additionally, a note is added to mention LoggerAwareTrait and
refer to older versions of this page.
Since the LoggerAwareTrait is still heavily used in the core of
v12 and not yet deprecated, it seems prudent to add this note
as orientation.