### PR TITLE
[TASK] Revise HTTP section

### DIFF
--- a/Documentation/ApiOverview/Http/Index.rst
+++ b/Documentation/ApiOverview/Http/Index.rst
@@ -1,40 +1,41 @@
-.. include:: /Includes.rst.txt
-.. index::
-   HTTP request
-   Guzzle
-   PSR-7
-.. _http:
+..  include:: /Includes.rst.txt
+..  index::
+    HTTP request
+    Guzzle
+    PSR-7
+..  _http:
 
 =====================================
 HTTP request library / Guzzle / PSR-7
 =====================================
 
-Since TYPO3 CMS 8.1 the PHP library `Guzzle` has been added via Composer dependency
-to work as a feature rich solution for creating HTTP requests based on the PSR-7 interfaces
-already used within TYPO3.
+The PHP library "Guzzle" is available in TYPO3 as a feature-rich solution for
+creating HTTP requests based on the PSR-7 interfaces.
 
-Guzzle auto-detects available underlying adapters available on the system, like cURL or
-stream wrappers and chooses the best solution for the system.
+Guzzle automatically detects the underlying adapters available on the system,
+such as cURL or stream wrappers, and chooses the best solution for the system.
 
-A TYPO3-specific PHP class called :php:`\TYPO3\CMS\Core\Http\RequestFactory` has been added as
-a simplified wrapper to access Guzzle clients.
+A TYPO3-specific PHP class named :php:`TYPO3\CMS\Core\Http\RequestFactory` is
+present as a simplified wrapper for accessing Guzzle clients.
 
