### PR TITLE
[TASK] #97354 - ExpressionBuilder methods andX() and orX()

### DIFF
--- a/Documentation/ApiOverview/Database/BasicCrud/Index.rst
+++ b/Documentation/ApiOverview/Database/BasicCrud/Index.rst
@@ -118,7 +118,7 @@ Advanced query using the `QueryBuilder` and manipulating the default restriction
         ->select('uid', 'pid', 'bodytext')
         ->from('tt_content')
         ->where(
-            $queryBuilder->expr()->orX(
+            $queryBuilder->expr()->or(
                 $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('klaus')),
                 $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT))
             )

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -53,9 +53,15 @@ to use it within the code flow of the `QueryBuilder` context directly:
 Junctions
 =========
 
-* :php:`->andX()` conjunction
+.. versionadded:: 11.5.10
+   The methods :php:`andX()` and :php:`orX()` are deprecated and replaced
+   by :php:`and()` and :php:`or()` to match with `doctrine/dbal`, which
+   `deprecated <https://github.com/doctrine/dbal/commit/84328cd947706210caebcaea3ca0394b3ebc4673>`_
+   these methods.
 
-* :php:`->orX()` disjunction
+* :php:`->and()` conjunction
+
+* :php:`->or()` disjunction
 
 
 Combine multiple single expressions with `AND` or `OR`. Nesting is possible, both methods are variadic and
@@ -79,7 +85,7 @@ Example to find tt_content records:
    $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_content');
    $queryBuilder->where(
       $queryBuilder->expr()->eq('CType', $queryBuilder->createNamedParameter('list')),
-      $queryBuilder->expr()->orX(
+      $queryBuilder->expr()->or(
          $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter('example_pi1')),
          $queryBuilder->expr()->eq('list_type', $queryBuilder->createNamedParameter('example_pi2'))
       )

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -53,7 +53,7 @@ to use it within the code flow of the `QueryBuilder` context directly:
 Junctions
 =========
 
-.. versionadded:: 11.5.10
+.. versionchanged:: 11.5.10
    The methods :php:`andX()` and :php:`orX()` are deprecated and replaced
    by :php:`and()` and :php:`or()` to match with `doctrine/dbal`, which
    `deprecated <https://github.com/doctrine/dbal/commit/84328cd947706210caebcaea3ca0394b3ebc4673>`_

--- a/Documentation/ApiOverview/Database/QueryHelper/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryHelper/Index.rst
@@ -120,7 +120,7 @@ stripLogicalOperatorPrefix()
 Removes the prefixes `AND` / `OR` from an input string.
 
 Those prefixes are added in Doctrine DBAL via :php:`QueryBuilder->where()`, :php:`QueryBuilder->orWhere()`,
-:php:`ExpressionBuilder->andX()` and friends. Some parts of the `TYPO3` framework however carry SQL fragments
+:php:`ExpressionBuilder->and()` and friends. Some parts of the `TYPO3` framework however carry SQL fragments
 prefixed with `AND` or `OR` around and it's not always possible to easily get rid of those. The method
 helps by killing those prefixes before they are handed over to the `doctrine` API:
 


### PR DESCRIPTION
Releases: main, 11.5

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/48