### PR TITLE
[DOC] Change Resources/Public/Icons/Extension.svg minimal dimensions …

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
@@ -49,7 +49,7 @@ Alternatives: :file:`Resources/Public/Icons/Extension.png`,
 These file names are reserved for th extension icon, which will be displayed
 in the extension manager.
 
-It must be in format SVG (preferred), PNG or GIF and should have at least 18x16
+It must be in format SVG (preferred), PNG or GIF and should have at least 16x16
 pixels.
 
 Common subfolders


### PR DESCRIPTION
…to 16x16 px

* Extension icons in EM are rendered as 16x16 px images (see https://github.com/TYPO3/typo3/blob/43106cad26698625a7203735ca66676ddde00aeb/Build/Sources/Sass/module/_extensionmanager.scss#L78)
* Most system extensions provide a 64x64 px icon (1:1 ratio)