-All options available under :php:`$GLOBALS['TYPO3_CONF_VARS'][HTTP]` are automatically applied to the Guzzle
-clients when using the :php:`RequestFactory` class. The options are a subset to the available options
-on Guzzle (https://docs.guzzlephp.org/en/latest/request-options.html) but can further be extended.
+All options available under :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']` are
+automatically applied to the Guzzle clients when using the :php:`RequestFactory`
+class. The options are a subset of the available options from Guzzle, but can be
+extended.
 
-Existing :php:`$GLOBALS['TYPO3_CONF_VARS'][HTTP]` options have been removed and/or migrated to the
-new Guzzle-compliant options.
+..  seealso::
+    -   :ref:`typo3ConfVars_http`
+    -   `Guzzle request options <https://docs.guzzlephp.org/en/stable/request-options.html>`__
+    -   `Full documentation for Guzzle <https://docs.guzzlephp.org/en/stable/>`__
 
-A full documentation for Guzzle can be found at https://docs.guzzlephp.org/en/latest/.
+Although Guzzle can handle Promises/A+ and asynchronous requests, it currently
+serves as a drop-in replacement for the previous mixed options and
+implementations within :php:`GeneralUtility::getUrl()` and a PSR-7-based API for
+HTTP requests.
 
-Although Guzzle can handle Promises/A+ and asynchronous requests, it currently acts as
-a drop-in replacement for the previous mixed options and implementations within
-:php:`GeneralUtility::getUrl()` and a PSR-7-based API for HTTP requests.
-
-The existing TYPO3-specific wrapper :php:`GeneralUtility::getUrl()` now uses Guzzle under the hood
-automatically for remote files, removing the need to configure settings based on certain
-implementations like stream wrappers or cURL directly.
+The TYPO3-specific wrapper :php:`GeneralUtility::getUrl()` uses Guzzle for
+remote files, eliminating the need to directly configure settings based on
+specific implementations such as stream wrappers or cURL.
 
 .. index:: HTTP request; RequestFactory
 .. _http-basic:
@@ -42,62 +43,67 @@ implementations like stream wrappers or cURL directly.
 Basic usage
 ===========
 
-The `RequestFactory` class can be used like this:
+The :php:`RequestFactory` class can be used like this:
 
-.. code-block:: php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/SomeClass.php
 
-      use Psr\Http\Message\RequestFactoryInterface;
+    use TYPO3\CMS\Core\Http\RequestFactory;
 
-      /** @var RequestFactoryInterface */
-      private $requestFactory;
+    class SomeClass
+    {
+        private RequestFactory $requestFactory;
 
-      // Initiate the Request Factory, which allows to run multiple requests (prefer dependency injection)
-      public function __construct(RequestFactoryInterface $requestFactory)
-      {
-         $this->requestFactory = $requestFactory;
-      }
+        // Initiate the RequestFactory, which allows to run multiple requests
+        // (prefer dependency injection)
+        public function __construct(RequestFactory $requestFactory)
+        {
+            $this->requestFactory = $requestFactory;
+        }
 
-      public function handle()
-      {
-         $url = 'https://typo3.com';
-         $additionalOptions = [
+        public function handle(): void
+        {
+            $url = 'https://example.org/';
+
             // Additional headers for this specific request
-            'headers' => ['Cache-Control' => 'no-cache'],
-            // Additional options, see https://docs.guzzlephp.org/en/latest/request-options.html
-            'allow_redirects' => false,
-            'cookies' => true,
-         ];
-         // Return a PSR-7 compliant response object
-         $response = $this->requestFactory->request($url, 'GET', $additionalOptions);
-         // Get the content as a string on a successful request
-         if ($response->getStatusCode() === 200) {
-            if (strpos($response->getHeaderLine('Content-Type'), 'text/html') === 0) {
-               $content = $response->getBody()->getContents();
+            // See: https://docs.guzzlephp.org/en/stable/request-options.html
+            $additionalOptions = [
+                'headers' => ['Cache-Control' => 'no-cache'],
+                'allow_redirects' => false,
+                'cookies' => true,
+            ];
+
+            // Return a PSR-7 compliant response object
+            $response = $this->requestFactory->request($url, 'GET', $additionalOptions);
+
+            // Get the content as a string on a successful request
+            if ($response->getStatusCode() === 200) {
+                if (strpos($response->getHeaderLine('Content-Type'), 'text/html') === 0) {
+                    $content = $response->getBody()->getContents();
+                }
             }
-         }
-      }
+        }
+    }
 
 A POST request can be achieved with:
 
-.. code-block:: php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/SomeClass.php
 
-   $additionalOptions = [
-      'body' => 'Your raw post data',
-      // OR form data:
-      'form_params' => [
-         'first_name' => 'Hans',
-         'last_name' => 'Dampf',
-      ]
-   ];
-   $response = $this->requestFactory->request($url, 'POST', $additionalOptions);
+    $additionalOptions = [
+        'body' => 'Your raw post data',
+        // OR form data:
+        'form_params' => [
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+        ]
+    ];
 
-Extension authors are advised to use the :php:`RequestFactory` class instead of using the Guzzle
-API directly in order to ensure a clear upgrade path when updates to the underlying API need to be done.
+    $response = $this->requestFactory->request($url, 'POST', $additionalOptions);
 
-
-.. note::
-
-   Some information on this page was moved to :ref:`backend-routing`.
+Extension authors are advised to use the :php:`RequestFactory` class instead of
+using the Guzzle API directly in order to ensure a clear upgrade path when
+updates to the underlying API need to be done.
 
 
 .. index:: HTTP request; Custom middleware handlers
@@ -106,16 +112,23 @@ API directly in order to ensure a clear upgrade path when updates to the underly
 Custom middleware handlers
 ==========================
 
-Guzzle will accept a stack of custom middleware handlers, which can be configured using :php:`$GLOBALS['TYPO3_CONF_VARS']`.
-If a custom configuration is given, the default handler stack is extended, but overridden.
+Guzzle accepts a stack of custom middleware handlers which can be configured
+in :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler']` as an array. If a
+custom configuration is specified, the default handler stack will be extended
+and not overwritten.
 
-.. code-block:: php
+..  code-block:: php
+    :caption: typo3conf/AdditionalConfiguration.php
 
-   # Add custom middleware to default Guzzle handler stack
-   $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'][] =
-      (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\ACME\Middleware\Guzzle\CustomMiddleware::class))->handler();
-   $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'][] =
-      (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\ACME\Middleware\Guzzle\SecondCustomMiddleware::class))->handler();
+    // Add custom middlewares to default Guzzle handler stack
+    $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'][] =
+        (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \MyVendor\MyExtension\Middleware\Guzzle\CustomMiddleware::class
+        ))->handler();
+    $GLOBALS['TYPO3_CONF_VARS']['HTTP']['handler'][] =
+        (\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+            \MyVendor\MyExtension\Middleware\Guzzle\SecondCustomMiddleware::class
+        ))->handler();
 
 
 .. index:: HTTP request; HttpUtility
