### PR TITLE
[BUGFIX] Correct heading of authentication events list

### DIFF
--- a/Documentation/Events/Events/Core/Authentication/Index.rst
+++ b/Documentation/Events/Events/Core/Authentication/Index.rst
@@ -1,14 +1,14 @@
 .. include:: /Includes.rst.txt
 .. index:: pair: Events; Core Authentication
-.. _eventlist-core-authentification:
+.. _eventlist-core-authentication:
 
 
-==========================
-Events in EXT:core
-==========================
+==============
+Authentication
+==============
 
 The following list contains :ref:`PSR-14 events <EventDispatcher>`
-in the TYPO3 Core .
+in EXT:core, namespace Authentication.
 
 **Contents:**
 


### PR DESCRIPTION
Releases: main, 11.5