### PR TITLE
[SECURITY] Update information about Indexes

### DIFF
--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -21,7 +21,7 @@ sensitive data can also be exposed.
 
 It is strongly recommended that you disable directory indexes.
 
-If your website requires directory indexing in other places
+If your web server requires directory indexing in other places
 outside of your TYPO3 installation, you should consider deactivating the option globally
 and only enable indexing on a case-by-case basis.
 

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -22,24 +22,27 @@ you to enable or disable the indexing of directories by the `Options`
 directive as shown in the following example:
 
 .. code-block:: apacheconf
-   :caption: .htaccess
+   :caption: myhost.conf (Apache configuration)
 
-   <Directory /path/to/your/webroot/>
-     Options Indexes FollowSymLinks
-   </Directory>
+   # bad example: here, Indexes is allowed!
+   Options Indexes FollowSymLinks
 
 By removing the `Indexes` option, Apache does not show the list of
 files and directories. Please note that the `Options` directive can be
-used in several containers (e.g. `<VirtualHost>`, `<Directory>`,
-`<Location>`, etc.). The correct configuration could look like the
+used in several containers (for example `<VirtualHost>`, `<Directory>`,
+in the Apache configuration) or in the file :file:`.htaccess`.
+Refer to `Context <https://httpd.apache.org/docs/2.4/mod/directive-dict.html#Context>`__
+for the `Options <https://httpd.apache.org/docs/2.4/mod/core.html#options>`__
+directive for more information.
+
+The correct configuration could look like the
 following example:
 
 .. code-block:: apacheconf
-   :caption: .htaccess
+   :caption: myhost.conf (Apache configuration)
 
-   <Directory /path/to/your/webroot/>
-     Options FollowSymLinks
-   </Directory>
+   # good example: here, Indexes is not allowed!
+   Options FollowSymLinks
 
 If your specific website requires directory indexing at other places
 outside TYPO3, you should consider to deactivate this option in

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -6,6 +6,12 @@
 Directory indexing
 ==================
 
+.. note::
+
+   The following information applies to the **Apache webserver**. For
+   other Webservers, check if directory indexing is active on
+   your website and disable it whenever possible.
+
 Depending on the operating system and distribution, the default
 configuration of Apache allows the indexing of directories. This
 enables search engines to index your file structure and possibly
@@ -17,7 +23,15 @@ data that can be retrieved with a simple HTTP request.
     :alt: Screenshot of an example directory index
 
 In this case only the list of extensions is revealed, but more
-sensitive data can be found easily. The Apache configuration allows
+sensitive data can be found easily.
+
+.. note::
+
+   In TYPO3, the default :file:`.htaccess` already contains the
+   directive to disable directory indexing. Also, this is only
+   necessary if the module autoindex (mod_autoindex) is active.
+
+The Apache configuration allows
 you to enable or disable the indexing of directories by the `Options`
 directive as shown in the following example:
 

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -2,15 +2,9 @@
 .. index:: pair: Security guidelines; Directory indexing
 .. _security-directory-indexing:
 
-==================
-Directory indexing
-==================
-
-.. note::
-
-   The following information applies to the **Apache webserver**. For
-   other Webservers, check if directory indexing is active on
-   your website and disable it whenever possible.
+==========================
+Disable directory indexing
+==========================
 
 Depending on the operating system and distribution, the default
 configuration of Apache allows the indexing of directories. This
@@ -25,45 +19,94 @@ data that can be retrieved with a simple HTTP request.
 In this case only the list of extensions is revealed, but more
 sensitive data can be found easily.
 
