### PR TITLE
[TASK] #97462 - Removed MSSQL supportive code

### DIFF
--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -116,8 +116,7 @@ Remarks:
 
 .. attention::
 
-    Connections to databases `postgres`, `maria` and `mysql` are actively tested.
-    However, `mssql` is currently not actively tested.
+    Connections to databases `postgres`, `mariadb` and `mysql` are actively tested.
 
     Furthermore, the TYPO3 CMS installer supports only a single `mysql` or `mariadb` connection
     at the moment and the connection details can not be properly edited within the `All configuration`

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -5,7 +5,6 @@
    MySQL
    MariaDB
    PostgreSQL
-   SQLServer
 .. _Database_Introduction:
 
 ============
@@ -15,13 +14,9 @@ Introduction
 TYPO3 CMS relies on storing its data in a relational database management
 system (RDBMS). The Doctrine DBAL component is used to enable connecting to
 different database management systems. Most used is still MySQL / MariaDB, but
-thanks to Doctrine others like PostgreSQL and SQLServer are also an option.
+thanks to Doctrine others like PostgreSQL and SQLite are also an option.
 
 The corresponding DBMS can be selected during installation.
-
-.. note::
-  At the time of writing the installation process does not fully work for
-  SQL Server, the connection settings have to be manually configured in that case.
 
 This chapter gives an overview of the basic TYPO3 database table structure, followed
 by some information on upgrading and maintaining table and field consistency, and then

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -28,7 +28,7 @@ values multiple times.
    defined as `int`, the `Statement` result may very well return that as PHP :php:`string`. This is
    true for other database column types like `FLOAT`, `DOUBLE` and others.
    This is an issue with the database drivers used below, it may happen that `MySQL` returns an integer
-   value for an `int` field, while `MSSQL` returns a string.
+   value for an `int` field, while others may return a string.
    In general, the application must take care of an according type cast on their own to reach maximum
    `DBMS` compatibility.
 

--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -33,7 +33,7 @@ System dependencies
 Many developers are familiar with `Docker <https://www.docker.com/>`_. As outlined in the
 :ref:`history <testing-history>` chapter, test execution needs a well defined, isolated, stable and
 reliable environment to run tests and also remove the need to manage niche dependencies on your local
-environment for tests such as "execute functional test "X" using MSSQL with xdebug".
+environment for tests such as "execute functional test "X" using PostgreSQL with xdebug".
 
 Git, docker and docker-compose are all required. For standalone test execution, a local installation of
 PHP is not required. You can even `composer install` a Core by calling `Build/Scripts/runTests.sh -s
@@ -141,8 +141,8 @@ Let's pick a :file:`runTests.sh` example and have a closer look:
     PHP: 8.0
     DBMS: mariadb  version 10.3  driver mysqli
     SUCCESS
-    ###########################################################################    
-    
+    ###########################################################################
+
     lolli@apoc /var/www/local/cms/Web $ echo $?
     0
     lolli@apoc /var/www/local/cms/Web $

--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -432,9 +432,6 @@ In order to tell the CI what to do, create a new workflow file in `.github/workf
          - name: Functional tests with mariadb
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
-         - name: Functional tests with mssql
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mssql -s functional
-
          - name: Functional tests with postgres
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
@@ -823,9 +820,6 @@ Now we want all of this automatically checked using Github Actions. As before, w
          - name: Functional Tests with mariadb
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -s functional
 
-         - name: Functional Tests with mssql
-           run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mssql -s functional
-
          - name: Functional Tests with postgres
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
 
@@ -836,5 +830,5 @@ Now we want all of this automatically checked using Github Actions. As before, w
            run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s acceptance
 
 This is similar to the enetcache example, but does some more: The functional tests are executed
-with four different DBMS (MariaDB, MSSQL, Postgres, sqlite), and the acceptance tests are executed, too.
+with three different DBMS (MariaDB, Postgres, sqlite), and the acceptance tests are executed, too.
 This setup takes some time to complete on Github Actions. But, `it's green <https://github.com/TYPO3/styleguide/actions>`_!


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/92

The chapter "Functional testing" mentions MSSQL also after this patch:
- https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Testing/ExtensionTesting.html#functional-testing
The section should be reworked to be consistent with the current styleguide code
in a separate PR.