### PR TITLE
Fix a minor ambiguity for naming conventions

### DIFF
--- a/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
+++ b/Documentation/ExtensionArchitecture/NamingConventions/Index.rst
@@ -204,10 +204,10 @@ Extbase domain model tables **should** follow this pattern:
 
 .. code-block:: none
 
-   tx_<extension-prefix>_domain_model_<table-name>
+   tx_<extension-prefix>_domain_model_<model-name>
 
 * `<extension-prefix>` is the extension key without underscores, so `foo_bar` becomes `foobar`
-* `<table-name>` should match the domain model name
+* `<model-name>` should match the domain model name
 
 Examples for Extbase domain models and table names of an extension named `cool_shop`:
 


### PR DESCRIPTION
The term "table-name" was used for part of the table for
Extbase extensions. This was confusing and has now
been clarified.