### PR TITLE
Clear up confusion of silent configuration upgrade and the upgrade wi…

### DIFF
--- a/Documentation/ApiOverview/PasswordHashing/Troubleshooting.rst
+++ b/Documentation/ApiOverview/PasswordHashing/Troubleshooting.rst
@@ -34,8 +34,8 @@ given user password to *argon2i* if the install tool has not been
 executed once.
 
 This typically happens if a system has just been upgraded and a
-backend login has been performed before the install tool has silently executed 
-upgrade wizards.
+backend login has been performed before the install tool has executed 
+the silent configuration upgrade.
 
 
 Solutions


### PR DESCRIPTION
…zard

https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/1910 improved the grammar of this sentence but made the confusion worse.

@lolli42 caught it there. 

Upgrade wizards are never run silently.

However there is class https://github.com/TYPO3/typo3/blob/main/typo3/sysext/install/Classes/Service/SilentConfigurationUpgradeService.php which performs a "silent configuration upgrade" which does get run silently and automatically.