### PR TITLE
[TASK] Add rendering via NOTIFICATION_QUEUE for flash messages

### DIFF
--- a/Documentation/ApiOverview/FlashMessages/Index.rst
+++ b/Documentation/ApiOverview/FlashMessages/Index.rst
@@ -102,13 +102,43 @@ rendering the next request:
 
 The message is added to the queue and then the template class calls
 :php:`\TYPO3\CMS\Core\Messaging\FlashMessageQueue::renderFlashMessages()` which renders all
-messages from the queue. Here's how such a message looks like in a module:
+messages from the queue as inline flash messages. Here's how such a message looks like in a module:
 
 .. include:: /Images/AutomaticScreenshots/Examples/FlashMessages/FlashMessagesExample.rst.txt
+
+This shows flash messages with 2 types of rendering mechanisms:
+
+*  several flash messages are displayed **inline**
+*  and an additional flash message ("Record count") is rendered as top-right
+   **notification** (which automatically disappear after a short delay).
+
+.. versionadded:: 12.0
+
+   :php:`FlashMessageQueue::NOTIFICATION_QUEUE` has been added in TYPO3 12 to
+   provide a simple mechanism to add flash messages (from PHP code) to be
+   displayed as notifications on the top-right edge of the backend. Previously,
+   this had to be implemented in JavaScript (e.g. :js:`Notification.success()`),
+   which is also still possible, see :ref:`flash-messages-javascript`.
+
+Use the php:`FlashMessageQueue::NOTIFICATION_QUEUE` to submit a flash message
+as top-right notifications, instead of inline:
+
+.. code-block:: php
+
+    $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+    $notificationQueue = $flashMessageService->getMessageQueueByIdentifier(FlashMessageQueue::NOTIFICATION_QUEUE);
+    $flashMessage = GeneralUtility::makeInstance(
+        FlashMessage::class,
+        'I\'m a message rendered as notification',
+        'Hooray!',
+        FlashMessage::OK
+    );
+    $notificationQueue->enqueue($flashMessage);
 
 The recommend way to show flash messages is to use the Fluid Viewhelper :html:`<f:flashMessages />`.
 This Viewhelper works in any context because it use the :php:`FlashMessageRendererResolver` class
 to find the correct renderer for the current context.
+
 
 .. _flash-messages-renderer:
 


### PR DESCRIPTION
A new mechanism was introduced for rendering notification
flash messages from PHP via FlashMessageQueue::NOTIFICATION_QUEUE.

Resolves: TYPO3-Documentation/Changelog-To-Doc#108