### PR TITLE
Restructure TYPO3_CONF_VARS

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -4,20 +4,34 @@
    TYPO3_CONF_VARS; BE
 .. _typo3ConfVars_be:
 
-=================================
-$GLOBALS['TYPO3_CONF_VARS']['BE']
-=================================
+====================================
+BE - backend configuration variables
+====================================
+
+The following configuration variables can be used to configure settings for
+the TYPO3 backend:
+
+.. contents::
+   :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']`.
+
+    This variable can be set in one of the following files:
+
+    *   :file:`typo3conf/LocalConfiguration.php`
+    *   :file:`typo3conf/AdditionalConfiguration.php`
 
 .. index::
    TYPO3_CONF_VARS BE; languageDebug
 .. _typo3ConfVars_be_languageDebug:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['languageDebug']
-==================================================
+languageDebug
+=============
 
-.. confval:: languageDebug
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['languageDebug']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -28,12 +42,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['languageDebug']
    TYPO3_CONF_VARS BE; fileadminDir
 .. _typo3ConfVars_be_fileadminDir:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir']
-=================================================
+fileadminDir
+============
 
-.. confval:: fileadminDir
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: 'fileadmin/'
 
@@ -47,12 +60,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir']
    TYPO3_CONF_VARS BE; lockRootPath
 .. _typo3ConfVars_be_lockRootPath:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
-=================================================
+lockRootPath
+============
 
-.. confval:: lockRootPath
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -64,12 +76,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
    TYPO3_CONF_VARS BE; userHomePath
 .. _typo3ConfVars_be_userHomePath:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['userHomePath']
-=================================================
+userHomePath
+============
 
-.. confval:: userHomePath
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['userHomePath']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -83,12 +94,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['userHomePath']
    TYPO3_CONF_VARS BE; groupHomePath
 .. _typo3ConfVars_be_groupHomePath:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['groupHomePath']
-==================================================
+groupHomePath
+=============
 
-.. confval:: groupHomePath
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['groupHomePath']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -102,12 +112,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['groupHomePath']
    TYPO3_CONF_VARS BE; userUploadDir
 .. _typo3ConfVars_be_userUploadDir:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['userUploadDir']
-==================================================
+userUploadDir
+=============
 
-.. confval:: userUploadDir
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['userUploadDir']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -119,12 +128,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['userUploadDir']
    TYPO3_CONF_VARS BE; warning_email_addr
 .. _typo3ConfVars_be_warning_email_addr:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']
-=======================================================
+warning_email_addr
+==================
 
-.. confval:: warning_email_addr
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -137,12 +145,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']
    TYPO3_CONF_VARS BE; warning_mode
 .. _typo3ConfVars_be_warning_mode:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['warning_mode']
-=================================================
+warning_mode
+============
 
-.. confval:: warning_mode
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_mode']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -159,12 +166,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_mode']
    TYPO3_CONF_VARS BE; passwordReset
 .. _typo3ConfVars_be_passwordReset:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['passwordReset']
-==================================================
+passwordReset
+=============
 
-.. confval:: passwordReset
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordReset']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: true
 
@@ -177,12 +183,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordReset']
    TYPO3_CONF_VARS BE; passwordResetForAdmins
 .. _typo3ConfVars_be_passwordResetForAdmins:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['passwordResetForAdmins']
-===========================================================
+passwordResetForAdmins
+======================
 
-.. confval:: passwordResetForAdmins
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordResetForAdmins']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: true
 
@@ -194,12 +199,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordResetForAdmins']
    TYPO3_CONF_VARS BE; requireMfa
 .. _typo3ConfVars_be_requireMfa:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa']
-===============================================
+requireMfa
+==========
 
-.. confval:: requireMfa
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -220,12 +224,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa']
    TYPO3_CONF_VARS BE; recommendedMfaProvider
 .. _typo3ConfVars_be_recommendedMfaProvider:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['recommendedMfaProvider']
-===========================================================
+recommendedMfaProvider
+======================
 
-.. confval:: recommendedMfaProvider
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['recommendedMfaProvider']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: 'totp'
 
@@ -237,12 +240,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['recommendedMfaProvider']
    TYPO3_CONF_VARS BE; loginRateLimit
 .. _typo3ConfVars_be_loginRateLimit:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimit']
-===================================================
+loginRateLimit
+==============
 
-.. confval:: loginRateLimit
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimit']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 5
 
@@ -256,12 +258,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimit']
    TYPO3_CONF_VARS BE; loginRateLimitInterval
 .. _typo3ConfVars_be_loginRateLimitInterval:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitInterval']
-===========================================================
+loginRateLimitInterval
+======================
 
-.. confval:: loginRateLimitInterval
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitInterval']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: string, PHP relative format
    :Default: '15 minutes'
    :allowedValues: '1 minute', '5 minutes', '15 minutes', '30 minutes'
@@ -276,12 +277,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitInterval']
    TYPO3_CONF_VARS BE; loginRateLimitIpExcludeList
 .. _typo3ConfVars_be_loginRateLimitIpExcludeList:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitIpExcludeList']
-================================================================
+loginRateLimitIpExcludeList
+===========================
 
-.. confval:: loginRateLimitIpExcludeList
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitIpExcludeList']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: string
    :Default: ''
 
@@ -294,12 +294,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitIpExcludeList']
    TYPO3_CONF_VARS BE; lockIP
 .. _typo3ConfVars_be_lockIP:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['lockIP']
-===========================================
+lockIP
+======
 
-.. confval:: lockIP
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIP']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -320,12 +319,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIP']
    TYPO3_CONF_VARS BE; lockIPv6
 .. _typo3ConfVars_be_lockIPv6:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['lockIPv6']
-=============================================
+lockIPv6
+========
 
-.. confval:: lockIPv6
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIPv6']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -354,12 +352,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIPv6']
    TYPO3_CONF_VARS BE; sessionTimeout
 .. _typo3ConfVars_be_sessionTimeout:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['sessionTimeout']
-===================================================
+sessionTimeout
+==============
 
-.. confval:: sessionTimeout
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['sessionTimeout']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 28800
 
@@ -369,12 +366,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['sessionTimeout']
    TYPO3_CONF_VARS BE; IPmaskList
 .. _typo3ConfVars_be_IPmaskList:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList']
-===============================================
+IPmaskList
+==========
 
-.. confval:: IPmaskList
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: list
    :Default: ''
 
@@ -390,12 +386,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList']
    TYPO3_CONF_VARS BE; lockSSL
 .. _typo3ConfVars_be_lockSSL:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']
-============================================
+lockSSL
+=======
 
-.. confval:: lockSSL
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -407,12 +402,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']
    TYPO3_CONF_VARS BE; lockSSLPort
 .. _typo3ConfVars_be_lockSSLPort:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSLPort']
-================================================
+lockSSLPort
+===========
 
-.. confval:: lockSSLPort
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSLPort']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
 
@@ -423,12 +417,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSLPort']
    TYPO3_CONF_VARS BE;
 .. _typo3ConfVars_be_cookieDomain:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['cookieDomain']
-=================================================
+cookieDomain
+============
 
-.. confval:: cookieDomain
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieDomain']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -440,12 +433,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieDomain']
    TYPO3_CONF_VARS BE; cookieName
 .. _typo3ConfVars_be_cookieName:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']
-===============================================
+cookieName
+==========
 
-.. confval:: cookieName:
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: 'be_typo_user'
 
@@ -455,12 +447,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']
    TYPO3_CONF_VARS BE; cookieSameSite
 .. _typo3ConfVars_be_cookieSameSite:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite']
-===================================================
+cookieSameSite
+==============
 
-.. confval:: cookieSameSite
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: 'strict'
    :allowedValues:
@@ -483,8 +474,8 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite']
    TYPO3_CONF_VARS BE; loginSecurityLevel
 .. _typo3ConfVars_be_loginSecurityLevel:
 
-Removed: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']
-================================================================
+Removed: loginSecurityLevel
+===========================
 
 .. deprecated:: 11.3
    This option was removed with version 11.3. The only possible
@@ -497,12 +488,11 @@ Removed: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']
    TYPO3_CONF_VARS BE; showRefreshLoginPopup
 .. _typo3ConfVars_be_showRefreshLoginPopup:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['showRefreshLoginPopup']
-==========================================================
+showRefreshLoginPopup
+=====================
 
-.. confval:: showRefreshLoginPopup
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['showRefreshLoginPopup']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -515,12 +505,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['showRefreshLoginPopup']
    TYPO3_CONF_VARS BE; adminOnly
 .. _typo3ConfVars_be_adminOnly:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['adminOnly']
-==============================================
+adminOnly
+=========
 
-.. confval:: adminOnly
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['adminOnly']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: int
    :Default: 0
 
@@ -536,12 +525,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['adminOnly']
    TYPO3_CONF_VARS BE; disable_exec_function
 .. _typo3ConfVars_be_disable_exec_function:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['disable_exec_function']
-==========================================================
+disable_exec_function
+=====================
 
-.. confval:: disable_exec_function
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['disable_exec_function']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -554,12 +542,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['disable_exec_function']
    TYPO3_CONF_VARS BE; compressionLevel
 .. _typo3ConfVars_be_compressionLevel:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['compressionLevel']
+compressionLevel']
 =====================================================
 
-.. confval:: compressionLevel
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['compressionLevel']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: 0
    :Range: 0-9
@@ -581,12 +568,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['compressionLevel']
    TYPO3_CONF_VARS BE; installToolPassword
 .. _typo3ConfVars_be_installToolPassword:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['installToolPassword']
+installToolPassword']
 ========================================================
 
-.. confval:: installToolPassword
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['installToolPassword']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: string
    :Default: ''
 
