### PR TITLE
[BUGFIX] Correct caption of code snippet in TypoScript Configuration

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/TypoScriptConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/TypoScriptConfiguration.rst
@@ -16,7 +16,7 @@ templates of your extension.
 All TypoScript settings are made in the following TypoScript blocks:
 
 .. code-block:: typoscript
-   :caption: EXT:blog_example/
+   :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
 
    plugin.tx_[lowercasedextensionname]
 


### PR DESCRIPTION
Releases: 11.5