### PR TITLE
[BUGFIX] Correct formatting of cards in tutorials section

### DIFF
--- a/Documentation/ExtensionArchitecture/Tutorials/Index.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Index.rst
@@ -18,11 +18,11 @@ Tutorials
 
                 ..  rubric:: :ref:`Minimal extension <extension-minimal>`
 
-                ..  container:: card-body
+            ..  container:: card-body
 
-                    Learn how to create a minimal TYPO3 extension containing
-                    one PHP class. Use the sitepackage builder to create
-                    this extension quickly.
+                Learn how to create a minimal TYPO3 extension containing
+                one PHP class. Use the sitepackage builder to create
+                this extension quickly.
 
     ..  container:: col-md-6 pl-0 pr-3 py-3 m-0
 
@@ -32,16 +32,14 @@ Tutorials
 
                 ..  rubric:: :ref:`Tea in a nutshell <extbase_tutorial_tea>`
 
-                ..  container:: card-body
+            ..  container:: card-body
 
-                    `tea` is a simple, well tested extension based on
-                    Extbase.
+                `tea` is a simple, well-tested extension based on Extbase.
 
-                    This tutorial guides you through the different
-                    files, configuration formats and PHP classes needed for
-                    an Extbase extension. Automatic tests are not covered in
-                    this tutorial. Refer to the extensions manual for this
-                    topic.
+                This tutorial guides you through the different files,
+                configuration formats and PHP classes needed for an Extbase
+                extension. Automatic tests are not covered in this tutorial.
+                Refer to the extensions manual for this topic.
 
 ..  toctree::
     :titlesonly:


### PR DESCRIPTION
The indentation was wrong, so the text was formatted as heading.

Releases: main, 11.5