### PR TITLE
Added example import-code for TsConfig

### DIFF
--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -143,6 +143,15 @@ to this wizard (via Page TSconfig).
          show := addToList(examples_newcontentelement)
       }
    }
+   
+
+:file:`ext_tables.php`:
+
+.. code-block:: php
+
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
+       '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:examples/Configuration/TsConfig/Page/Mod/Wizards/NewContentElement.tsconfig">'
+   );
 
 .. include:: /Images/AutomaticScreenshots/CustomContentElements/ContentElementWizard.rst.txt
 

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -121,11 +121,10 @@ Add it to the new content element wizard
 
 Content elements in the :guilabel:`New Content Element Wizard` are easier
 to find for editors. It is therefore advised to add the new content element
-to this wizard (via Page TSconfig).
-
-:file:`Configuration/TsConfig/Page/Mod/Wizards/NewContentElement.tsconfig`:
+to this wizard (via page TSconfig).
 
 .. code-block:: typoscript
+   :caption: EXT:my_sitepackage/Configuration/page.tsconfig
 
    mod.wizards.newContentElement.wizardItems {
       // add the content element to the tab "common"
@@ -144,14 +143,12 @@ to this wizard (via Page TSconfig).
       }
    }
    
+.. versionchanged:: 12.0 
 
-:file:`ext_tables.php`:
-
-.. code-block:: php
-
-   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-       '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:examples/Configuration/TsConfig/Page/Mod/Wizards/NewContentElement.tsconfig">'
-   );
+   Starting with TYPO3 version 12.0 file :file:`EXT:my_sitepackage/Configuration/page.tsconfig` 
+   is automatically included. For version 11.5 and below this file has to be included in the 
+   :file:`ext_localconf.php`. See :ref:`Setting global page TSconfig, compatible with TYPO3 
+   11 and 12 <t3tsconfig:global-page-tsconfig-compatible-with-typo3-11-and-12>`.
 
 .. include:: /Images/AutomaticScreenshots/CustomContentElements/ContentElementWizard.rst.txt
 


### PR DESCRIPTION
Even if there is a link below which explains it - with these 3 lines of code the example just works. Also in the linked document the directory is called "example" instead of "examples". And in the GitHub repo of the example there is a typo in the directory name which is called "TSconfig" instead of "TsConfig". There is a risk that beginners copy one of the wrong paths, so I just added the correct code here.