### PR TITLE
[BUGFIX] Remove unavailable additionalClasses option in FontawesomeIconProvider

### DIFF
--- a/Documentation/CodeSnippets/Manual/Extension/Configuration/IconsPhp.rst.txt
+++ b/Documentation/CodeSnippets/Manual/Extension/Configuration/IconsPhp.rst.txt
@@ -19,8 +19,6 @@
               'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\FontawesomeIconProvider::class,
                // the fontawesome icon name
               'name' => 'spinner',
-               // additional css classes
-              'additionalClasses' => 'fa-fw',
                // all icon providers provide the possibility to register an icon that spins
               'spinning' => true,
           ],


### PR DESCRIPTION
The option is not available, so remove it from documentation.
As the FontAwesomeIconProvider is gone in v12, only v11 and v10 need to be updated.

See:
- https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/core/Classes/Imaging/IconProvider/FontawesomeIconProvider.php
- https://github.com/FriendsOfTYPO3/fontawesome-provider/pull/2#pullrequestreview-1070910641

Releases: 11.5, 10.4