-.. note::
-
-   In TYPO3, the default :file:`.htaccess` already contains the
-   directive to disable directory indexing. Also, this is only
-   necessary if the module autoindex (mod_autoindex) is active.
-
-The Apache configuration allows
-you to enable or disable the indexing of directories by the `Options`
-directive as shown in the following example:
-
-.. code-block:: apacheconf
-   :caption: myhost.conf (Apache configuration)
-
-   # bad example: here, Indexes is allowed!
-   Options Indexes FollowSymLinks
-
-By removing the `Indexes` option, Apache does not show the list of
-files and directories. Please note that the `Options` directive can be
-used in several containers (for example `<VirtualHost>`, `<Directory>`,
-in the Apache configuration) or in the file :file:`.htaccess`.
-Refer to `Context <https://httpd.apache.org/docs/2.4/mod/directive-dict.html#Context>`__
-for the `Options <https://httpd.apache.org/docs/2.4/mod/core.html#options>`__
-directive for more information.
-
-The correct configuration could look like the
-following example:
-
-.. code-block:: apacheconf
-   :caption: myhost.conf (Apache configuration)
-
-   # good example: here, Indexes is not allowed!
-   Options FollowSymLinks
+An appropriate counter measure is to disable directory indexes.
 
 If your specific website requires directory indexing at other places
 outside TYPO3, you should consider to deactivate this option in
 general but explicitly allow indexing for the required directories
 only.
 
-Other web servers such as Microsoft Internet Services (IIS) allow
-similar configurations. See your web server's manual for further
-details on how to disable directory indexing.
 
+.. contents::
+   :depth: 1
+   :local:
+
+Apache webserver
+================
+
+By removing the `Indexes` from `Options` (or not setting it in the first place),
+Apache web server does not show the list of files and directories.
+
+In TYPO3, the default :file:`.htaccess` already contains the
+directive to disable directory indexing. Check if the following is
+in your :file:`.htaccess`:
+
+.. code-block:: apacheconf
+   :caption: /var/www/myhost/public/.htaccess
+
+   # Make sure that directory listings are disabled.
+   <IfModule mod_autoindex.c>
+      Options -Indexes
+   </IfModule>
+
+This example, does not set all `Options`, it just removes `Indexes` from the
+list of Options. Directory indexing is provided by the module `autoindex`.
+By setting the options this way, it will be disabled in any case, even if the
+module is currently not active but might be activated at a later time.
+
+It is also possible, to configure the `Options` in the Apache configuration,
+for example:
+
+.. code-block:: apacheconf
+   :caption: /etc/apache2/sites-available/myhost.conf
+
+   <IfModule mod_autoindex.c>
+      <Directory /var/www/myhost/public>
+         # override all Options, do not activate Indexes for security reasons
+         Options FollowSymLinks
+      </Directory>
+   </IfModule>
+
+Please note that the `Options` directive can be
+used in several containers (for example `<VirtualHost>`, `<Directory>`,
+in the Apache configuration) or in the file :file:`.htaccess`.
+Refer to the `Options <https://httpd.apache.org/docs/2.4/mod/core.html#options>`__
+directive for more information.
+
+Nginx
+=====
+
+For Nginx, directory listing is handled by the :nginx:`ngx_http_index_module`.
+Directory listing is disabled by default.
+
+You can explicitly disable directory listing by using the parameter
+:nginx:`autoindex`.
+
+.. code-block:: nginx
+   :caption: /etc/nginx/sites-available/myhost.com
+
+   server {
+      # ...
+
+      location /var/www/myhost/public {
+         autoindex off;
+      }
+   }
+
+IIS
+===
+
+For IIS web server, directory listing is disabled by default.
+
+It is possible to disable directory listing in case it was enabled because of a
+regression or configuration changes.
+
+For IIS7 and above, it is possible to disable directory listing from the
+:guilable:`Directory Browsing` settings using the IIS manager console.
+
+Alternatively, the following command can be used:
+
+.. code-block:: shell
+   :caption: command line
+
+   appcmd set config /section:directoryBrowse /enabled:false

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -102,7 +102,7 @@ It is possible to disable directory listing in case it was enabled because of a
 regression or configuration changes.
 
 For IIS7 and above, it is possible to disable directory listing from the
