### PR TITLE
Restructure the menu of TYPO3 Explained

### DIFF
--- a/Documentation/ApiOverview/Index.rst
+++ b/Documentation/ApiOverview/Index.rst
@@ -1,12 +1,8 @@
-:orphan:
-
 .. include:: /Includes.rst.txt
 
-
-
-============
-API Overview
-============
+=======
+API A-Z
+=======
 
 The TYPO3 APIs are first and foremost documented inside of the source
 scripts. It would be impossible to maintain documentation at more than
@@ -16,4 +12,12 @@ This chapter describes the most important elements of the API.
 .. note::
 
    The source is the documentation! (General wisdom)
+
+**Contents:**
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   */Index
 

--- a/Documentation/ExtensionArchitecture/Index.rst
+++ b/Documentation/ExtensionArchitecture/Index.rst
@@ -4,7 +4,7 @@
 .. _extension-development:
 
 =====================
-Extension Development
+Extension development
 =====================
 
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -32,81 +32,21 @@ management system TYPO3.
 
 **Table of Contents:**
 
-.. toctree::
-   :maxdepth: 1
+..  toctree::
+    :maxdepth: 1
 
-   Introduction/Index
+    Introduction/Index
 
-.. toctree::
-   :caption: TYPO3 A-Z
-   :maxdepth: 1
+..  toctree::
+    :maxdepth: 1
 
-   ApiOverview/Ajax/Index
-   ApiOverview/Assets/Index
-   ApiOverview/Authentication/Index
-   ApiOverview/Autoloading/Index
-   ApiOverview/AccessControl/Index
-   ApiOverview/BackendRouting/Index
-   ApiOverview/BackendUserObject/Index
-   ApiOverview/Bootstrapping/Index
-   ApiOverview/BroadcastChannels/Index
-   ApiOverview/CachingFramework/Index
-   CodingGuidelines/Index
-   Configuration/Index
-   ApiOverview/GlobalValues/Constants/Index
-   ApiOverview/ContentElements/Index
-   ApiOverview/CommandControllers/Index
-   ApiOverview/Context/Index
-   ApiOverview/CropVariants/Index
-   ApiOverview/FileProcessing/Index
-   ApiOverview/Database/Index
-   ApiOverview/Debugging/Index
-   ApiOverview/DependencyInjection/Index
-   ApiOverview/Deprecation/Index
-   ApiOverview/DirectoryStructure/Index
-   ApiOverview/Enumerations/Index
-   ApiOverview/Environment/Index
-   ApiOverview/ErrorAndExceptionHandling/Index
-   Events/Index
-   ExtensionArchitecture/Index
-   ApiOverview/ExtensionScanner/Index
-   ApiOverview/Fal/Index
-   ApiOverview/FlashMessages/Index
-   ApiOverview/Fluid/Index
-   ApiOverview/FormEngine/Index
-   ApiOverview/FormProtection/Index
-   ApiOverview/Http/Index
-   ApiOverview/Icon/Index
-   ApiOverview/Internationalization/Index
-   ApiOverview/JavaScript/Index
-   ApiOverview/LinkBrowser/Index
-   ApiOverview/LockingApi/Index
-   ApiOverview/Logging/Index
-   ApiOverview/Mail/Index
-   ApiOverview/MountPoints/Index
-   ApiOverview/Namespaces/Index
-   ApiOverview/PageTypes/Index
-   ApiOverview/Pagination/Index
-   ApiOverview/PasswordHashing/Index
-   ApiOverview/RequestHandling/Index
-   ApiOverview/Rte/Index
-   ApiOverview/Routing/Index
-   Security/Index
-   ApiOverview/Seo/Index
-   ApiOverview/Services/Index
-   ApiOverview/SessionStorageFramework/Index
-   ApiOverview/SiteHandling/Index
-   ApiOverview/SoftReferences/Index
-   ApiOverview/SymfonyExpressionLanguage/Index
-   ApiOverview/Categories/Index
-   ApiOverview/SystemRegistry/Index
-   ApiOverview/Typo3CoreEngine/Index
-   Testing/Index
-   ApiOverview/UpdateWizards/Index
-   ApiOverview/Workspaces/Index
-   ApiOverview/Xclasses/Index
-
-.. todo:: ApiOverview/Examples/
+    ApiOverview/Index
+    CodingGuidelines/Index
+    Configuration/Index
+    Events/Index
+    ExtensionArchitecture/Index
+    Security/Index
+    Testing/Index
 
 .. Meta Menu
 


### PR DESCRIPTION
Right now the menu of TYPO3 Explained is a long list. Even though many Documents are stored in the folder "ApiOverview" they are directly displayed in the main menu.

In TYPO3 6.2 we still had a shorter Menu where the API part was expandable:
https://docs.typo3.org/m/typo3/reference-coreapi/6.2/en-us/ExtensionArchitecture/FilesAndLocations/Index.html

I would like to return to roughly that menu structure. This makes Important chapters like Extension development, Security and Testing easier to find. The A-Z Api part is also just one click away by simply expanding that point in the menu.

It looks like this:

![image](https://user-images.githubusercontent.com/48202465/186809330-56231767-8493-480b-a246-19e3f332a6dd.png)


releases: main, 11.5, 10.4