### PR TITLE
[TASK] Correct TsConfig path

### DIFF
--- a/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
+++ b/Documentation/ExtensionArchitecture/FilesAndLocations/Index.rst
@@ -445,12 +445,12 @@ Configuration/TCA/Overrides
   General advice: One file per database table, using the name of the table for the file, plus ".php".
   For more informations, see chapter :ref:`Extending the TCA Array <storing-changes-extension>`.
 
-Configuration/TSconfig/Page
+Configuration/TsConfig/Page
   Page TSconfig, see chapter :ref:`'Page TSconfig' in the TSconfig Reference
   <t3tsconfig:PageTSconfig>`. Files should have the file extension
   :file:`.tsconfig`.
 
-Configuration/TSconfig/User
+Configuration/TsConfig/User
   User TSconfig, see chapter :ref:`'User TSconfig' in the TSconfig Reference
   <t3tsconfig:UserTSconfig>`. Files should have the file extension
   :file:`.tsconfig`.


### PR DESCRIPTION
In v11/main branch the path is already adjusted as TsConfig. The v10 branch should also be reflect this best practise for users coming from search engine results to this older version.

See: https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/FileStructure/Index.html

Releases: 10.4