### PR TITLE
[TASK] Document $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'] in detail

### DIFF
--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -9,7 +9,7 @@
 Configuration
 =============
 
-Configuring the Doctrine DBAL for TYPO3 CMS is all about specifying the single database endpoints
+Configuring the Doctrine DBAL for TYPO3 is all about specifying the single database endpoints
 and handing over connection credentials. The framework supports the parallel usage of multiple
 database connections, a specific connection is mapped depending on its table name. The table space
 can be seen as a transparent layer that determines which specific connection is chosen for a query
@@ -45,23 +45,23 @@ database endpoint:
 
 Remarks:
 
-* The `Default` connection must be configured, this can not be left out or renamed.
+*  The `Default` connection must be configured, this can not be left out or renamed.
 
-* For mysqli, if the `host` is set to `localhost` and if the default `PHP` options in this area are not
-  changed, the connection will be socket based. This saves a little overhead. To force a `TCP/IP` based
-  connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
-  must be used as `host` value.
+*  For mysqli, if the `host` is set to `localhost` and if the default `PHP` options in this area are not
+   changed, the connection will be socket based. This saves a little overhead. To force a `TCP/IP` based
+   connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
+   must be used as `host` value.
 
-* The connect options are hand over to Doctrine DBAL without much manipulation from TYPO3 CMS side.
-  Please refer to the
-  `doctrine connection docs <https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
-  for a full overview of settings.
+*  The connect options are hand over to Doctrine DBAL without much manipulation from TYPO3 CMS side.
+   Please refer to the
+   `doctrine connection docs <https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
+   for a full overview of settings.
 
-* If `charset` option is not specified it defaults to `utf8`.
+*  If `charset` option is not specified it defaults to `utf8`.
 
-* The option `wrapperClass` is used by TYPO3 to insert the extended
-  :ref:`Connection <database-connection>` class :php:`TYPO3\CMS\Database\Connection` as main facade
-  around Doctrine DBAL.
+*  The option `wrapperClass` is used by TYPO3 to insert the extended
+   :ref:`Connection <database-connection>` class :php:`TYPO3\CMS\Database\Connection` as main facade
+   around Doctrine DBAL.
 
 
 A slightly more complex example with two connections, mapping the `sys_log`
@@ -102,22 +102,25 @@ table to a different endpoint:
 
 Remarks:
 
-* The array key `Syslog` is just a name, it can be different but it's good practice to give it
-  a useful speaking name.
+*  The array key `Syslog` is just a name, it can be different but it's good practice to give it
+   a useful speaking name.
 
-* It is possible to map multiple tables to a different endpoint by adding further table name /
-  connection name pairs to `TableMapping`.
+*  It is possible to map multiple tables to a different endpoint by adding further table name /
+   connection name pairs to `TableMapping`.
 
-* Mind this "connection per table" approach is limited: If in the above example a join query
-  that spans over different connections is fired, an exception is raised. It is up to the
-  administrator to group affected tables to the same connection in those cases, or a developer
-  should implement some fallback logic to suppress the `join()`.
+*  Mind this "connection per table" approach is limited: If in the above example a join query
+   that spans over different connections is fired, an exception is raised. It is up to the
+   administrator to group affected tables to the same connection in those cases, or a developer
+   should implement some fallback logic to suppress the `join()`.
 
 
 .. attention::
 
-    Connections to databases `postgres`, `mariadb` and `mysql` are actively tested.
+   Connections to databases `postgres`, `mariadb` and `mysql` are actively tested.
 
-    Furthermore, the TYPO3 CMS installer supports only a single `mysql` or `mariadb` connection
-    at the moment and the connection details can not be properly edited within the `All configuration`
-    section of the Install Tool.
+   Furthermore, the TYPO3 installer supports only a single `mysql` or `mariadb` connection
+   at the moment and the connection details can not be properly edited within the `All configuration`
+   section of the Install Tool.
+
+.. seealso::
+   :ref:`Overview of all DB configuration options <typo3ConfVars_db_connections>`

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -24,3 +24,291 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
    It is possible to add additional query restrictions by adding class names as
    key to :php:`$GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']`.
    Have a look into the chapter :ref:`database-custom-restrictions` for details.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections
