### PR TITLE
[BUGFIX] Change object to array notation regarding "funding" property

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -119,10 +119,12 @@ Extended composer.json
       "support": {
          "issues": "https://github.com/vendorname/my-extensions/issues"
       },
-      "funding": {
-         "type": "other",
-         "url:" : "myfundpage.org/vendorname"
-      },
+      "funding": [
+         {
+            "type": "other",
+            "url:" : "myfundpage.org/vendorname"
+         }
+      ],
       "autoload": {
          "psr-4": {
             "Vendorname\\MyExtension\\": "Classes/"


### PR DESCRIPTION
Fix error "Incompatible types. Required: array. Actual: object" according to Composer schema requirements https://getcomposer.org/doc/04-schema.md#funding