### PR TITLE
Remove .. only:: html directives

### DIFF
--- a/Documentation/ApiOverview/ExtensionScanner/Index.rst
+++ b/Documentation/ApiOverview/ExtensionScanner/Index.rst
@@ -27,9 +27,7 @@ and it should help Core developers to add Core patches which use the scanner.
 
 This module has been featured on the TYPO3 youtube channel:
 
-.. only:: html
-
-   .. youtube:: UdIYDZgBrQU
+.. youtube:: UdIYDZgBrQU
 
 
 .. index:: Admin tool; Scan extension files

--- a/Documentation/ApiOverview/Internationalization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Internationalization/TranslationServer/Crowdin/Faq.rst
@@ -6,8 +6,6 @@
 Frequently Asked Questions (FAQ)
 ================================
 
-.. only:: html
-
 .. contents::
         :local:
         :depth: 2


### PR DESCRIPTION
These directives used to be important since we had HTML and PDF
rendering but the PDF rendering has been dropped.

So we no longer use these directives in general.

Also on one of the pages, the indenting was not correct: All
content to which the directive applies should be indented and
it was not.

Related: TYPO3-Documentation/T3DocTeam#11