### PR TITLE
Fix indenting for Services API

### DIFF
--- a/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
+++ b/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
@@ -84,43 +84,43 @@ Most of the below methods are quite obvious, except for
 :php:`getServiceOption()`.
 
 getServiceInfo
-  Returns the array containing the service's properties
+   Returns the array containing the service's properties
 
 getServiceKey
-  Returns the service's key
+   Returns the service's key
 
 getServiceTitle
-  Returns the service's title
+   Returns the service's title
 
 getServiceOption
-  This method is used to retrieve the value of a service option, as
-  defined in the :php:`$GLOBALS['TYPO3_CONF_VARS']['SVCONF']` array. It will
-  take into account possible default values as described in the
-  :ref:`Service configuration chapter <services-configuration-service-configuration>`.
+   This method is used to retrieve the value of a service option, as
+   defined in the :php:`$GLOBALS['TYPO3_CONF_VARS']['SVCONF']` array. It will
+   take into account possible default values as described in the
+   :ref:`Service configuration chapter <services-configuration-service-configuration>`.
 
-  This method requires more explanation.
-  Imagine your service has an option called "ignoreBozo". To retrieve it
-  in a proper way, you should not access
-  :php:`$GLOBALS['TYPO3_CONF_VARS']['SVCONF']` directly, but use
-  :php:`getServiceOption()` instead. In its simplest form, it will look
-  like this (inside your service's code):
+   This method requires more explanation.
+   Imagine your service has an option called "ignoreBozo". To retrieve it
+   in a proper way, you should not access
+   :php:`$GLOBALS['TYPO3_CONF_VARS']['SVCONF']` directly, but use
+   :php:`getServiceOption()` instead. In its simplest form, it will look
+   like this (inside your service's code):
 
    .. code-block:: php
       :caption: EXT:some_extension/Classes/Services/SomeService.php
 
       $ignoreBozo = $this->getServiceOption('ignoreBozo');
 
-  This will retrieve the value of the "ignoreBozo" option for your
-  specific service, if defined. If not, it will try to find a value in
-  the default configuration. Additional call parameters can be added:
+   This will retrieve the value of the "ignoreBozo" option for your
+   specific service, if defined. If not, it will try to find a value in
+   the default configuration. Additional call parameters can be added:
 
-  - the second parameter is a default value to be used if no value was
-    found at all (including in the default configuration)
+   -  the second parameter is a default value to be used if no value was
+      found at all (including in the default configuration)
 
-  - the third parameter can be used to temporarily switch off the usage of
-    the default configuration.
+   -  the third parameter can be used to temporarily switch off the usage of
+      the default configuration.
 
-  This allows for a lot of flexibility.
+   This allows for a lot of flexibility.
 
 
 .. _services-developer-service-api-error:
@@ -138,26 +138,26 @@ The error queue exists only at run-time. It is not stored into session
 or any other form of persistence.
 
 errorPush
-  Puts a new error on top of the queue stack.
+   Puts a new error on top of the queue stack.
 
 errorPull
-  Removes the latest (topmost) error in the queue stack.
+   Removes the latest (topmost) error in the queue stack.
 
 getLastError
-  Returns the error number from the latest error in the queue, or true
-  if queue is empty.
+   Returns the error number from the latest error in the queue, or true
+   if queue is empty.
 
 getLastErrorMsg
-  Same as above, but returns the error message.
+   Same as above, but returns the error message.
 
 getErrorMsgArray
-  Returns an array with the error messages of all errors in the queue.
+   Returns an array with the error messages of all errors in the queue.
 
 getLastErrorArray
-  Returns the latest error as an array (number and message).
+   Returns the latest error as an array (number and message).
 
 resetErrors
-  Empties the error queue.
+   Empties the error queue.
 
 
 .. _services-developer-service-api-general:
@@ -166,18 +166,18 @@ General Service Functions
 =========================
 
 checkExec
-  This method checks the availability of one or more executables on the
-  server. A comma-separated list of executable names is provided as a
-  parameter. The method returns :php:`true` if **all** executables are
-  available.
+   This method checks the availability of one or more executables on the
+   server. A comma-separated list of executable names is provided as a
+   parameter. The method returns :php:`true` if **all** executables are
+   available.
 
-  The method relies on :php:`\TYPO3\CMS\Core\Utility\CommandUtility::checkCommand()`
-  to find the executables, so it will search through the paths defined/allowed by
-  the TYPO3 CMS configuration.
+   The method relies on :php:`\TYPO3\CMS\Core\Utility\CommandUtility::checkCommand()`
+   to find the executables, so it will search through the paths defined/allowed by
+   the TYPO3 CMS configuration.
 
 deactivateService
-  Internal method to temporarily deactivate a service at run-time, if it
-  suddenly fails for some reason.
+   Internal method to temporarily deactivate a service at run-time, if it
+   suddenly fails for some reason.
 
 
 .. _services-developer-service-api-io-tools:
@@ -192,27 +192,27 @@ write files. In particular it provides an easy way of creating and
 cleaning up temporary files.
 
 checkInputFile
-  Checks if a file exists and is readable within the paths allowed by
-  the TYPO3 CMS configuration.
+   Checks if a file exists and is readable within the paths allowed by
+   the TYPO3 CMS configuration.
 
 readFile
-  Reads the content of a file and returns it as a string. Calls on
-  :php:`checkInputFile()` first.
+   Reads the content of a file and returns it as a string. Calls on
+   :php:`checkInputFile()` first.
 
 writeFile
-  Writes a string to a file, if writable and within allowed paths. If no
-  file name is provided, the data is written to a temporary file, as
-  created by :php:`tempFile()` below. The file path is returned.
+   Writes a string to a file, if writable and within allowed paths. If no
+   file name is provided, the data is written to a temporary file, as
+   created by :php:`tempFile()` below. The file path is returned.
 
 tempFile
-  Creates a temporary file and keeps its name in an internal registry of
-  temp files.
+   Creates a temporary file and keeps its name in an internal registry of
+   temp files.
 
 registerTempFile
-  Adds a given file name to the registry of temporary files.
+   Adds a given file name to the registry of temporary files.
 
 unlinkTempFiles
-  Deletes all the registered temporary files.
+   Deletes all the registered temporary files.
 
 
 .. _services-developer-service-api-io-input-output:
@@ -225,33 +225,33 @@ content that needs to be processed – if this is the kind of operation
 that the service provides – and the processed output after that.
 
 setInput
-  Sets the content (and optionally the type of content) to be processed.
+   Sets the content (and optionally the type of content) to be processed.
 
 setInputFile
-  Sets the input file from which to get the content (and optionally the
-  type).
+   Sets the input file from which to get the content (and optionally the
+   type).
 
 getInput
-  Gets the input to process. If the content is currently empty, tries to
-  read it from the input file.
+   Gets the input to process. If the content is currently empty, tries to
+   read it from the input file.
 
 getInputFile
-  Gets the name of the input file, after putting it through
-  :php:`checkInputFile()` . If no file is defined, but some content is,
-  the method writes the content to a temporary file and returns the path
-  to that file.
+   Gets the name of the input file, after putting it through
+   :php:`checkInputFile()` . If no file is defined, but some content is,
+   the method writes the content to a temporary file and returns the path
+   to that file.
 
 setOutputFile
-  Sets the output file name.
+   Sets the output file name.
 
 getOutput
-  Gets the output content. If an output file name is defined, the
-  content is gotten from that file.
+   Gets the output content. If an output file name is defined, the
+   content is gotten from that file.
 
 getOutputFile
-  Gets the name of the output file. If such file is not defined, a
-  temporary file is created with the output content and that file's path
-  is returned.
+   Gets the name of the output file. If such file is not defined, a
+   temporary file is created with the output content and that file's path
+   is returned.
 
 
 .. _services-developer-service-api-migration:


### PR DESCRIPTION
- Fix inconsistent indenting due to an unncessary blockquote
- Change indenting consistently to use 3 spaces instead of
  2 spaces

Related: TYPO3-Documentation/T3DocTeam#150
Related: TYPO3-Documentation/T3DocTeam#191
Releases: main, 11.5, 10.4

----

not in commit message:

* see rendered page: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Services/Developer/ServiceApi.html#getter-methods-for-service-information