+.. _typo3ConfVars_db_connections:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
+================================================
+
+.. confval:: Connections
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: array
+
+   One or more database connections can be configured under the
+   :php:`Connections` key. There must be at least one configuration with the
+   :php:`Default` key, in which the default database is configured, for example:
+
+   .. code-block:: php
+      :caption: typo3conf/LocalConfiguration.php
+
+      'Connections' => [
+          'Default' => [
+              'charset' => 'utf8mb4',
+              'driver' => 'mysqli',
+              'dbname' => 'typo3_database',
+              'host' => '127.0.0.1',
+              'password' => 'typo3',
+              'port' => 3306,
+              'user' => 'typo3',
+          ],
+      ]
+
+   It is possible to swap out tables from the default database and use a specific
+   setup (e.g. for logging or caching). For example, the following snippet could
+   be used to swap the :sql:`sys_log` table to another database or even another
+   database server:
+
+   .. code-block:: php
+      :caption: typo3conf/LocalConfiguration.php
+
+      'Connections' => [
+          'Default' => [
+              'charset' => 'utf8mb4',
+              'driver' => 'mysqli',
+              'dbname' => 'typo3_database',
+              'host' => '127.0.0.1',
+              'password' => '***',
+              'port' => 3306,
+              'user' => 'typo3',
+          ],
+          'Syslog' => [
+              'charset' => 'utf8mb4',
+              'driver' => 'mysqli',
+              'dbname' => 'syslog_dbname',
+              'host' => 'syslog_host',
+              'password' => '***',
+              'port' => 3306,
+              'user' => 'syslog_user',
+          ],
+      ],
+      'TableMapping' => [
+          'sys_log' => 'Syslog',
+      ]
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Charset
+.. _typo3ConfVars_db_connections_charset:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
+------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> charset
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+   :Default: 'utf8'
+
+   The charset used when connecting to the database. Can be used with
+   MySQL/MariaDB and PostgreSQL.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Database name
+.. _typo3ConfVars_db_connections_dbname:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
+-----------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> dbname
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   Name of the database/schema to connect to. Can be used with
+   MySQL/MariaDB and PostgreSQL.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Driver
+.. _typo3ConfVars_db_connections_driver:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
+-----------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> driver
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   The built-in driver implementation to use. The following drivers are
+   currently available:
+
+   mysqli
+      A MySQL/MariaDB driver that uses the mysqli extension.
+   pdo_mysql
+      A MySQL/MariaDB driver that uses the pdo_mysql PDO extension.
+   pdo_pgsql
+      A PostgreSQL driver that uses the pdo_pgsql PDO extension.
+   pdo_sqlite
+      An SQLite driver that uses the pdo_sqlite PDO extension.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Host
+.. _typo3ConfVars_db_connections_host:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
+-------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> host
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   Hostname or IP address of the database to connect to. Can be used with
+   MySQL/MariaDB and PostgreSQL.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Password
+.. _typo3ConfVars_db_connections_password:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
+-------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> password
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+    Password to use when connecting to the database.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Path
+.. _typo3ConfVars_db_connections_path:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
+-------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> path
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   The filesystem path to the SQLite database file.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Port
+.. _typo3ConfVars_db_connections_port:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
+---------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> port
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   Port of the database to connect to. Can be used with MySQL/MariaDB and
+   PostgreSQL.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Table options
+.. _typo3ConfVars_db_connections_tableoptions:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoptions']
+-----------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> tableoptions
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: array
+   :Default: []
+
+   Defines the charset and collate options for tables for MySQL/MariaDB:
+
+   .. code-block:: php
+      :caption: typo3conf/LocalConfiguration.php
+
+      'Connections' => [
+          'Default' => [
+              'driver' => 'mysqli',
+              // ...
+              'charset' => 'utf8mb4',
+              'tableoptions' => [
+                  'charset' => 'utf8mb4',
+                  'collate' => 'utf8mb4_unicode_ci',
+              ],
+
+          ],
+      ]
+
+   For new installations the above is the default.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections Unix socket
+.. _typo3ConfVars_db_connections_unixsocket:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket']
+----------------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> unix_socket
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   Name of the socket used to connect to the database. Can be used with
+   MySQL/MariaDB.
+
+.. index::
+   TYPO3_CONF_VARS DB; Connections User
+.. _typo3ConfVars_db_connections_user:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
+---------------------------------------------------------------------------
+
+.. confval:: Connections <connection_name> user
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: string
+
+   Username to use when connecting to the database.
+
+
+.. index::
+   TYPO3_CONF_VARS DB; TableMapping
+.. _typo3ConfVars_db_tablemapping:
+
+$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']
+=================================================
+
+.. confval:: TableMapping
+
+   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
+   :type: array
+   :Default: []
+
+   When a TYPO3 table is swapped to another database (either on the same host
+   or another host) this table must be mapped to the other database.
+
+   For example, the :sql:`sys_log` table should be swapped to another database:
+
+   .. code-block:: php
+      :caption: typo3conf/LocalConfiguration.php
+
+      'Connections' => [
+          'Default' => [
+              // ...
+          ],
+          'Syslog' => [
+              'charset' => 'utf8mb4',
+              'driver' => 'mysqli',
+              'dbname' => 'syslog_dbname',
+              'host' => 'syslog_host',
+              'password' => '***',
+              'port' => 3306,
+              'user' => 'syslog_user',
+          ],
+      ],
+      'TableMapping' => [
+          'sys_log' => 'Syslog',
+      ]


### PR DESCRIPTION
References:
- https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/8.1/Breaking-75454-LocalConfigurationDBConfigStructureHasChanged.html
- https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/8.1/Feature-75454-DoctrineDBALForDatabaseConnections.html
- https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Feature-80398-Utf8mb4OnMysqlByDefaultForNewInstances.html
- https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html

Releases: main, 11.5