### PR TITLE
Replace term object "object accessors"

### DIFF
--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -62,10 +62,10 @@ ViewHelpers:
    :ref:`t3viewhelper:typo3fluid-fluid-spaceless` ViewHelper or create a link
    as is done in the TYPO3 Fluid Viewhelper :ref:`t3viewhelper:typo3-fluid-link-page`.
 
-Object Accessors:
-   Fluid can access variables that have been defined. Just use braces
-   and the name of the variable: `{somevariable}`. In Fluid, these placeholders
-   are called `Object Accessors`.
+Expressions, variables:
+   Fluid uses placeholders to fill content in specified areas in the template
+   where the result is rendered when the template is evaluated. Content within
+   braces (e.g. :html:`{somevariable}`) can contain variables or expresssions.
 
 Conditions:
     The conditions are supplied here by the if / then / else ViewHelpers.

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -65,7 +65,7 @@ ViewHelpers:
 Expressions, variables:
    Fluid uses placeholders to fill content in specified areas in the template
    where the result is rendered when the template is evaluated. Content within
-   braces (e.g. :html:`{somevariable}`) can contain variables or expresssions.
+   braces (for example :html:`{somevariable}`) can contain variables or expressions.
 
 Conditions:
     The conditions are supplied here by the if / then / else ViewHelpers.


### PR DESCRIPTION
This term was used in the Extbase book to refer to
variables, but it is not really used in the Fluid
world. In the typo3fluid documentation, "expressions"
are used.

Also, the term object accessors is somewhat misleading
as in the examples, the variable might not refer to
an object.