### PR TITLE
Adjust logging quickstart for default loglevel

### DIFF
--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -48,7 +48,6 @@ Log a simple message:
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
 
-   $this->logger->info('Everything went fine.');
    $this->logger->warning('Something went awry, check your configuration!');
 
 
@@ -85,16 +84,18 @@ specifying what an invalid value was) should use placeholders, denoted by
 Set logging output
 ==================
 
-TYPO3 has the :ref:`FileWriter <logging-writers-FileWriter>` enabled by default,
-so all log entries are written to a file. If the filename is not set,
-then the file will contain a hash like :file:`typo3temp/var/logs/typo3_<hash>.log`,
-for example :file:`typo3temp/var/logs/typo3_7ac500bce5.log`.
+TYPO3 has the :ref:`FileWriter <logging-writers-FileWriter>` enabled by default
+for warnings (:php:`LogLevel::WARNING`) and lower, so all matching log entries
+are written to a file.
+
+If the filename is not set, then the file will contain a hash like
+:file:`typo3temp/var/logs/typo3_<hash>.log`, for example
+:file:`typo3temp/var/logs/typo3_7ac500bce5.log`.
 
 A sample output looks like this:
 
 .. code-block:: none
 
-   Fri, 08 Mar 2013 09:45:00 +0100 [INFO] request="5139a50bee3a1" component="TYPO3.Examples.Controller.DefaultController": Everything went fine.
    Fri, 08 Mar 2013 09:45:00 +0100 [WARNING] request="5139a50bee3a1" component="TYPO3.Examples.Controller.DefaultController": Something went awry, check your configuration!
    Fri, 08 Mar 2013 09:45:00 +0100 [ERROR] request="5139a50bee3a1" component="TYPO3.Examples.Controller.DefaultController": This was not a good idea - {"foo":"bar","bar":{}}
    Fri, 08 Mar 2013 09:45:00 +0100 [CRITICAL] request="5139a50bee3a1" component="TYPO3.Examples.Controller.DefaultController": This is an utter failure!


### PR DESCRIPTION
By default TYPO3 logs only warnings and lower. So examples should not use higher log levels since they will not be logged anywhere and cause confusion.