### PR TITLE
[TASK] Rename "Symfony console commands" chapter to "Console commands"

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -5,9 +5,9 @@
 .. _cli-mode-command-controllers:
 .. _symfony-console-commands:
 
-==============================
-Symfony console commands (cli)
-==============================
+======================
+Console commands (cli)
+======================
 
 It is possible to run TYPO3 scripts from the command line.
 This functionality can be used to set up cron jobs, for example.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -55,6 +55,7 @@ management system TYPO3.
    Configuration/Index
    ApiOverview/GlobalValues/Constants/Index
    ApiOverview/ContentElements/Index
+   ApiOverview/CommandControllers/Index
    ApiOverview/Context/Index
    ApiOverview/CropVariants/Index
    ApiOverview/FileProcessing/Index
@@ -96,7 +97,6 @@ management system TYPO3.
    ApiOverview/SessionStorageFramework/Index
    ApiOverview/SiteHandling/Index
    ApiOverview/SoftReferences/Index
-   ApiOverview/CommandControllers/Index
    ApiOverview/SymfonyExpressionLanguage/Index
    ApiOverview/Categories/Index
    ApiOverview/SystemRegistry/Index


### PR DESCRIPTION
This is a suggestion to make this chapter better findable
by navigation. One would look there for "console" or "command"
(which are very close in the alphabet) and not really for
"Symfony console command".

Releases: main, 11.5