@@ -597,12 +583,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['installToolPassword']
    TYPO3_CONF_VARS BE; checkStoredRecords
 .. _typo3ConfVars_be_checkStoredRecords:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecords']
+checkStoredRecords']
 =======================================================
 
-.. confval:: checkStoredRecords
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecords']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: true
 
@@ -613,12 +598,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecords']
    TYPO3_CONF_VARS BE; checkStoredRecordsLoose
 .. _typo3ConfVars_be_checkStoredRecordsLoose:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecordsLoose']
+checkStoredRecordsLoose']
 ============================================================
 
-.. confval:: checkStoredRecordsLoose
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecordsLoose']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: true
 
@@ -631,12 +615,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecordsLoose']
    TYPO3_CONF_VARS BE; defaultUserTSconfig
 .. _typo3ConfVars_be_defaultUserTSconfig:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
-============================================================
+defaultUserTSconfig']
+========================================================
 
-.. confval:: defaultUserTSconfig
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
 
    Contains the default user TSconfig.
@@ -662,12 +645,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
    TYPO3_CONF_VARS BE; defaultPageTSconfig
 .. _typo3ConfVars_be_defaultPageTSconfig:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
+defaultPageTSconfig']
 ========================================================
 
-.. confval:: defaultPageTSconfig
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
 
    Contains the default page TSconfig.
@@ -696,12 +678,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
    TYPO3_CONF_VARS BE; defaultPermissions
 .. _typo3ConfVars_be_defaultPermissions:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPermissions']
+defaultPermissions']
 ========================================================
 
-.. confval:: defaultPermissions
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPermissions']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: array
    :Default: []
 
@@ -738,12 +719,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPermissions']
    TYPO3_CONF_VARS BE; defaultUC
 .. _typo3ConfVars_be_defaultUC:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUC']
+defaultUC']
 ==============================================
 
-.. confval:: defaultUC
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUC']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: array
    :Default: []
 
@@ -773,12 +753,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUC']
    TYPO3_CONF_VARS BE; customPermOptions
 .. _typo3ConfVars_be_customPermOptions:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']
+customPermOptions']
 ======================================================
 
-.. confval:: customPermOptions
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: array
    :Default: []
 
@@ -802,12 +781,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']
    TYPO3_CONF_VARS BE; fileDenyPattern
 .. _typo3ConfVars_be_fileDenyPattern:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
+fileDenyPattern']
 ====================================================
 
-.. confval:: fileDenyPattern
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: text
    :Default: ''
 
@@ -826,7 +804,7 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
    TYPO3_CONF_VARS BE; interfaces
 .. _typo3ConfVars_be_interfaces:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['interfaces']
+interfaces']
 ===============================================
 
 .. versionchanged:: 12.0
@@ -838,7 +816,7 @@ where also a custom Fluid template may be used.
 
 .. _typo3ConfVars_be_explicitADmode:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']
+explicitADmode']
 ===================================================
 
 .. versionchanged:: 12.0
@@ -854,9 +832,8 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']
 $GLOBALS['TYPO3_CONF_VARS']['BE']['flexformForceCDATA']
 =======================================================
 
-.. confval:: flexformForceCDATA
+.. confval:: flexformForceCDATA']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: 0
 
@@ -868,12 +845,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['flexformForceCDATA']
    TYPO3_CONF_VARS BE; versionNumberInFilename
 .. _typo3ConfVars_be_versionNumberInFilename:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']
+versionNumberInFilename']
 ============================================================
 
-.. confval:: versionNumberInFilename
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -893,12 +869,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']
    TYPO3_CONF_VARS BE; debug
 .. _typo3ConfVars_be_debug:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['debug']
+debug']
 ==========================================
 
-.. confval:: debug
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['debug']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: bool
    :Default: false
 
@@ -911,7 +886,7 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['debug']
    TYPO3_CONF_VARS BE; toolbarItems (removed)
 .. _typo3ConfVars_be_toolbarItems:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']
+toolbarItems']
 =================================================
 
 .. warning::
@@ -936,12 +911,11 @@ your :file:`Configuration/Services.(yaml|php)`, add the tag
    TYPO3_CONF_VARS BE; HTTP
 .. _typo3ConfVars_be_HTTP:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
+HTTP']
 =========================================
 
-.. confval:: HTTP
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']
    :type: array
    :Default:
       .. code-block:: php
@@ -959,12 +933,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
    TYPO3_CONF_VARS BE; passwordHashing className
 .. _typo3ConfVars_be_passwordHashing_className:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['className']
+passwordHashing']['className']
 =================================================================
 
-.. confval:: passwordHashing className
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['className']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']
    :type: string
    :Default: :php:`\TYPO3\CMS\Core\Crypto\PasswordHashing\Argon2iPasswordHash::class`
 
@@ -985,12 +958,11 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['className']
    TYPO3_CONF_VARS BE; passwordHashing options
 .. _typo3ConfVars_be_passwordHashing_options:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['options']
-=================================================================
+passwordHashing']['options']
+===============================================================
 
-.. confval:: passwordHashing options
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['options']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']
    :type: array
    :Default: []
 

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -5,14 +5,14 @@
 .. _typo3ConfVars_be:
 
 ====================================
-BE - backend configuration variables
+BE - backend configuration
 ====================================
 
 The following configuration variables can be used to configure settings for
 the TYPO3 backend:
 
-.. contents::
-   :local:
+..  contents::
+    :local:
 
 ..  note::
     The configuration values listed here are keys in the global PHP array
@@ -20,8 +20,8 @@ the TYPO3 backend:
 
     This variable can be set in one of the following files:
 
-    *   :file:`typo3conf/LocalConfiguration.php`
-    *   :file:`typo3conf/AdditionalConfiguration.php`
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
 
 .. index::
    TYPO3_CONF_VARS BE; languageDebug
@@ -542,8 +542,8 @@ disable_exec_function
    TYPO3_CONF_VARS BE; compressionLevel
 .. _typo3ConfVars_be_compressionLevel:
 
-compressionLevel']
-=====================================================
+compressionLevel
+================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['compressionLevel']
 
@@ -568,8 +568,8 @@ compressionLevel']
    TYPO3_CONF_VARS BE; installToolPassword
 .. _typo3ConfVars_be_installToolPassword:
 
-installToolPassword']
-========================================================
+installToolPassword
+===================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['installToolPassword']
 
@@ -583,8 +583,8 @@ installToolPassword']
    TYPO3_CONF_VARS BE; checkStoredRecords
 .. _typo3ConfVars_be_checkStoredRecords:
 
-checkStoredRecords']
-=======================================================
+checkStoredRecords
+==================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecords']
 
@@ -598,8 +598,8 @@ checkStoredRecords']
    TYPO3_CONF_VARS BE; checkStoredRecordsLoose
 .. _typo3ConfVars_be_checkStoredRecordsLoose:
 
-checkStoredRecordsLoose']
-============================================================
+checkStoredRecordsLoose
+=======================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['checkStoredRecordsLoose']
 
@@ -615,8 +615,8 @@ checkStoredRecordsLoose']
    TYPO3_CONF_VARS BE; defaultUserTSconfig
 .. _typo3ConfVars_be_defaultUserTSconfig:
 
-defaultUserTSconfig']
-========================================================
+defaultUserTSconfig
+===================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUserTSconfig']
 
@@ -645,8 +645,8 @@ defaultUserTSconfig']
    TYPO3_CONF_VARS BE; defaultPageTSconfig
 .. _typo3ConfVars_be_defaultPageTSconfig:
 
-defaultPageTSconfig']
-========================================================
+defaultPageTSconfig
+===================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
 
@@ -678,8 +678,8 @@ defaultPageTSconfig']
    TYPO3_CONF_VARS BE; defaultPermissions
 .. _typo3ConfVars_be_defaultPermissions:
 
-defaultPermissions']
-========================================================
+defaultPermissions
+==================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPermissions']
 
@@ -719,8 +719,8 @@ defaultPermissions']
    TYPO3_CONF_VARS BE; defaultUC
 .. _typo3ConfVars_be_defaultUC:
 
-defaultUC']
-==============================================
+defaultUC
+=========
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUC']
 
@@ -753,8 +753,8 @@ defaultUC']
    TYPO3_CONF_VARS BE; customPermOptions
 .. _typo3ConfVars_be_customPermOptions:
 
-customPermOptions']
-======================================================
+customPermOptions
+=================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']
 
@@ -781,8 +781,8 @@ customPermOptions']
    TYPO3_CONF_VARS BE; fileDenyPattern
 .. _typo3ConfVars_be_fileDenyPattern:
 
-fileDenyPattern']
-====================================================
+fileDenyPattern
+===============
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
 
@@ -804,8 +804,8 @@ fileDenyPattern']
    TYPO3_CONF_VARS BE; interfaces
 .. _typo3ConfVars_be_interfaces:
 
-interfaces']
-===============================================
+interfaces
+==========
 
 .. versionchanged:: 12.0
    This option was removed with TYPO3 v12.0.
@@ -816,8 +816,8 @@ where also a custom Fluid template may be used.
 
 .. _typo3ConfVars_be_explicitADmode:
 
-explicitADmode']
-===================================================
+explicitADmode
+==============
 
 .. versionchanged:: 12.0
    The handling of :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']` has been changed and
@@ -829,8 +829,8 @@ explicitADmode']
    TYPO3_CONF_VARS BE; flexformForceCDATA
 .. _typo3ConfVars_be_flexformForceCDATA:
 
-$GLOBALS['TYPO3_CONF_VARS']['BE']['flexformForceCDATA']
-=======================================================
+flexformForceCDATA
+==================
 
 .. confval:: flexformForceCDATA']
 