@@ -128,93 +141,87 @@ TYPO3 provides a small set of helper methods related to HTTP Requests in the cla
 HttpUtility::redirect
 ---------------------
 
-.. deprecated:: 11.3
-   With TYPO3 v11.3 this method has been deprecated. Create a direct response
-   using the :ref:`ResponseFactory <request-handling>` instead.
+..  deprecated:: 11.3
+    This method is deprecated and will be removed with TYPO3 v12.0. Create a
+    direct response using the :ref:`ResponseFactory <request-handling-psr-17>`
+    instead.
 
 .. _http_utility_response_migration:
 
 Migration
 ~~~~~~~~~
 
-Most of the time, a proper PSR-7 Response
-can be passed back to the call stack (request handler). Unfortunately there
-might still be some places, inside the call stack, where it is not possible to
-directly return a PSR-7 response. In such case, a :php:`PropagateResponseException`
-could be thrown. It will automatically be caught by a PSR-15 middleware and the
-given PSR-7 Response will then directly be returned.
+Most of the time, a proper PSR-7 response can be returned to the call stack
+(request handler). Unfortunately there might still be some places within the
+call stack where it is not possible to return a PSR-7 response directly. In such
+a case a :php:`TYPO3\CMS\Core\Http\PropagateResponseException` could be thrown.
+This is automatically caught by a PSR-15 middleware and the given PSR-7 response
+is then returned directly.
 
-.. code-block:: php
+..  code-block:: php
 
-   // Before
-   HttpUtility::redirect('https://example.org', HttpUtility::HTTP_STATUS_303);
+    // Before
+    HttpUtility::redirect('https://example.org/', HttpUtility::HTTP_STATUS_303);
 
-   // After
+    // After
 
-   // Inject PSR-17 ResponseFactoryInterface
-   public function __construct(ResponseFactoryInterface $responseFactory)
-   {
-      $this->responseFactory = $responseFactory
-   }
+    // use Psr\Http\Message\ResponseFactoryInterface
+    // use TYPO3\CMS\Core\Http\PropagateResponseException
 
-   // Create redirect response
-   $response = $this->responseFactory
-      ->createResponse(303)
-      ->withAddedHeader('location', 'https://example.org')
+    // Inject PSR-17 ResponseFactoryInterface
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory
+    }
 
-   // Return Response directly
-   return $reponse;
+    // Create redirect response
+    $response = $this->responseFactory
+        ->createResponse(303)
+        ->withAddedHeader('location', 'https://example.org/')
 
-   // or throw PropagateResponseException
-   new PropagateResponseException($response);
+    // Return response directly
+    return $response;
 
-.. note::
+    // Or throw PropagateResponseException
+    new PropagateResponseException($response);
 
