### PR TITLE
[TASK] Create page "Using Fluid in TYPO3"

### DIFF
--- a/Documentation/ApiOverview/Fluid/Index.rst
+++ b/Documentation/ApiOverview/Fluid/Index.rst
@@ -7,28 +7,7 @@
 Fluid
 =====
 
-.. sidebar:: Sitepackage
-
-   In TYPO3, (almost) everything is an extension. If you want to create a theme, override
-   some configuration or add custom content elements you will do this in a custom TYPO3
-   extension. A sitepackage is an extension that contains the foundation (in particular,
-   the visual appearance) of a website: The configuration, necessary assets for a theme
-   (images, css etc.) and a combination of TypoScript and Fluid.
-
-You can use Fluid in TYPO3 to do one of the following:
-
-* Create a template (theme) using a combination of TypoScript
-  :ref:`FLUIDTEMPLATE <t3tsref:cobj-fluidtemplate>` and Fluid.
-  Check out the :doc:`t3sitepackage:Index` which walks you through the
-  creation of a sitepackage extension.
-* :ref:`adding-your-own-content-elements` in addition to the already existing content
-  elements TYPO3 supplies.
-* The previous point describes the lightweight components which
-  are created using a combination of TypoScript and Fluid. If you need more functionality
-  or flexibility in your content element, you can create a content plugin using
-  a combination of Extbase and Fluid. This is explained in :doc:`t3extbasebook:Index`
-* Use Fluid to create emails using the :ref:`TYPO3 Mail API <mail-fluid-email>`.
-* Use Fluid in :ref:`backend modules <backend-modules-template>`.
+Fluid is a templating engine commonly used within TYPO3.
 
 **Table of contents**
 
@@ -37,6 +16,7 @@ You can use Fluid in TYPO3 to do one of the following:
 
    Introduction
    Syntax
+   UsingFluidInTypo3
    UsingTypoScriptCObjectViewHelper
    DevelopCustomViewhelper
    ViewHelper reference <https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/>

--- a/Documentation/ApiOverview/Fluid/UsingFluidInTypo3.rst
+++ b/Documentation/ApiOverview/Fluid/UsingFluidInTypo3.rst
@@ -1,0 +1,24 @@
+.. include:: /Includes.rst.txt
+.. index::
+   Fluid; Using Fluid in TYPO3
+.. _fluid-usage-in-typo3:
+
+====================
+Using Fluid in TYPO3
+====================
+
+Here are some examples of how Fluid can be used in TYPO3:
+
+*  Create a template (theme) using a combination of TypoScript
+   :ref:`FLUIDTEMPLATE <t3tsref:cobj-fluidtemplate>` and Fluid.
+   Check out the :doc:`t3sitepackage:Index` which walks you through the
+   creation of a sitepackage extension.
+*  :ref:`adding-your-own-content-elements` in addition to the already existing
+   content elements TYPO3 supplies.
+*  The previous point describes the lightweight components which
+   are created using a combination of TypoScript and Fluid. If you need more
+   functionality or flexibility in your content element, you can create a
+   content plugin using a combination of Extbase and Fluid.
+*  Use Fluid to create emails using the :ref:`TYPO3 Mail API <mail-fluid-email>`.
+*  Use Fluid in :ref:`backend modules <backend-modules-template>`, either with or
+   without Extbase.


### PR DESCRIPTION
The content which was on the start page is moved to a dedicated
page "Using Fluid in TYPO3" for the following reasons:

- the content is on a dedicated page with an appropriate title
  so it is clear for the user what this is about
- the startpage is not cluttered up with use cases - as more
  pages are added to the Fluid page, the table of contents is
  more important and several other links have the effect of
  a distraction.