@@ -845,8 +845,8 @@ $GLOBALS['TYPO3_CONF_VARS']['BE']['flexformForceCDATA']
    TYPO3_CONF_VARS BE; versionNumberInFilename
 .. _typo3ConfVars_be_versionNumberInFilename:
 
-versionNumberInFilename']
-============================================================
+versionNumberInFilename
+=======================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']
 
@@ -869,8 +869,8 @@ versionNumberInFilename']
    TYPO3_CONF_VARS BE; debug
 .. _typo3ConfVars_be_debug:
 
-debug']
-==========================================
+debug
+=====
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['debug']
 
@@ -886,8 +886,8 @@ debug']
    TYPO3_CONF_VARS BE; toolbarItems (removed)
 .. _typo3ConfVars_be_toolbarItems:
 
-toolbarItems']
-=================================================
+toolbarItems
+============
 
 .. warning::
    This configuration variable has been removed in TYPO3 version 12.0. Setting
@@ -911,8 +911,8 @@ your :file:`Configuration/Services.(yaml|php)`, add the tag
    TYPO3_CONF_VARS BE; HTTP
 .. _typo3ConfVars_be_HTTP:
 
-HTTP']
-=========================================
+HTTP
+====
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
 
@@ -933,8 +933,11 @@ HTTP']
    TYPO3_CONF_VARS BE; passwordHashing className
 .. _typo3ConfVars_be_passwordHashing_className:
 
-passwordHashing']['className']
-=================================================================
+passwordHashing
+===============
+
+className
+---------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['className']
 
@@ -958,8 +961,8 @@ passwordHashing']['className']
    TYPO3_CONF_VARS BE; passwordHashing options
 .. _typo3ConfVars_be_passwordHashing_options:
 
-passwordHashing']['options']
-===============================================================
+options
+-------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']['options']
 

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -15,9 +15,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
 ================================================================
 
-.. confval:: additionalQueryRestrictions
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: array
    :Default: []
 
@@ -33,9 +32,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
 ================================================
 
-.. confval:: Connections
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: array
 
    One or more database connections can be configured under the
@@ -97,9 +95,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
 ------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> charset
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
    :Default: 'utf8'
 
@@ -114,9 +111,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
 -----------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> dbname
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    Name of the database/schema to connect to. Can be used with
@@ -130,9 +126,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
 -----------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> driver
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    The built-in driver implementation to use. The following drivers are
@@ -155,9 +150,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
 -------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> host
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    Hostname or IP address of the database to connect to. Can be used with
@@ -171,9 +165,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
 -------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> password
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
     Password to use when connecting to the database.
@@ -186,9 +179,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
 -------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> path
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    The filesystem path to the SQLite database file.
@@ -201,9 +193,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
 ---------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> port
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    Port of the database to connect to. Can be used with MySQL/MariaDB and
@@ -217,9 +208,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoptions']
 -----------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> tableoptions
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoptions']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: array
    :Default: []
 
@@ -251,9 +241,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoption
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket']
 ----------------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> unix_socket
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    Name of the socket used to connect to the database. Can be used with
@@ -266,9 +255,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket
 $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
 ---------------------------------------------------------------------------
 
-.. confval:: Connections <connection_name> user
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: string
 
    Username to use when connecting to the database.
@@ -281,9 +269,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
 $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']
 =================================================
 
-.. confval:: TableMapping
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']
    :type: array
    :Default: []
 

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -1,19 +1,35 @@
 .. include:: /Includes.rst.txt
 
-.. index::
-   TYPO3_CONF_VARS; DB
+..  index::
+    TYPO3_CONF_VARS; DB
+    Database; Connections
 .. _typo3ConfVars_db:
 
-=================================
-$GLOBALS['TYPO3_CONF_VARS']['DB']
-=================================
+=========================
+DB - Database connections
+=========================
+
+The following configuration variables can be used to configure settings for
+the connection to the database:
+
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['DB']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
 
 .. index::
    TYPO3_CONF_VARS DB; additionalQueryRestrictions
 .. _typo3ConfVars_db_additionalQueryRestrictions:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
-================================================================
+additionalQueryRestrictions
+===========================
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
 
@@ -29,8 +45,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
    TYPO3_CONF_VARS DB; Connections
 .. _typo3ConfVars_db_connections:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
-================================================
+Connections
+===========
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
 
@@ -92,8 +108,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
    TYPO3_CONF_VARS DB; Connections Charset
 .. _typo3ConfVars_db_connections_charset:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
-------------------------------------------------------------------------------
+charset
+-------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
 
@@ -108,8 +124,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['charset']
    TYPO3_CONF_VARS DB; Connections Database name
 .. _typo3ConfVars_db_connections_dbname:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
------------------------------------------------------------------------------
+dbname
+------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
 
@@ -123,8 +139,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['dbname']
    TYPO3_CONF_VARS DB; Connections Driver
 .. _typo3ConfVars_db_connections_driver:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
------------------------------------------------------------------------------
+driver
+------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
 
@@ -147,8 +163,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['driver']
    TYPO3_CONF_VARS DB; Connections Host
 .. _typo3ConfVars_db_connections_host:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
--------------------------------------------------------------------------------
+host
+----
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
 
@@ -162,8 +178,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['host']
    TYPO3_CONF_VARS DB; Connections Password
 .. _typo3ConfVars_db_connections_password:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
--------------------------------------------------------------------------------
+password
+--------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
 
@@ -176,8 +192,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['password']
    TYPO3_CONF_VARS DB; Connections Path
 .. _typo3ConfVars_db_connections_path:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
--------------------------------------------------------------------------------
+path
+----
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
 
@@ -190,8 +206,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['path']
    TYPO3_CONF_VARS DB; Connections Port
 .. _typo3ConfVars_db_connections_port:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
----------------------------------------------------------------------------
+port
+----
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
 
@@ -205,8 +221,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['port']
    TYPO3_CONF_VARS DB; Connections Table options
 .. _typo3ConfVars_db_connections_tableoptions:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoptions']
------------------------------------------------------------------------------------
+tableoptions
+------------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoptions']
 
