### PR TITLE
[TASK] Remove superfluous toctree captions (#2015)

### DIFF
--- a/Documentation/Events/Events/Backend/Index.rst
+++ b/Documentation/Events/Events/Backend/Index.rst
@@ -13,7 +13,6 @@ in EXT:backend.
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    *

--- a/Documentation/Events/Events/Core/Index.rst
+++ b/Documentation/Events/Events/Core/Index.rst
@@ -14,7 +14,6 @@ in EXT:core .
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    */Index

--- a/Documentation/Events/Events/Extbase/Index.rst
+++ b/Documentation/Events/Events/Extbase/Index.rst
@@ -14,7 +14,6 @@ in EXT:extbase.
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    */Index

--- a/Documentation/Events/Events/ExtensionManager/Index.rst
+++ b/Documentation/Events/Events/ExtensionManager/Index.rst
@@ -14,7 +14,6 @@ in EXT:extension_manager.
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    *

--- a/Documentation/Events/Events/Index.rst
+++ b/Documentation/Events/Events/Index.rst
@@ -14,7 +14,6 @@ in the TYPO3 Core .
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    */Index

--- a/Documentation/Events/Events/Linkvalidator/Index.rst
+++ b/Documentation/Events/Events/Linkvalidator/Index.rst
@@ -14,7 +14,6 @@ in EXT:linkvalidator .
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    *

--- a/Documentation/Events/Events/Recordlist/Index.rst
+++ b/Documentation/Events/Events/Recordlist/Index.rst
@@ -14,7 +14,6 @@ in EXT:recordlist.
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    *

--- a/Documentation/Events/Events/Setup/Index.rst
+++ b/Documentation/Events/Events/Setup/Index.rst
@@ -14,7 +14,6 @@ in EXT:setup.
 
 .. toctree::
    :titlesonly:
-   :caption: backend
    :glob:
 
    *


### PR DESCRIPTION
Some sections have captions and mostly wrong, the others have it not at all.
As the header of the page mentions the section, the toctree caption is
superfluous and can be removed.

Releases: main, 11.5, 10.4