-   Throwing exceptions for returning an immediate PSR-7 Response is considered
-   as an intermediate solution only, until it's possible to return PSR-7
-   responses in every relevant place. Therefore, the exception is marked
-   as :php:`@internal` and will most likely vanish again in the future.
+..  note::
+    Throwing exceptions for returning an immediate PSR-7 response is only
+    considered as an intermediate solution until it is possible to return PSR-7
+    responses at any relevant place. Therefore, the exception is marked as
+    :php:`@internal` and will most likely vanish in the future.
 
 HttpUtility::setResponseCode
 ----------------------------
 
-.. deprecated:: 11.3
-   With TYPO3 v11.3 this method has been deprecated. Create a direct response
-   using the :ref:`ResponseFactory <request-handling>` instead. See also
-   :ref:`Migration <http_utility_response_migration>`.
+..  deprecated:: 11.3
+    This method is deprecated and will be removed with TYPO3 v12.0. Create a
+    direct response using the :ref:`ResponseFactory <request-handling-psr-17>`
+    instead. See also :ref:`Migration <http_utility_response_migration>`.
 
 HttpUtility::setResponseCodeAndExit
 -----------------------------------
 
-.. deprecated:: 11.3
-   With TYPO3 v11.3 this method has been deprecated. Create a direct response
-   using the :ref:`ResponseFactory <request-handling>` instead. See also
-   :ref:`Migration <http_utility_response_migration>`.
+..  deprecated:: 11.3
+    This method is deprecated and will be removed with TYPO3 v12.0. Create a
+    direct response using the :ref:`ResponseFactory <request-handling-psr-17>`
+    instead. See also :ref:`Migration <http_utility_response_migration>`.
 
 HttpUtility::buildUrl
 ---------------------
 
-Builds a URL string from an array with the URL parts, as e.g. output by :php:`parse_url()`.
+Creates a URL string from an array containing the URL parts, such as those
+output by :php:`parse_url()`.
 
 HttpUtility::buildQueryString
 -----------------------------
 
-The method :php:`buildQueryString()` is an enhancement to the `PHP function`_ :php:`http_build_query()`.
-It implodes multidimensional parameter arrays and properly encodes parameter names as well as values to a valid query string.
+The :php:`buildQueryString()` method is an enhancement to the `PHP function`_
+:php:`http_build_query()`. It implodes multidimensional parameter arrays and
+properly encodes parameter names as well as values into a valid query string
 with an optional prepend of :php:`?` or :php:`&`.
 
 If the query is not empty, `?` or `&` are prepended in the correct sequence.
 Empty parameters are skipped.
 
 .. _`PHP function`: https://secure.php.net/manual/de/function.http-build-query.php
-
-HttpUtility::idn_to_ascii
--------------------------
-
-Compatibility layer for PHP versions running ICU 4.4, as the constant :php:`INTL_IDNA_VARIANT_UTS46`
-is only available as of ICU 4.6.
-
-.. important::
-
-   Once PHP 7.4 is the minimum requirement, this method will vanish without further notice
-   as it is recommended to use the native method instead, when working against a modern environment.


### PR DESCRIPTION
- Correct code snippet in basic usage: RequestFactoryInterface is wrong
  as it does not have a request method. The RequestFactory implements
  that factory (with the method createRequest) and the additional method
  request.
- Correct that custom middlewares do not overwrite the existing ones
  (See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-88871-RequestFactoryRespectsGuzzleMiddlewareHandlerConfigurationFromTYPO3_CONF_VARS.html)
- Correct wrong information about overwriting the middleware handler stack,
  actually, is not overwritten (https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-88871-RequestFactoryRespectsGuzzleMiddlewareHandlerConfigurationFromTYPO3_CONF_VARS.html)
- Remove note about moving of information to backend routing, as that
  page has actually less in common with this chapter.
- Remove outdated chapter about HttpUtility::idn_to_ascii as it was
  deprecated in v10.0 and obviously removed with v11.0.
  (See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87894-GeneralUtilityidnaEncode.html)
- Use the stable links to Guzzle documentation, not latest (=dev).

Releases: main, 11.5