@@ -238,8 +254,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['tableoption
    TYPO3_CONF_VARS DB; Connections Unix socket
 .. _typo3ConfVars_db_connections_unixsocket:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket']
-----------------------------------------------------------------------------------
+unix_socket
+-----------
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket']
 
@@ -252,8 +268,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['unix_socket
    TYPO3_CONF_VARS DB; Connections User
 .. _typo3ConfVars_db_connections_user:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
----------------------------------------------------------------------------
+user
+----
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
 
@@ -266,8 +282,8 @@ $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections'][<connection_name>]['user']
    TYPO3_CONF_VARS DB; TableMapping
 .. _typo3ConfVars_db_tablemapping:
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']
-=================================================
+TableMapping
+============
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']
 

--- a/Documentation/Configuration/Typo3ConfVars/EXT.rst
+++ b/Documentation/Configuration/Typo3ConfVars/EXT.rst
@@ -4,18 +4,38 @@
    TYPO3_CONF_VARS; EXT
 .. _typo3ConfVars_ext:
 
-==================================
-$GLOBALS['TYPO3_CONF_VARS']['EXT']
-==================================
+=====================================
+EXT - Extension manager configuration
+=====================================
+
+The following configuration variables can be used to configure settings for
+the Extension manager:
+
+..  contents::
+    :local:
+
+..  attention::
+    Extension specific configuration should be stored in
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSION']` and not here.
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['EXT']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
+
 
 .. index::
    TYPO3_CONF_VARS SYS; excludeForPackaging
 .. _typo3ConfVars_ext_excludeForPackaging:
 
-$GLOBALS['TYPO3_CONF_VARS']['EXT']['excludeForPackaging']
-=========================================================
+excludeForPackaging
+===================
 
-.. confval:: excludeForPackaging:
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['EXT']['excludeForPackaging']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['EXT']
    :type: list

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -4,20 +4,34 @@
    TYPO3_CONF_VARS; FE
 .. _typo3ConfVars_fe:
 
-=================================
-$GLOBALS['TYPO3_CONF_VARS']['FE']
-=================================
+===========================
+FE - frontend configuration
+===========================
+
+The following configuration variables can be used to configure settings for
+the TYPO3 frontend:
+
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
 
 .. index::
    TYPO3_CONF_VARS FE; addAllowedPaths
 .. _typo3ConfVars_fe_addAllowedPaths:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['addAllowedPaths']
-====================================================
+addAllowedPaths
+===============
 
-.. confval:: addAllowedPaths
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['addAllowedPaths']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: list
    :Default: ''
 
@@ -37,12 +51,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['addAllowedPaths']
    TYPO3_CONF_VARS FE; debug
 .. _typo3ConfVars_fe_debug:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['debug']
-==========================================
+debug
+=====
 
-.. confval:: debug
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['debug']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: false
 
@@ -54,12 +67,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['debug']
    TYPO3_CONF_VARS FE; compressionLevel
 .. _typo3ConfVars_fe_compressionLevel:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']
-=====================================================
+compressionLevel
+================
 
-.. confval:: compressionLevel
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 0
 
@@ -80,12 +92,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']
    TYPO3_CONF_VARS FE; pageNotFoundOnCHashError
 .. _typo3ConfVars_fe_pageNotFoundOnCHashError:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFoundOnCHashError']
-=============================================================
+pageNotFoundOnCHashError
+========================
 
-.. confval:: pageNotFoundOnCHashError
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFoundOnCHashError']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: true
 
@@ -96,12 +107,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFoundOnCHashError']
    TYPO3_CONF_VARS FE; pageUnavailable_force
 .. _typo3ConfVars_fe_pageUnavailable_force:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['pageUnavailable_force']
-==========================================================
+pageUnavailable_force
+=====================
 
-.. confval:: pageUnavailable_force
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['pageUnavailable_force']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: false
 
@@ -113,12 +123,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['pageUnavailable_force']
    TYPO3_CONF_VARS FE; addRootLineFields
 .. _typo3ConfVars_fe_addRootLineFields:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']
-======================================================
+addRootLineFields
+=================
 
-.. confval:: addRootLineFields
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: list
    :Default: ''
 
@@ -129,12 +138,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']
    TYPO3_CONF_VARS FE; checkFeUserPid
 .. _typo3ConfVars_fe_checkFeUserPid:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['checkFeUserPid']
-===================================================
+checkFeUserPid
+==============
 
-.. confval:: checkFeUserPid
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['checkFeUserPid']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: true
 
@@ -151,12 +159,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['checkFeUserPid']
    TYPO3_CONF_VARS FE; loginRateLimit
 .. _typo3ConfVars_fe_loginRateLimit:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimit']
-===================================================
+loginRateLimit
+==============
 
-.. confval:: loginRateLimit
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimit']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 5
 
@@ -170,12 +177,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimit']
    TYPO3_CONF_VARS FE; loginRateLimitInterval
 .. _typo3ConfVars_fe_loginRateLimitInterval:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitInterval']
-===========================================================
+loginRateLimitInterval
+======================
 
-.. confval:: loginRateLimitInterval
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitInterval']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: string, PHP relative format
    :Default: '15 minutes'
    :allowedValues: '1 minute', '5 minutes', '15 minutes', '30 minutes'
@@ -190,12 +196,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitInterval']
    TYPO3_CONF_VARS FE; loginRateLimitIpExcludeList
 .. _typo3ConfVars_fe_loginRateLimitIpExcludeList:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitIpExcludeList']
-================================================================
+loginRateLimitIpExcludeList
+===========================
 
-.. confval:: loginRateLimitIpExcludeList
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitIpExcludeList']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: string
    :Default: ''
 
@@ -207,12 +212,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitIpExcludeList']
    TYPO3_CONF_VARS FE; lockIP
 .. _typo3ConfVars_fe_lockIP:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['lockIP']
-===========================================
+lockIP
+======
 
-.. confval:: lockIP
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIP']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -241,12 +245,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIP']
    TYPO3_CONF_VARS FE; lockIPv6
 .. _typo3ConfVars_fe_lockIPv6:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['lockIPv6']
-====================================================
+lockIPv6
+========
 
-.. confval:: lockIPv6
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIPv6']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 0
    :allowedValues:
@@ -292,8 +295,8 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIPv6']
    TYPO3_CONF_VARS FE; loginSecurityLevel
 .. _typo3ConfVars_fe_loginSecurityLevel:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['loginSecurityLevel']
-=======================================================
+loginSecurityLevel
+==================
 
 .. deprecated:: 11.3
    This option got removed with version 11.3. The only possible
@@ -306,12 +309,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['loginSecurityLevel']
    TYPO3_CONF_VARS FE; lifetime
 .. _typo3ConfVars_fe_lifetime:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['lifetime']
-=============================================
+lifetime
+========
 
-.. confval:: lifetime
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['lifetime']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 0
 
@@ -326,12 +328,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['lifetime']
    TYPO3_CONF_VARS FE; sessionTimeout
 .. _typo3ConfVars_fe_sessionTimeout:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['sessionTimeout']
-====================================================
+sessionTimeout
+==============
 
-.. confval:: sessionTimeout
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionTimeout']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 6000
 
@@ -342,12 +343,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionTimeout']
    TYPO3_CONF_VARS FE; sessionDataLifetime
 .. _typo3ConfVars_fe_sessionDataLifetime:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['sessionDataLifetime']
-========================================================
+sessionDataLifetime
+===================
 
-.. confval:: sessionDataLifetime
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionDataLifetime']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: int
    :Default: 86400
 
@@ -359,12 +359,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionDataLifetime']
    TYPO3_CONF_VARS FE; permalogin
 .. _typo3ConfVars_fe_permalogin:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['permalogin']
-===============================================
+permalogin
+==========
 
-.. confval:: permalogin
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['permalogin']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: 0
 
@@ -389,12 +388,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['permalogin']
    TYPO3_CONF_VARS FE; cookieDomain
 .. _typo3ConfVars_fe_cookieDomain:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cookieDomain']
-=================================================
+cookieDomain
+============
 
-.. confval:: cookieDomain
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieDomain']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: ''
 
@@ -406,12 +404,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieDomain']
    TYPO3_CONF_VARS FE; cookieName
 .. _typo3ConfVars_fe_cookieName:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cookieName']
-===============================================
+cookieName
+==========
 
-.. confval:: cookieName
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieName']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: 'fe_typo_user'
 
@@ -421,12 +418,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieName']
    TYPO3_CONF_VARS FE; cookieSameSite
 .. _typo3ConfVars_fe_cookieSameSite:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cookieSameSite']
-===================================================
+cookieSameSite
+==============
 
-.. confval:: cookieSameSite
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieSameSite']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: 'lax'
    :allowedValues:
@@ -447,12 +443,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieSameSite']
    TYPO3_CONF_VARS FE; defaultUserTSconfig
 .. _typo3ConfVars_fe_defaultUserTSconfig:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['defaultUserTSconfig']
-========================================================
+defaultUserTSconfig
+===================
 
-.. confval:: defaultUserTSconfig
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultUserTSconfig']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: multiline
    :Default: ''
 
@@ -462,12 +457,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultUserTSconfig']
    TYPO3_CONF_VARS FE; defaultTypoScript_constants
 .. _typo3ConfVars_fe_defaultTypoScript_constants:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_constants']
-================================================================
+defaultTypoScript_constants
+===========================
 
-.. confval:: defaultTypoScript_constants
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_constants']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: multiline
    :Default: ''
 
@@ -477,12 +471,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_constants']
    TYPO3_CONF_VARS FE; defaultTypoScript_setup
 .. _typo3ConfVars_fe_defaultTypoScript_setup:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_setup']
-============================================================
+defaultTypoScript_setup
+=======================
 
-.. confval:: defaultTypoScript_setup
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_setup']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: multiline
    :Default: ''
 
@@ -492,12 +485,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_setup']
    TYPO3_CONF_VARS FE; additionalAbsRefPrefixDirectories
 .. _typo3ConfVars_fe_additionalAbsRefPrefixDirectories:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['additionalAbsRefPrefixDirectories']
-======================================================================
+additionalAbsRefPrefixDirectories
+=================================
 
-.. confval:: additionalAbsRefPrefixDirectories
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalAbsRefPrefixDirectories']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: ''
 
@@ -509,12 +501,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalAbsRefPrefixDirectories']
    TYPO3_CONF_VARS FE; enable_mount_pids
 .. _typo3ConfVars_fe_enable_mount_pids:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids']
-======================================================
+enable_mount_pids
+=================
 
-.. confval:: enable_mount_pids
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: true
 
@@ -525,12 +516,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids']
    TYPO3_CONF_VARS FE; hidePagesIfNotTranslatedByDefault
 .. _typo3ConfVars_fe_hidePagesIfNotTranslatedByDefault:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['hidePagesIfNotTranslatedByDefault']
-======================================================================
+hidePagesIfNotTranslatedByDefault
+=================================
 
-.. confval:: hidePagesIfNotTranslatedByDefault
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['hidePagesIfNotTranslatedByDefault']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: false
 
@@ -544,12 +534,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['hidePagesIfNotTranslatedByDefault']
    TYPO3_CONF_VARS FE; eID_include
 .. _typo3ConfVars_fe_eID_include:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']
-================================================
+eID_include
+===========
 
-.. confval:: eID_include
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: array
    :Default: []
 
@@ -566,12 +555,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']
    TYPO3_CONF_VARS FE; disableNoCacheParameter
 .. _typo3ConfVars_fe_disableNoCacheParameter:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['disableNoCacheParameter']
-============================================================
+disableNoCacheParameter
+=======================
 
-.. confval:: disableNoCacheParameter
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['disableNoCacheParameter']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: false
 
@@ -586,12 +574,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['disableNoCacheParameter']
    TYPO3_CONF_VARS FE; additionalCanonicalizedUrlParameters
 .. _typo3ConfVars_fe_additionalCanonicalizedUrlParameters:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
-=========================================================================
+additionalCanonicalizedUrlParameters
+====================================
 
-.. confval:: additionalCanonicalizedUrlParameters
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: array
    :Default: []
 
@@ -602,19 +589,18 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
    TYPO3_CONF_VARS FE; cacheHash
 .. _typo3ConfVars_fe_cacheHash:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
-==============================================
+cacheHash
+=========
 
 .. index::
    TYPO3_CONF_VARS FE; cacheHash cachedParametersWhiteList
 .. _typo3ConfVars_fe_cacheHash_cachedParametersWhiteList:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['cachedParametersWhiteList']
-___________________________________________________________________________
+cachedParametersWhiteList
+_________________________
 
-.. confval:: cachedParametersWhiteList:
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['cachedParametersWhiteList']['cacheHash']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
    :type: array
    :Default: []
 
@@ -630,12 +616,11 @@ ___________________________________________________________________________
    TYPO3_CONF_VARS FE; cacheHash requireCacheHashPresenceParameters
 .. _typo3ConfVars_fe_cacheHash_requireCacheHashPresenceParameters:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['requireCacheHashPresenceParameters']
-____________________________________________________________________________________
+requireCacheHashPresenceParameters
+__________________________________
 
-.. confval:: requireCacheHashPresenceParameters
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['requireCacheHashPresenceParameters']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
    :type: array
    :Default: []
 
@@ -647,12 +632,11 @@ ________________________________________________________________________________
    TYPO3_CONF_VARS FE; cacheHash excludedParameters
 .. _typo3ConfVars_fe_cacheHash_excludedParameters:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters']
-____________________________________________________________________
+excludedParameters
+__________________
 
-.. confval:: excludedParameters
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
    :type: array
    :Default: ['L', 'pk_campaign', 'pk_kwd', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'gclid', 'fbclid']
 
@@ -668,12 +652,11 @@ ____________________________________________________________________
    TYPO3_CONF_VARS FE; cacheHash excludedParametersIfEmpty
 .. _typo3ConfVars_fe_cacheHash_excludedParametersIfEmpty:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParametersIfEmpty']
-___________________________________________________________________________
+excludedParametersIfEmpty
+_________________________
 
-.. confval:: excludedParametersIfEmpty
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParametersIfEmpty']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
    :type: array
    :Default: []
 
@@ -685,12 +668,11 @@ ___________________________________________________________________________
    TYPO3_CONF_VARS FE; cacheHash excludeAllEmptyParameters
 .. _typo3ConfVars_fe_cacheHash_excludeAllEmptyParameters:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludeAllEmptyParameters']
-___________________________________________________________________________
+excludeAllEmptyParameters
+_________________________
 
-.. confval:: excludeAllEmptyParameters
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludeAllEmptyParameters']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']
    :type: bool
    :Default: false
 
