### PR TITLE
Add additional headers to FlashMessage page

### DIFF
--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -38,7 +38,7 @@ Flash messages API
 ==================
 
 Instantiate a flash message
-------------------------
+---------------------------
 
 Creating a flash message is achieved by simply instantiating an object
 of class :php:`\TYPO3\CMS\Core\Messaging\FlashMessage`
@@ -93,7 +93,7 @@ default is not). Storage in the session should be used if you need the
 message to be still present after a redirection.
 
 Add a flash message to the queue
--------------------------
+--------------------------------
 
 >>>>>>> 57ed2c9f (Add additional headers to FlashMessage page)
 In backend modules you can then make that message appear on top of the

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -152,7 +152,7 @@ as top-right notifications, instead of inline:
     $notificationQueue->enqueue($flashMessage);
 
 The recommended way to show flash messages is to use the Fluid ViewHelper :html:`<f:flashMessages />`.
-This Viewhelper works in any context because it use the :php:`FlashMessageRendererResolver` class
+This ViewHelper works in any context because it use the :php:`FlashMessageRendererResolver` class
 to find the correct renderer for the current context.
 
 .. _flash-messages-renderer:

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -151,7 +151,7 @@ as top-right notifications, instead of inline:
     );
     $notificationQueue->enqueue($flashMessage);
 
-The recommend way to show flash messages is to use the Fluid Viewhelper :html:`<f:flashMessages />`.
+The recommended way to show flash messages is to use the Fluid ViewHelper :html:`<f:flashMessages />`.
 This Viewhelper works in any context because it use the :php:`FlashMessageRendererResolver` class
 to find the correct renderer for the current context.
 

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -37,6 +37,9 @@ The different severity levels are described below:
 Flash messages API
 ==================
 
+Instantiate FlashMessage
+------------------------
+
 Creating a flash message is achieved by simply instantiating an object
 of class :php:`\TYPO3\CMS\Core\Messaging\FlashMessage`
 
@@ -84,6 +87,15 @@ The severity is defined by using class constants provided by
 
 *  :php:`FlashMessage::ERROR` for errors
 
+The fourth parameter passed to the constructor is a flag that
+indicates whether the message should be stored in the session or not (the
+default is not). Storage in the session should be used if you need the
+message to be still present after a redirection.
+
+Add FlashMessage to queue
+-------------------------
+
+>>>>>>> 57ed2c9f (Add additional headers to FlashMessage page)
 In backend modules you can then make that message appear on top of the
 module after a page refresh or the rendering of the next page request
 or render it on your own where ever you want.
@@ -108,6 +120,7 @@ messages from the queue as inline flash messages. Here's how such a message look
 
 .. include:: /Images/AutomaticScreenshots/Examples/FlashMessages/FlashMessagesExample.rst.txt
 
+<<<<<<< HEAD
 This shows flash messages with 2 types of rendering mechanisms:
 
 *  several flash messages are displayed **inline**
@@ -141,7 +154,6 @@ as top-right notifications, instead of inline:
 The recommend way to show flash messages is to use the Fluid Viewhelper :html:`<f:flashMessages />`.
 This Viewhelper works in any context because it use the :php:`FlashMessageRendererResolver` class
 to find the correct renderer for the current context.
-
 
 .. _flash-messages-renderer:
 

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -37,7 +37,7 @@ The different severity levels are described below:
 Flash messages API
 ==================
 
-Instantiate FlashMessage
+Instantiate a flash message
 ------------------------
 
 Creating a flash message is achieved by simply instantiating an object

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -120,7 +120,6 @@ messages from the queue as inline flash messages. Here's how such a message look
 
 .. include:: /Images/AutomaticScreenshots/Examples/FlashMessages/FlashMessagesExample.rst.txt
 
-<<<<<<< HEAD
 This shows flash messages with 2 types of rendering mechanisms:
 
 *  several flash messages are displayed **inline**

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -95,7 +95,6 @@ message to be still present after a redirection.
 Add a flash message to the queue
 --------------------------------
 
->>>>>>> 57ed2c9f (Add additional headers to FlashMessage page)
 In backend modules you can then make that message appear on top of the
 module after a page refresh or the rendering of the next page request
 or render it on your own where ever you want.

--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -92,7 +92,7 @@ indicates whether the message should be stored in the session or not (the
 default is not). Storage in the session should be used if you need the
 message to be still present after a redirection.
 
-Add FlashMessage to queue
+Add a flash message to the queue
 -------------------------
 
 >>>>>>> 57ed2c9f (Add additional headers to FlashMessage page)


### PR DESCRIPTION
Previously, a large content block was under "Message severities"
which was primarily not related to the severities. Now, additional
headers have been added for the sections.