-:guilable:`Directory Browsing` settings using the IIS manager console.
+:guilabel:`Directory Browsing` settings using the IIS manager console.
 
 Alternatively, the following command can be used:
 

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -6,36 +6,35 @@
 Disable directory indexing
 ==========================
 
-Depending on the operating system and distribution, the default
-configuration of Apache allows the indexing of directories. This
-enables search engines to index your file structure and possibly
-reveals sensitive data. The screenshot below shows an example of such
+Depending on the operating system and distribution, Apache’s default configuration may have directory indexing enabled by default.
+
+This allows search engines to index the file structure of your site and potentially 
+reveal sensitive data. The screenshot below shows an example of the kind
 data that can be retrieved with a simple HTTP request.
 
 .. figure:: /Images/ManualScreenshots/Security/DirectoryIndexing.png
     :class: with-shadow
     :alt: Screenshot of an example directory index
 
-In this case only the list of extensions is revealed, but more
-sensitive data can be found easily.
+In this example only the list of extensions are revealed, but more
+sensitive data can also be exposed.
 
-An appropriate counter measure is to disable directory indexes.
+It is strongly recommended that you disable directory indexes.
 
-If your specific website requires directory indexing at other places
-outside TYPO3, you should consider to deactivate this option in
-general but explicitly allow indexing for the required directories
-only.
+If your website requires directory indexing in other places
+outside of your TYPO3 installation, you should consider deactivating the option globally
+and only enable indexing on a case-by-case basis.
 
 
 .. contents::
    :depth: 1
    :local:
 
-Apache webserver
-================
+Apache web server
+===============
 
 By removing the `Indexes` from `Options` (or not setting it in the first place),
-Apache web server does not show the list of files and directories.
+Apache does not show the list of files and directories.
 
 In TYPO3, the default :file:`.htaccess` already contains the
 directive to disable directory indexing. Check if the following is
@@ -76,8 +75,8 @@ directive for more information.
 Nginx
 =====
 
-For Nginx, directory listing is handled by the `ngx_http_index_module`.
-Directory listing is disabled by default.
+For Nginx, directory listing is handled by the `ngx_http_index_module` and
+directory listing is disabled by default.
 
 You can explicitly disable directory listing by using the parameter
 `autoindex`.
@@ -96,10 +95,10 @@ You can explicitly disable directory listing by using the parameter
 IIS
 ===
 
-For IIS web server, directory listing is disabled by default.
+For IIS web servers, directory listing is also disabled by default.
 
-It is possible to disable directory listing in case it was enabled because of a
-regression or configuration changes.
+It is possible to disable directory listing in the event it was enabled because of a
+regression or a configuration change.
 
 For IIS7 and above, it is possible to disable directory listing from the
 :guilabel:`Directory Browsing` settings using the IIS manager console.

--- a/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
+++ b/Documentation/Security/GuidelinesAdministrators/DirectoryIndexing.rst
@@ -76,11 +76,11 @@ directive for more information.
 Nginx
 =====
 
-For Nginx, directory listing is handled by the :nginx:`ngx_http_index_module`.
+For Nginx, directory listing is handled by the `ngx_http_index_module`.
 Directory listing is disabled by default.
 
 You can explicitly disable directory listing by using the parameter
-:nginx:`autoindex`.
+`autoindex`.
 
 .. code-block:: nginx
    :caption: /etc/nginx/sites-available/myhost.com


### PR DESCRIPTION
Previously, a `<Directory>` directive was used in the code snippet
and a caption was added later that this applies for .htaccess
file. But Directory directives in .htaccess are not supported by Apache. Directory can
be used in Context "server config" or "virtual host", but not
.htaccess.

The following has been changed:

1. Do not use` <Directory>` directive in the code snippet for .htaccess

2. Differentiate between .htaccess and server config

3. Links to Apache configuration are added.

4. Directives already in TYPO3 core .htaccess mentioned

5. Add configuration for Nginx and ISS as well


Resolves: #1990
Related: #1993