@@ -701,12 +683,11 @@ ___________________________________________________________________________
    TYPO3_CONF_VARS FE; workspacePreviewLogoutTemplate
 .. _typo3ConfVars_fe_workspacePreviewLogoutTemplate:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['workspacePreviewLogoutTemplate']
-===================================================================
+workspacePreviewLogoutTemplate
+==============================
 
-.. confval:: workspacePreviewLogoutTemplate
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['workspacePreviewLogoutTemplate']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: text
    :Default: ''
 
@@ -721,12 +702,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['workspacePreviewLogoutTemplate']
    TYPO3_CONF_VARS FE; versionNumberInFilename
 .. _typo3ConfVars_fe_versionNumberInFilename:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename']
-============================================================
+versionNumberInFilename
+=======================
 
-.. confval:: versionNumberInFilename
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: dropdown
    :Default: 'querystring'
    :allowedValues:
@@ -754,12 +734,11 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename']
    TYPO3_CONF_VARS FE; contentRenderingTemplates
 .. _typo3ConfVars_fe_contentRenderingTemplates:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates']
-==============================================================
+contentRenderingTemplates
+=========================
 
-.. confval:: contentRenderingTemplates
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: array
    :Default: []
 
@@ -777,8 +756,8 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates']
    TYPO3_CONF_VARS FE; ContentObjects
 .. _typo3ConfVars_fe_ContentObjects:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
-===================================================
+ContentObjects
+==============
 
 .. versionchanged:: 12.0
 
@@ -804,12 +783,11 @@ TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
    TYPO3_CONF_VARS FE; typolinkBuilder
 .. _typo3ConfVars_fe_typolinkBuilder:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']
-====================================================
+typolinkBuilder
+===============
 
-.. confval:: typolinkBuilder
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: array
 
    Matches the LinkService implementations for generating URL, link text via typolink
@@ -832,20 +810,18 @@ $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']
    TYPO3_CONF_VARS FE; passwordHashing
 .. _typo3ConfVars_fe_passwordHashing:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']
-====================================================
-
+passwordHashing
+===============
 
 .. index::
    TYPO3_CONF_VARS FE; passwordHashing className
 .. _typo3ConfVars_fe_passwordHashing_className:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['className']
-_________________________________________________________________
+className
+_________
 
-.. confval:: className
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['className']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']
    :type: string
    :Default: :php:`\TYPO3\CMS\Core\Crypto\PasswordHashing\Argon2iPasswordHash::class`
    :allowedValues:
@@ -865,12 +841,11 @@ _________________________________________________________________
    TYPO3_CONF_VARS FE; passwordHashing options
 .. _typo3ConfVars_fe_passwordHashing_options:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['options']
-_______________________________________________________________
+options
+_______
 
-.. confval:: options
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['options']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']
    :type: array
    :Default: []
 
@@ -881,12 +856,11 @@ _______________________________________________________________
    TYPO3_CONF_VARS FE; exposeRedirectInformation
 .. _typo3ConfVars_fe_exposeRedirectInformation:
 
-$GLOBALS['TYPO3_CONF_VARS']['FE']['exposeRedirectInformation']
-==============================================================
+exposeRedirectInformation
+=========================
 
-.. confval:: exposeRedirectInformation
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['exposeRedirectInformation']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']
    :type: bool
    :Default: false
 

--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -10,7 +10,7 @@ GFX - graphics configuration
 ============================
 
 The following configuration variables can be used to configure settings for
-the handling images and graphics:
+the handling of images and graphics:
 
 ..  contents::
     :local:

--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -5,20 +5,35 @@
    TYPO3_CONF_VARS GFX
 .. _typo3ConfVars_gfx:
 
-==================================
-$GLOBALS['TYPO3_CONF_VARS']['GFX']
-==================================
+============================
+GFX - graphics configuration
+============================
+
+The following configuration variables can be used to configure settings for
+the handling images and graphics:
+
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
+
 
 .. index::
    TYPO3_CONF_VARS GFX; thumbnails
 .. _typo3ConfVars_gfx_thumbnails:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails']
-================================================
+thumbnails
+==========
 
-.. confval:: thumbnails
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -28,12 +43,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails']
    TYPO3_CONF_VARS GFX; thumbnails_png
 .. _typo3ConfVars_gfx_thumbnails_png:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails_png']
-====================================================
+thumbnails_png
+==============
 
-.. confval:: thumbnails_png
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails_png']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -44,12 +58,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails_png']
    TYPO3_CONF_VARS GFX; gif_compress
 .. _typo3ConfVars_gfx_gif_compress:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['gif_compress']
-==================================================
+gif_compress
+============
 
-.. confval:: gif_compress
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['gif_compress']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -62,12 +75,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['gif_compress']
    TYPO3_CONF_VARS GFX; imagefile_ext
 .. _typo3ConfVars_gfx_imagefile_ext:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
-===================================================
+imagefile_ext
+=============
 
-.. confval:: imagefile_ext
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: list
    :Default: 'gif,jpg,jpeg,tif,tiff,bmp,pcx,tga,png,pdf,ai,svg'
 
@@ -79,12 +91,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
    TYPO3_CONF_VARS GFX; gdlib
 .. _typo3ConfVars_gfx_gdlib:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib']
-===========================================
+gdlib
+=====
 
-.. confval:: gdlib
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -94,12 +105,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib']
    TYPO3_CONF_VARS GFX; gdlib_png
 .. _typo3ConfVars_gfx_gdlib_png:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib_png']
-===============================================
+gdlib_png
+=========
 
-.. confval:: gdlib_png
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib_png']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: false
 
@@ -110,12 +120,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['gdlib_png']
    TYPO3_CONF_VARS GFX;
 .. _typo3ConfVars_gfx_processor_enabled:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_enabled']
-=======================================================
+processor_enabled
+=================
 
-.. confval:: processor_enabled
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_enabled']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -125,12 +134,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_enabled']
    TYPO3_CONF_VARS GFX; processor_path
 .. _typo3ConfVars_gfx_processor_path:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path']
-====================================================
+processor_path
+==============
 
-.. confval:: processor_path
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: text
    :Default: '/usr/bin/'
 
@@ -140,12 +148,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path']
    TYPO3_CONF_VARS GFX; processor
 .. _typo3ConfVars_gfx_processor:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor']
-===============================================
+processor
+=========
 
-.. confval:: processor
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: dropdown
    :Default: 'ImageMagick'
    :allowedValues:
@@ -161,12 +168,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor']
    TYPO3_CONF_VARS GFX; processor_effects
 .. _typo3ConfVars_gfx_processor_effects:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_effects']
-=======================================================
+processor_effects
+=================
 
-.. confval:: processor_effects
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_effects']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: false
 
@@ -176,12 +182,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_effects']
    TYPO3_CONF_VARS GFX; processor_allowUpscaling
 .. _typo3ConfVars_gfx_processor_allowUpscaling:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowUpscaling']
-==============================================================
+processor_allowUpscaling
+========================
 
-.. confval:: processor_allowUpscaling
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowUpscaling']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -192,12 +197,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowUpscaling']
    TYPO3_CONF_VARS GFX; processor_allowFrameSelection
 .. _typo3ConfVars_gfx_processor_allowFrameSelection:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowFrameSelection']
-===================================================================
+processor_allowFrameSelection
+=============================
 
-.. confval:: processor_allowFrameSelection
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowFrameSelection']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -210,12 +214,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowFrameSelection']
    TYPO3_CONF_VARS GFX; processor_allowTemporaryMasksAsPng
 .. _typo3ConfVars_gfx_processor_allowTemporaryMasksAsPng:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowTemporaryMasksAsPng']
-========================================================================
+processor_allowTemporaryMasksAsPng
+==================================
 
-.. confval:: processor_allowTemporaryMasksAsPng
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowTemporaryMasksAsPng']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: false
 
@@ -226,12 +229,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_allowTemporaryMasksAsPng']
    TYPO3_CONF_VARS GFX;
 .. _typo3ConfVars_gfx_processor_stripColorProfileByDefault:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileByDefault']
-==========================================================================
+processor_stripColorProfileByDefault
+====================================
 
-.. confval:: processor_stripColorProfileByDefault
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileByDefault']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: bool
    :Default: true
 
@@ -243,12 +245,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileByDefault']
    TYPO3_CONF_VARS GFX; processor_stripColorProfileCommand
 .. _typo3ConfVars_gfx_processor_stripColorProfileCommand:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']
-========================================================================
+processor_stripColorProfileCommand
+==================================
 
