### PR TITLE
Add note about language records

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -12,6 +12,11 @@ To add new languages to the system, follow :ref:`t3editors:languages`, afterward
 
 For an explanation of each of the properties, see below.
 
+.. note::
+    Before you can add languages to your site configuration, you need to create records for each language you want to have in your TYPO3
+    installation, regardless if it should be available for a specific site.
+    To do so, go to the root page (id=0) and create a new record of type "Website Language" there.
+
 When the backend shows the list of available languages - for instance in the page module language selector,
 when editing records and in the list module - the list of languages is now restricted to those defined by
 the site module. If there are for instance five language records in the system, but a site configures only


### PR DESCRIPTION
In this [StackOverflow question](https://stackoverflow.com/questions/72467813/typo3-10-4-how-to-add-available-language), a 10.4 user had difficulties to add new languages to the site configuration because he was not aware that sys_language records are necessary to do so.

I've added a hint to to the 10.4 documentation. Maybe that that hint should also be applied to these pages:
- https://docs.typo3.org/m/typo3/reference-coreapi/10.4/en-us/ApiOverview/SiteHandling/Basics.html#sitehandling-basics
- https://docs.typo3.org/m/typo3/tutorial-editors/10.4/en-us/Languages/Index.html#languages
- https://docs.typo3.org/m/typo3/guide-frontendlocalization/10.4/en-us/SettingUpLanguages/Index.html

Feel free to improve my wording!

And maybe it should be even backported to the 9.x documentation?