### PR TITLE
[BUGFIX] remove pagination widget from EXT:news routing example

### DIFF
--- a/Documentation/ApiOverview/Routing/Examples.rst
+++ b/Documentation/ApiOverview/Routing/Examples.rst
@@ -39,7 +39,7 @@ If you use the *category menu* or *tag list* plugins to filter news records, the
          - routePath: '/page-{page}'
            _controller: 'News::list'
            _arguments:
-             page: '@widget_0/currentPage'
+             page: currentPage
          - routePath: '/{news-title}'
            _controller: 'News::detail'
            _arguments:


### PR DESCRIPTION
EXT:news no longer uses widget viewhelpers, see https://docs.typo3.org/p/georgringer/news/9.4/en-us/Misc/Changelog/9-0-0.html#removed-viewhelpers