-.. confval:: processor_stripColorProfileCommand
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: text
    :Default: \+profile \'\*\'
 
@@ -262,12 +263,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileCommand']
    TYPO3_CONF_VARS GFX; processor_colorspace
 .. _typo3ConfVars_gfx_processor_colorspace:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_colorspace']
-==========================================================
+processor_colorspace
+====================
 
-.. confval:: processor_colorspace
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_colorspace']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: text
    :Default: RGB
 
@@ -282,12 +282,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_colorspace']
    TYPO3_CONF_VARS GFX; processor_interlace
 .. _typo3ConfVars_gfx_processor_interlace:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_interlace']
-=========================================================
+processor_interlace
+===================
 
-.. confval:: processor_interlace
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_interlace']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: text
    :Default: 'None'
 
@@ -301,12 +300,11 @@ $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_interlace']
    TYPO3_CONF_VARS GFX; jpg_quality
 .. _typo3ConfVars_gfx_jpg_quality:
 
-$GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality']
-=================================================
+jpg_quality
+===========
 
-.. confval:: jpg_quality
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']
    :type: int
    :Default: 85
 

--- a/Documentation/Configuration/Typo3ConfVars/HTTP.rst
+++ b/Documentation/Configuration/Typo3ConfVars/HTTP.rst
@@ -5,40 +5,50 @@
    TYPO3_CONF_VARS HTTP
 .. _typo3ConfVars_http:
 
-===================================
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']
-===================================
+====================
+HTTP - tune requests
+====================
 
 HTTP configuration to tune how TYPO3 behaves on HTTP requests made by TYPO3.
 See `Guzzle documentation <https://docs.guzzlephp.org/en/latest/request-options.html>`__
 for more background information on those settings.
 
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
+
+
 .. index::
    TYPO3_CONF_VARS HTTP; allow_redirects
 .. _typo3ConfVars_http_allow_redirects:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']
-======================================================
+allow_redirects
+===============
 
-.. confval:: allow_redirects
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: mixed
 
    Mixed, set to false if you want to disallow redirects, or use it as an
-   array to add more values.
-
+   array to add more configuration values (see below).
 
 .. index::
    TYPO3_CONF_VARS HTTP; allow_redirects strict
 .. _typo3ConfVars_http_allow_redirects_strict:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['strict']
-----------------------------------------------------------------
+strict
+------
 
-.. confval:: allow_redirects strict
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['strict']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: bool
    :Default: false
 
@@ -56,12 +66,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['strict']
    TYPO3_CONF_VARS HTTP; allow_redirects max
 .. _typo3ConfVars_http_allow_redirects_max:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['max']
--------------------------------------------------------------
+max
+---
 
-.. confval:: allow_redirects max
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['max']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: int
    :Default: 5
 
@@ -71,12 +80,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']['max']
    TYPO3_CONF_VARS HTTP; cert
 .. _typo3ConfVars_http_cert:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['cert']
-===========================================
+cert
+====
 
-.. confval:: cert
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['cert']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: mixed
    :Default: null
 
@@ -88,12 +96,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['cert']
    TYPO3_CONF_VARS HTTP; connect_timeout
 .. _typo3ConfVars_http_connect_timeout:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout']
-======================================================
+connect_timeout
+===============
 
-.. confval:: connect_timeout
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: int
    :Default: 10
 
@@ -104,12 +111,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout']
    TYPO3_CONF_VARS HTTP; proxy
 .. _typo3ConfVars_http_proxy:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']
-====================================================
+proxy
+=====
 
-.. confval:: proxy
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: mixed
    :Default: null
 
@@ -128,12 +134,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']
    TYPO3_CONF_VARS HTTP; ssl_key
 .. _typo3ConfVars_http_ssl_key:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['ssl_key']
-====================================================
+ssl_key
+=======
 
-.. confval:: ssl_key
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['ssl_key']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: mixed
    :Default: null
 
@@ -144,12 +149,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['ssl_key']
    TYPO3_CONF_VARS HTTP; timeout
 .. _typo3ConfVars_http_timeout:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']
-====================================================
+timeout
+=======
 
-.. confval:: timeout
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: int
    :Default: 0
 
@@ -164,12 +168,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']
    TYPO3_CONF_VARS HTTP; verify
 .. _typo3ConfVars_http_verify:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify']
-====================================================
+verify
+======
 
-.. confval:: verify
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: mixed
    :Default: true
 
@@ -180,12 +183,11 @@ $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify']
    TYPO3_CONF_VARS HTTP; version
 .. _typo3ConfVars_http_version:
 
-$GLOBALS['TYPO3_CONF_VARS']['HTTP']['version']
-====================================================
+version
+=======
 
-.. confval:: version
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['version']
 
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']
    :type: text
    :Default: '1.1'
 

--- a/Documentation/Configuration/Typo3ConfVars/Index.rst
+++ b/Documentation/Configuration/Typo3ConfVars/Index.rst
@@ -5,7 +5,7 @@
 .. _typo3ConfVars:
 
 ===========================
-$GLOBALS['TYPO3_CONF_VARS']
+TYPO3_CONF_VARS
 ===========================
 
 However the main configuration is achieved via a set of global settings

--- a/Documentation/Configuration/Typo3ConfVars/Index.rst
+++ b/Documentation/Configuration/Typo3ConfVars/Index.rst
@@ -8,25 +8,24 @@
 TYPO3_CONF_VARS
 ===========================
 
-However the main configuration is achieved via a set of global settings
+The main configuration is achieved via a set of global settings
 stored in a global array called :php:`$GLOBALS['TYPO3_CONF_VARS']`.
 
 This chapter describes this global configuration in more details and hints
 at other configuration possibilities.
 
-.. toctree::
-   :maxdepth: 1
-   :titlesonly:
-   :hidden:
+..  note::
+    This variable can be set in one of the following files:
 
-   BE
-   DB
-   EXT
-   FE
-   GFX
-   HTTP
-   MAIL
-   SYS
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
+
+..  toctree::
+    :titlesonly:
+    :glob:
+    :hidden:
+
+    *
 
 .. index::
    ! File; typo3conf/LocalConfiguration.php
@@ -168,13 +167,13 @@ T3_SERVICES
    :ref:`Service registration configuration <services-configuration-registration-changes>`
    and the backend.
 
-Further details on the various configuration options can be found in the Install Tool
-as well as the TYPO3 source at
+Further details on the various configuration options can be found in the
+:guilabel:`Admin Tools` as well as the TYPO3 source at
 :file:`typo3/sysext/core/Configuration/DefaultConfigurationDescription.yaml`.
-The documentation shown in the Install Tool is automatically extracted from
-those values of :file:`DefaultConfigurationDescription.yaml`.
+The documentation shown in the :guilabel:`Admin Tools` is automatically
+extracted from those values of :file:`DefaultConfigurationDescription.yaml`.
 
-The Install Tool provides various dedicated modules that change parts of
+The :guilabel:`Admin Tools` provides various dedicated modules that change parts of
 :file:`LocalConfiguration.php`, those can be found in
 :guilabel:`Admin Tools > Settings`, most importantly section
 :guilabel:`Configure installation-wide options`:
@@ -258,5 +257,3 @@ Here is an extract of that file:
 You will probably find it interesting to take a look at that file,
 which also contains values not displayed in the Install Tool and thus
 not easily available for modification.
-
-

--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -5,18 +5,33 @@
    TYPO3_CONF_VARS MAIL
 .. _typo3ConfVars_mail:
 
-===================================
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']
-===================================
+=============
+MAIL settings
+=============
+
+The following configuration variables can be used to configure settings for
+the sending mails by TYPO3:
+
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['MAIL']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
 
 .. index::
    TYPO3_CONF_VARS MAIL; format
 .. _typo3ConfVars_mail_format:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['format']
-=============================================
+format
+======
 
-.. confval:: format
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['format']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: dropdown
@@ -37,10 +52,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['format']
    TYPO3_CONF_VARS MAIL; layoutRootPaths
 .. _typo3ConfVars_mail_layoutRootPaths:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['layoutRootPaths']
-======================================================
+layoutRootPaths
+===============
 
-.. confval:: layoutRootPaths
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['layoutRootPaths']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: array
@@ -59,10 +74,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['layoutRootPaths']
    TYPO3_CONF_VARS MAIL; partialRootPaths
 .. _typo3ConfVars_mail_partialRootPaths:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths']
-=======================================================
+partialRootPaths
+================
 
-.. confval:: partialRootPaths
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: array
@@ -81,10 +96,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['partialRootPaths']
    TYPO3_CONF_VARS MAIL; templateRootPaths
 .. _typo3ConfVars_mail_templateRootPaths:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths']
-========================================================
+templateRootPaths
+=================
 
-.. confval:: templateRootPaths
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: array
@@ -103,10 +118,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths']
    TYPO3_CONF_VARS MAIL; validators
 .. _typo3ConfVars_mail_validators:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['validators']
-=================================================
+validators
+==========
 
-.. confval:: validators
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['validators']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: array
@@ -126,10 +141,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['validators']
    TYPO3_CONF_VARS MAIL; transport
 .. _typo3ConfVars_mail_transport:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport']
-================================================
+transport
+=========
 
-.. confval:: transport
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -168,10 +183,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport']
    TYPO3_CONF_VARS MAIL; transport_smtp_server
 .. _typo3ConfVars_mail_transport_smtp_server:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server']
-============================================================
+transport_smtp_server
+=====================
 
-.. confval:: transport_smtp_server
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -184,10 +199,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_server']
    TYPO3_CONF_VARS MAIL; transport_smtp_domain
 .. _typo3ConfVars_mail_transport_smtp_domain:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_domain']
-============================================================
+transport_smtp_domain
+=====================
 
