### PR TITLE
[TASK] Streamline spelling of "event"

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
@@ -29,7 +29,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
@@ -32,7 +32,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
@@ -10,10 +10,10 @@ ModifyGenericBackendMessagesEvent
    This event serves as direct replacement for the now removed hook
    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['displayWarningMessages']`.
 
-This Event allows to add or alter messages that are displayed
+This event allows to add or alter messages that are displayed
 in the "About" module (default start module of the TYPO3 Backend).
 
-Extensions such as the system extension EXT:reports use this Event to display
+Extensions such as the system extension EXT:reports use this event to display
 custom messages based on the status of the system:
 
 .. include:: /Images/ManualScreenshots/Backend/GenericBackendMessage.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
@@ -35,7 +35,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
@@ -26,7 +26,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
@@ -13,7 +13,7 @@ ModifyLinkExplanationEvent
 
 While the removed hook effectively only allowed to modify the link explanation
 of TCA `link` fields in case the resolved link type did not already match
-one of those, implemented by TYPO3 itself, does the new Event now allow to
+one of those, implemented by TYPO3 itself, does the new event now allow to
 always modify the link explanation of any type. Additionally, this also allows
 to modify the `additionalAttributes`, displayed below the actual link
 explanation field. This is especially useful for extended link handler setups.
@@ -45,7 +45,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
@@ -25,7 +25,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -20,7 +20,7 @@ content or reorder the content.
 Example
 =======
 
-Registration of the Event in your extension's :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
@@ -21,7 +21,7 @@ before execution.
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -30,7 +30,7 @@ Example
 This example is available in our
 `examples extension <https://github.com/TYPO3-Documentation/t3docs-examples>`__.
 
-Registration of the Events in the extension's :file:`Services.yaml`:
+Registration of the events in the extension's :file:`Services.yaml`:
 
 ..  code-block:: yaml
     :caption: EXT:examples/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Frontend/FilterMenuItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/FilterMenuItemsEvent.rst
@@ -8,7 +8,7 @@ FilterMenuItemsEvent
 
 .. versionadded:: 12.0
 
-This Event has a variety of properties and getters, along with
+This event has a variety of properties and getters, along with
 :php:func:`TYPO3\\CMS\\Frontend\\Event\\FilterMenuItemsEvent::getFilteredMenuItems()`
 and
 :php:func:`TYPO3\\CMS\\Frontend\\Event\\FilterMenuItemsEvent::setFilteredMenuItems()`.
@@ -16,7 +16,7 @@ Those methods can be used to change the items of a menu, which has been generate
 with :ref:`a TypoScript HMENU <t3tsref:cobj-hmenu>` or
 a :ref:`MenuProcessor <t3tsref:MenuProcessor>`.
 
-This Event is fired after TYPO3 has filtered all menu items. The menu can then
+This event is fired after TYPO3 has filtered all menu items. The menu can then
 be adjusted by adding, removing or modifying the menu items. Also changing the
 order is possible.
 
@@ -33,7 +33,7 @@ API
 History
 =======
 
-The PSR-14 Event :php:class:`TYPO3\CMS\Frontend\Event\FilterMenuItemsEvent` has been
+The PSR-14 event :php:class:`TYPO3\CMS\Frontend\Event\FilterMenuItemsEvent` has been
 introduced to serve as a more powerful and flexible alternative
 for the removed hook
 :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/tslib/class.tslib_menu.php']['filterMenuPages']`.

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
@@ -17,7 +17,7 @@ The page to be linked to can also be modified to link to a different page.
 Example
 =======
 
-Registration of the Event in your extension's :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
@@ -25,7 +25,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
@@ -38,7 +38,7 @@ content.
 Example
 =======
 
-Registration of the Event in your extension's :file:`Configuration/Services.yaml`:
+Registration of the event in your extension's :file:`Configuration/Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
@@ -37,7 +37,7 @@ API
 Example
 =======
 
-Registration of the Event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extensions' :file:`Services.yaml`:
 
 .. code-block:: yaml
    :caption: EXT:my_extension/Configuration/Services.yaml


### PR DESCRIPTION
This should be spelled lowercase at is not a proper name. Most uses in the docs spell it already in lowercase.

Releases: main, 11.5