-.. confval:: transport_smtp_domain
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_domain']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -229,10 +244,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_domain']
    TYPO3_CONF_VARS MAIL; transport_smtp_stream_options
 .. _typo3ConfVars_mail_transport_smtp_stream_options:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_stream_options']
-====================================================================
+transport_smtp_stream_options
+=============================
 
-.. confval:: transport_smtp_stream_options
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_stream_options']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: bool
@@ -265,10 +280,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_stream_options']
    TYPO3_CONF_VARS MAIL; transport_smtp_encrypt
 .. _typo3ConfVars_mail_transport_smtp_encrypt:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_encrypt']
-=============================================================
+transport_smtp_encrypt
+======================
 
-.. confval:: transport_smtp_encrypt
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_encrypt']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: bool
@@ -284,10 +299,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_encrypt']
    TYPO3_CONF_VARS MAIL; transport_smtp_username
 .. _typo3ConfVars_mail_transport_smtp_username:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_username']
-==============================================================
+transport_smtp_username
+=======================
 
-.. confval:: transport_smtp_username
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_username']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -300,10 +315,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_username']
    TYPO3_CONF_VARS MAIL; transport_smtp_password
 .. _typo3ConfVars_mail_transport_smtp_password:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_password']
-==============================================================
+transport_smtp_password
+=======================
 
-.. confval:: transport_smtp_password
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_password']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: password
@@ -316,10 +331,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_password']
    TYPO3_CONF_VARS MAIL; transport_smtp_restart_threshold
 .. _typo3ConfVars_mail_transport_smtp_restart_threshold:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold']
-=======================================================================
+transport_smtp_restart_threshold
+================================
 
-.. confval:: transport_smtp_restart_threshold
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -332,10 +347,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold']
    TYPO3_CONF_VARS MAIL; transport_smtp_restart_threshold_sleep
 .. _typo3ConfVars_mail_transport_smtp_restart_threshold_sleep:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold_sleep']
-=============================================================================
+transport_smtp_restart_threshold_sleep
+======================================
 
-.. confval:: transport_smtp_restart_threshold_sleep
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold_sleep']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -348,10 +363,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_restart_threshold_sleep']
    TYPO3_CONF_VARS MAIL; transport_smtp_ping_threshold
 .. _typo3ConfVars_mail_transport_smtp_ping_threshold:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_ping_threshold']
-=======================================================================
+transport_smtp_ping_threshold
+=============================
 
-.. confval:: transport_smtp_ping_threshold
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_ping_threshold']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -373,10 +388,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_ping_threshold']
    TYPO3_CONF_VARS MAIL; transport_sendmail_command
 .. _typo3ConfVars_mail_transport_sendmail_command:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_sendmail_command']
-=================================================================
+transport_sendmail_command
+==========================
 
-.. confval:: transport_sendmail_command
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_sendmail_command']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -388,10 +403,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_sendmail_command']
    TYPO3_CONF_VARS MAIL; transport_mbox_file
 .. _typo3ConfVars_mail_transport_mbox_file:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file']
-==========================================================
+transport_mbox_file
+===================
 
-.. confval:: transport_mbox_file
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -405,10 +420,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_mbox_file']
    TYPO3_CONF_VARS MAIL; transport_spool_type
 .. _typo3ConfVars_mail_transport_spool_type:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type']
-===========================================================
+transport_spool_type
+====================
 
-.. confval:: transport_spool_type
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -426,10 +441,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type']
    TYPO3_CONF_VARS MAIL; transport_spool_filepath
 .. _typo3ConfVars_mail_transport_spool_filepath:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_filepath']
-===============================================================
+transport_spool_filepath
+========================
 
-.. confval:: transport_spool_filepath
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_filepath']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -442,10 +457,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_filepath']
    TYPO3_CONF_VARS MAIL; dsn
 .. _typo3ConfVars_mail_dsn:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['dsn']
-==========================================
+dsn
+===
 
-.. confval:: dsn
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['dsn']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -470,10 +485,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['dsn']
    TYPO3_CONF_VARS MAIL; defaultMailFromAddress
 .. _typo3ConfVars_mail_defaultMailFromAddress:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress']
-=============================================================
+defaultMailFromAddress
+======================
 
-.. confval:: defaultMailFromAddress
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -487,10 +502,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromAddress']
    TYPO3_CONF_VARS MAIL; defaultMailFromName
 .. _typo3ConfVars_mail_defaultMailFromName:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName']
-==========================================================
+defaultMailFromName
+===================
 
-.. confval:: defaultMailFromName
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -503,10 +518,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailFromName']
    TYPO3_CONF_VARS MAIL; defaultMailReplyToAddress
 .. _typo3ConfVars_mail_defaultMailReplyToAddress:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailReplyToAddress']
-================================================================
+defaultMailReplyToAddress
+=========================
 
-.. confval:: defaultMailReplyToAddress
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailReplyToAddress']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text
@@ -520,10 +535,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailReplyToAddress']
    TYPO3_CONF_VARS MAIL; defaultMailReplyToName
 .. _typo3ConfVars_mail_defaultMailReplyToName:
 
-$GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailReplyToName']
-=============================================================
+defaultMailReplyToName
+======================
 
-.. confval:: defaultMailReplyToName
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['defaultMailReplyToName']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['MAIL']
    :type: text

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -5,18 +5,33 @@
    TYPO3_CONF_VARS SYS
 .. _typo3ConfVars_sys:
 
-==================================
-$GLOBALS['TYPO3_CONF_VARS']['SYS']
-==================================
+==========================
+SYS - System configuration
+==========================
+
+The following configuration variables can be used for system wide
+configurations.
+
+..  contents::
+    :local:
+
+..  note::
+    The configuration values listed here are keys in the global PHP array
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']`.
+
+    This variable can be set in one of the following files:
+
+    *   :ref:`typo3conf/LocalConfiguration.php <typo3ConfVars-localConfiguration>`
+    *   :ref:`typo3conf/AdditionalConfiguration.php <typo3ConfVars-additionalConfiguration>`
 
 .. index::
    TYPO3_CONF_VARS SYS; fileCreateMask
 .. _typo3ConfVars_sys_fileCreateMask:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']
-====================================================
+fileCreateMask
+==============
 
-.. confval:: fileCreateMask
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -28,10 +43,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']
    TYPO3_CONF_VARS SYS; folderCreateMask
 .. _typo3ConfVars_sys_folderCreateMask:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']
-======================================================
+folderCreateMask
+================
 
-.. confval:: folderCreateMask
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -43,10 +58,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']
    TYPO3_CONF_VARS SYS; createGroup
 .. _typo3ConfVars_sys_createGroup:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['createGroup']
-=================================================
+createGroup
+===========
 
-.. confval:: createGroup
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['createGroup']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -67,10 +82,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['createGroup']
    TYPO3_CONF_VARS SYS; sitename
 .. _typo3ConfVars_sys_sitename:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']
-==============================================
+sitename
+========
 
-.. confval:: sitename
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -82,15 +97,15 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']
    TYPO3_CONF_VARS SYS; defaultScheme
 .. _typo3ConfVars_sys_defaultScheme:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['defaultScheme']
-===================================================
+defaultScheme
+=============
 
 .. versionadded:: 12.0
    The setting :php:`defaultScheme` was added in TYPO3 v12 to make it possible to
    configure the default URI scheme when links are created by the Core.
    Previously, :php:`'http'` was always used.
 
-.. confval:: defaultScheme
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['defaultScheme']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -103,10 +118,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['defaultScheme']
    TYPO3_CONF_VARS SYS; encryptionKey
 .. _typo3ConfVars_sys_encryptionKey:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
-===================================================
+encryptionKey
+=============
 
-.. confval:: encryptionKey
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -122,10 +137,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
    TYPO3_CONF_VARS SYS; cookieDomain
 .. _typo3ConfVars_sys_cookieDomain:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['cookieDomain']
-==================================================
+cookieDomain
+============
 
-.. confval:: cookieDomain
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['cookieDomain']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -148,10 +163,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['cookieDomain']
    TYPO3_CONF_VARS SYS; trustedHostsPattern
 .. _typo3ConfVars_sys_trustedHostsPattern:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']
-=========================================================
+trustedHostsPattern
+===================
 
-.. confval:: trustedHostsPattern
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -187,10 +202,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']
    TYPO3_CONF_VARS SYS; devIPmask
 .. _typo3ConfVars_sys_devIPmask:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']
-===============================================
+devIPmask
+=========
 
-.. confval:: devIPmask
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -206,10 +221,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']
    TYPO3_CONF_VARS SYS; ddmmyy
 .. _typo3ConfVars_sys_ddmmyy:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
-============================================
+ddmmyy
+======
 
-.. confval:: ddmmyy
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -221,10 +236,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
    TYPO3_CONF_VARS SYS; hhmm
 .. _typo3ConfVars_sys_hhmm:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm']
-==========================================
+hhmm
+====
 
-.. confval:: hhmm
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -236,10 +251,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm']
    TYPO3_CONF_VARS SYS; loginCopyrightWarrantyProvider
 .. _typo3ConfVars_sys_loginCopyrightWarrantyProvider:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyProvider']
-====================================================================
+loginCopyrightWarrantyProvider
+==============================
 
-.. confval:: loginCopyrightWarrantyProvider
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyProvider']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -253,10 +268,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyProvider']
    TYPO3_CONF_VARS SYS; loginCopyrightWarrantyURL
 .. _typo3ConfVars_sys_loginCopyrightWarrantyURL:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyURL']
-===============================================================
+loginCopyrightWarrantyURL
+=========================
 
-.. confval:: loginCopyrightWarrantyURL
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyURL']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -273,10 +288,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['loginCopyrightWarrantyURL']
    TYPO3_CONF_VARS SYS; textfile_ext
 .. _typo3ConfVars_sys_textfile_ext:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['textfile_ext']
-==================================================
+textfile_ext
+============
 
-.. confval:: textfile_ext
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['textfile_ext']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -289,10 +304,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['textfile_ext']
    TYPO3_CONF_VARS SYS; mediafile_ext
 .. _typo3ConfVars_sys_mediafile_ext:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
-===================================================
+mediafile_ext
+=============
 
-.. confval:: mediafile_ext
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -305,10 +320,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
    TYPO3_CONF_VARS SYS; binPath
 .. _typo3ConfVars_sys_binPath:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['binPath']
-=============================================
+binPath
+=======
 
-.. confval:: binPath
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['binPath']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -322,10 +337,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['binPath']
    TYPO3_CONF_VARS SYS; binSetup
 .. _typo3ConfVars_sys_binSetup:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['binSetup']
-==============================================
+binSetup
+========
 
-.. confval:: binSetup
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['binSetup']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: multiline
@@ -342,10 +357,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['binSetup']
    TYPO3_CONF_VARS SYS; setMemoryLimit
 .. _typo3ConfVars_sys_setMemoryLimit:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['setMemoryLimit']
-====================================================
+setMemoryLimit
+==============
 
-.. confval:: setMemoryLimit
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['setMemoryLimit']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: int
@@ -359,10 +374,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['setMemoryLimit']
    TYPO3_CONF_VARS SYS; phpTimeZone
 .. _typo3ConfVars_sys_phpTimeZone:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['phpTimeZone']
-=================================================
+phpTimeZone
+===========
 
-.. confval:: phpTimeZone
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['phpTimeZone']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -381,10 +396,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['phpTimeZone']
    TYPO3_CONF_VARS SYS; UTF8filesystem
 .. _typo3ConfVars_sys_UTF8filesystem:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']
-====================================================
+UTF8filesystem
+==============
 
-.. confval:: UTF8filesystem
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: bool
@@ -413,10 +428,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']
    TYPO3_CONF_VARS SYS; systemLocale
 .. _typo3ConfVars_sys_systemLocale:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']
-==================================================
+systemLocale
+============
 
-.. confval:: systemLocale
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -431,10 +446,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']
    TYPO3_CONF_VARS SYS; reverseProxyIP
 .. _typo3ConfVars_sys_reverseProxyIP:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']
-====================================================
+reverseProxyIP
+==============
 
-.. confval:: reverseProxyIP
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: list
@@ -447,10 +462,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyIP']
    TYPO3_CONF_VARS SYS; reverseProxyHeaderMultiValue
 .. _typo3ConfVars_sys_reverseProxyHeaderMultiValue:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue']
-==================================================================
+reverseProxyHeaderMultiValue
+============================
 
-.. confval:: reverseProxyHeaderMultiValue
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -473,10 +488,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue']
    TYPO3_CONF_VARS SYS; reverseProxyPrefix
 .. _typo3ConfVars_sys_reverseProxyPrefix:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix']
-=========================================================
+reverseProxyPrefix
+==================
 
-.. confval:: reverseProxyPrefix
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -492,10 +507,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix']
    TYPO3_CONF_VARS SYS; reverseProxySSL
 .. _typo3ConfVars_sys_reverseProxySSL:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxySSL']
-=====================================================
+reverseProxySSL
+===============
 
-.. confval:: reverseProxySSL
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxySSL']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -510,10 +525,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxySSL']
    TYPO3_CONF_VARS SYS; reverseProxyPrefixSSL
 .. _typo3ConfVars_sys_reverseProxyPrefixSSL:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL']
-============================================================
+reverseProxyPrefixSSL
+=====================
 
-.. confval:: reverseProxyPrefixSSL
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
@@ -527,10 +542,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL']
    TYPO3_CONF_VARS SYS;
 .. _typo3ConfVars_sys_displayErrors:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']
-===================================================
+displayErrors
+=============
 
-.. confval:: displayErrors
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: int
@@ -569,10 +584,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']
    TYPO3_CONF_VARS SYS; productionExceptionHandler
 .. _typo3ConfVars_sys_productionExceptionHandler:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler']
-================================================================
+productionExceptionHandler
+==========================
 
-.. confval:: productionExceptionHandler
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: phpClass
@@ -592,10 +607,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler']
    TYPO3_CONF_VARS SYS; debugExceptionHandler
 .. _typo3ConfVars_sys_debugExceptionHandler:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler']
-===========================================================
+debugExceptionHandler
+=====================
 
-.. confval:: debugExceptionHandler
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: phpClass
@@ -615,10 +630,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['debugExceptionHandler']
    TYPO3_CONF_VARS SYS; errorHandler
 .. _typo3ConfVars_sys_errorHandler:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler']
-==================================================
+errorHandler
+============
 
-.. confval:: errorHandler
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: phpClass
@@ -638,10 +653,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler']
    TYPO3_CONF_VARS SYS; errorHandlerErrors
 .. _typo3ConfVars_sys_errorHandlerErrors:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors']
-========================================================
+errorHandlerErrors
+==================
 
-.. confval:: errorHandlerErrors
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: errors
@@ -660,10 +675,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors']
    TYPO3_CONF_VARS SYS; exceptionalErrors
 .. _typo3ConfVars_sys_exceptionalErrors:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors']
-=======================================================
+exceptionalErrors
+=================
 
-.. confval:: exceptionalErrors
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: errors
@@ -680,10 +695,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors']
    TYPO3_CONF_VARS SYS; belogErrorReporting
 .. _typo3ConfVars_sys_belogErrorReporting:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['belogErrorReporting']
-=========================================================
+belogErrorReporting
+===================
 
-.. confval:: belogErrorReporting
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['belogErrorReporting']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: errors
@@ -699,10 +714,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['belogErrorReporting']
    TYPO3_CONF_VARS SYS; generateApacheHtaccess
 .. _typo3ConfVars_sys_generateApacheHtaccess:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['generateApacheHtaccess']
-============================================================
+generateApacheHtaccess
+======================
 
-.. confval:: generateApacheHtaccess
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['generateApacheHtaccess']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: bool
@@ -720,10 +735,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['generateApacheHtaccess']
    TYPO3_CONF_VARS SYS; ipAnonymization
 .. _typo3ConfVars_sys_ipAnonymization:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['ipAnonymization']
-=====================================================
+ipAnonymization
+===============
 
-.. confval:: ipAnonymization
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['ipAnonymization']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: int
@@ -746,10 +761,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['ipAnonymization']
    TYPO3_CONF_VARS SYS; systemMaintainers
 .. _typo3ConfVars_sys_systemMaintainers:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']
-=======================================================
+systemMaintainers
+=================
 
-.. confval:: systemMaintainers
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: array
@@ -761,8 +776,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']
    TYPO3_CONF_VARS SYS; features
 .. _typo3ConfVars_sys_features:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
-==============================================
+features
+========
 
 New features of TYPO3 that are activated on new installations but upgrading
 installations may still use the old behaviour.
@@ -772,10 +787,10 @@ installations may still use the old behaviour.
    TYPO3_CONF_VARS SYS; features form.legacyUploadMimeTypes
 .. _typo3ConfVars_sys_features_form.legacyUploadMimeTypes:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['form.legacyUploadMimeTypes']
-----------------------------------------------------------------------------
+form.legacyUploadMimeTypes
+--------------------------
 
-.. confval:: form.legacyUploadMimeTypes:
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['form.legacyUploadMimeTypes']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
    :type: bool
@@ -789,10 +804,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['form.legacyUploadMimeTypes']
    TYPO3_CONF_VARS SYS; features redirects.hitCount
 .. _typo3ConfVars_sys_features_redirects.hitCount:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['redirects.hitCount']
---------------------------------------------------------------------
+redirects.hitCount
+------------------
 
-.. confval:: redirects.hitCount
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['redirects.hitCount']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
    :type: bool
@@ -805,10 +820,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['redirects.hitCount']
    TYPO3_CONF_VARS SYS; features security.backend.enforceReferrer
 .. _typo3ConfVars_sys_features_security.backend.enforceReferrer:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.backend.enforceReferrer']
-----------------------------------------------------------------------------------
+security.backend.enforceReferrer
+--------------------------------
 
-.. confval:: security.backend.enforceReferrer
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.backend.enforceReferrer']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
    :type: bool
@@ -823,10 +838,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.backend.enforceReferrer
    TYPO3_CONF_VARS SYS; features yamlImportsFollowDeclarationOrder
 .. _typo3ConfVars_sys_features_yamlImportsFollowDeclarationOrder:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['yamlImportsFollowDeclarationOrder']
------------------------------------------------------------------------------------
+yamlImportsFollowDeclarationOrder
+---------------------------------
 
-.. confval:: yamlImportsFollowDeclarationOrder
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['yamlImportsFollowDeclarationOrder']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
    :type: bool
@@ -834,15 +849,14 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['yamlImportsFollowDeclarationOrde
 
    If on, the YAML imports are imported in the order they are defined in the importing YAML configuration.
 
-
 .. index::
    TYPO3_CONF_VARS SYS; availablePasswordHashAlgorithms
 .. _typo3ConfVars_sys_availablePasswordHashAlgorithms:
 
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['availablePasswordHashAlgorithms']
-=====================================================================
+availablePasswordHashAlgorithms
+===============================
 
-.. confval:: availablePasswordHashAlgorithms
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['availablePasswordHashAlgorithms']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
    :type: array


### PR DESCRIPTION
Use the full path in the confval, this removes the warnings about duplicate confvals and lists the
complete confvals in the index.

Beautify the menu

Leave hints on how and where to set them.

releases: main, 11.5