### PR TITLE
[Backport 11.5] [TASK] Streamline events documentation (#2223)

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -19,6 +19,9 @@ contains, next to the usual "getter" and "setter" methods, the convenience
 method :php:`add` for the :php:`cacheActions` and
 :php:`cacheActionIdentifiers` arrays.
 
+Example
+=======
+
 Registration of the event in the :file:`Services.yaml`:
 
 .. code-block:: yaml
@@ -36,7 +39,7 @@ The corresponding event listener class:
 
     use TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent;
 
-    class MyEventListener {
+    final class MyEventListener {
 
         public function __invoke(ModifyClearCacheActionsEvent $event): void
         {
@@ -60,6 +63,6 @@ The cache action array element consists of the following keys and values:
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Backend/ModifyClearCacheActionsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
@@ -10,6 +10,6 @@ Allows to modify variables for the view depending
 on a special login provider set in the controller.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
@@ -10,6 +10,6 @@ SwitchUserEvent
 This event is dispatched when a "SU" (switch user) action has been triggered.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Backend/SwitchUserEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
@@ -10,6 +10,6 @@ An event to enrich the system information toolbar in the TYPO3 Backend top toolb
 with various information.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Backend/SystemInformationToolbarCollectorEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterTcaCompilationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterTcaCompilationEvent.rst
@@ -14,6 +14,6 @@ Event after `$GLOBALS['TCA']` is built to allow to further manipulate the TCA.
    before this event is fired.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AfterTcaCompilationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
@@ -10,6 +10,6 @@ Extensions can modify Page TSConfig entries that can be overridden or added, bas
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/ModifyLoadedPageTsConfigEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
@@ -18,6 +18,9 @@ Use cases for this event include running extensions'
 code which needs to be executed at any time, and needs
 TYPO3's full configuration including all loaded extensions.
 
+Example
+=======
+
 Registration of the event in the :file:`Services.yaml`:
 
 .. code-block:: yaml
@@ -29,7 +32,7 @@ Registration of the event in the :file:`Services.yaml`:
 
 .. code-block:: php
 
-    class MyEventListener {
+    final class MyEventListener {
         public function __invoke(BootCompletedEvent $e): void
         {
             // do your magic
@@ -38,6 +41,6 @@ Registration of the event in the :file:`Services.yaml`:
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/BootCompletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/DataHandling/AppendLinkHandlerElementsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/DataHandling/AppendLinkHandlerElementsEvent.rst
@@ -7,9 +7,9 @@ AppendLinkHandlerElementsEvent
 ==============================
 
 Event fired so listeners can intercept add elements when checking
-links within the SoftRef parser.
+links within the :ref:`soft reference <soft-references>` parser.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AppendLinkHandlerElementsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/DataHandling/IsTableExcludedFromReferenceIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/DataHandling/IsTableExcludedFromReferenceIndexEvent.rst
@@ -7,10 +7,10 @@ IsTableExcludedFromReferenceIndexEvent
 ======================================
 
 Event to intercept if a certain table should be excluded from the Reference Index.
-There is no need to add tables without a definition in $GLOBALS['TCA'] since
-ReferenceIndex only handles those.
+There is no need to add tables without a definition in :php:`$GLOBALS['TCA']`
+since ReferenceIndex only handles those.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/IsTableExcludedFromReferenceIndexEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Database/AlterTableDefinitionStatementsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Database/AlterTableDefinitionStatementsEvent.rst
@@ -6,9 +6,9 @@
 AlterTableDefinitionStatementsEvent
 ===================================
 
-Event to intercept the "CREATE TABLE" statement from all loaded extensions.
+Event to intercept the :sql:`CREATE TABLE` statement from all loaded extensions.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AlterTableDefinitionStatementsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Html/BrokenLinkAnalysisEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Html/BrokenLinkAnalysisEvent.rst
@@ -23,6 +23,6 @@ This functionality is implemented in the system extension "linkvalidator".
 Other extensions can use the event to override the default behaviour.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/BrokenLinkAnalysisEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerInitializationEvent.rst
@@ -9,6 +9,9 @@ AfterMailerInitializationEvent
 This event is fired once a new Mailer is instantiated with specific transport settings.
 So it is possible to add custom mailing settings.
 
+Example
+=======
+
 An example listener, which hooks into the Mailer API to modify Mailer settings to not send any emails,
 could look like this:
 
@@ -17,7 +20,7 @@ could look like this:
    namespace MyCompany\MyPackage\EventListener;
    use TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent;
 
-   class NullMailer
+   final class NullMailer
    {
        public function __invoke(AfterMailerInitializationEvent $event): void
        {
@@ -26,6 +29,6 @@ could look like this:
    }
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AfterMailerInitializationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
@@ -12,6 +12,6 @@ Event that is triggered after a package has been activated.
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AfterPackageActivationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
@@ -12,6 +12,6 @@ Event that is triggered after a package has been deactivated.
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/AfterPackageDeactivationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Package/BeforePackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/BeforePackageActivationEvent.rst
@@ -8,10 +8,10 @@ BeforePackageActivationEvent
 
 .. versionadded:: 10.3
 
-Event that is triggered before a number of packages should become active
+Event that is triggered before a number of packages should become active.
 
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/BeforePackageActivationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
@@ -8,7 +8,8 @@ PackagesMayHaveChangedEvent
 
 .. versionadded:: 10.3
 
-Marker event to ensure that Core is re-triggering the package ordering and package listings
+Marker event to ensure that Core is re-triggering the package ordering and
+package listings.
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Page/BeforeJavaScriptsRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Page/BeforeJavaScriptsRenderingEvent.rst
@@ -1,6 +1,5 @@
 .. include:: /Includes.rst.txt
-
-
+.. index:: Events; BeforeJavaScriptsRenderingEvent
 .. _BeforeJavaScriptsRenderingEvent:
 
 

--- a/Documentation/ApiOverview/Events/Events/Core/Page/BeforeStylesheetsRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Page/BeforeStylesheetsRenderingEvent.rst
@@ -1,6 +1,5 @@
 .. include:: /Includes.rst.txt
-
-
+.. index:: Events; BeforeStylesheetsRenderingEvent
 .. _BeforeStylesheetsRenderingEvent:
 
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedEvent.rst
@@ -12,6 +12,6 @@ Use case: Using listeners for this event allows to e.g. post-check permissions o
 specific analysis of files like additional metadata analysis after adding them to TYPO3.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileAddedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedToIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedToIndexEvent.rst
@@ -10,9 +10,10 @@ This event is fired once an index was just added to the database (= indexed).
 
 *Examples:*
 
-Allows to additionally populate custom fields of the sys_file/sys_file_metadata database records.
+Allows to additionally populate custom fields of the
+:sql:`sys_file`/:sql:`sys_file_metadata` database records.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileAddedToIndexEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-
+.. index:: Events; AfterFileCommandProcessedEvent
 .. _AfterFileCommandProcessedEvent:
 
 ==============================
@@ -12,6 +12,9 @@ The :php:`AfterFileCommandProcessedEvent` can be used to perform additional task
 
 The `AfterFileCommandProcessedEvent` is fired in the :php:`ExtendedFileUtility`
 class.
+
+Example
+=======
 
 Registration of the event in the :file:`Services.yaml`:
 
@@ -28,7 +31,7 @@ The corresponding event listener class:
 
     use TYPO3\CMS\Core\Resource\Event\AfterFileCommandProcessedEvent;
 
-    class MyEventListener {
+    final class MyEventListener {
 
         public function __invoke(AfterFileCommandProcessedEvent $event): void
         {
@@ -38,6 +41,6 @@ The corresponding event listener class:
     }
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileCommandProcessedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
@@ -9,9 +9,9 @@ AfterFileContentsSetEvent
 
 This event is fired after the contents of a file got set / replaced.
 
-*Examples*: Listeners can analyze content for AI purposes within Extensions.
+*Examples*: Listeners can analyze content for AI purposes within extensions.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileContentsSetEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCopiedEvent.rst
@@ -13,6 +13,6 @@ The folder represents the "target folder".
 *Example*: Listeners can sign up for listing duplicates using this event.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileCopiedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
@@ -13,6 +13,6 @@ The folder represents the "target folder".
 *Example*: This allows to modify a file or check for an appropriate signature after a file was created in TYPO3.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileCreatedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileDeletedEvent.rst
@@ -14,6 +14,6 @@ this event allows listener to also clean
 up their custom handling. This can also be used for versioning of files.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileDeletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMarkedAsMissingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMarkedAsMissingEvent.rst
@@ -13,6 +13,6 @@ This event is fired once a file was just marked as missing in the database (sys_
 where editors also work via FTP.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileMarkedAsMissingEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataCreatedEvent.rst
@@ -11,6 +11,6 @@ This event is fired once metadata of a file was added to the database,
 so it can be enriched with more information.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileMetaDataCreatedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataDeletedEvent.rst
@@ -11,6 +11,6 @@ This event is fired once all metadata of a file was removed, in order to manage 
 added previously.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileMetaDataDeletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataUpdatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataUpdatedEvent.rst
@@ -10,6 +10,6 @@ AfterFileMetaDataUpdatedEvent
 This event is fired once metadata of a file was updated, in order to update custom metadata fields accordingly.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileMetaDataUpdatedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMovedEvent.rst
@@ -13,6 +13,6 @@ The folder represents the "target folder".
 *Examples*: Use this to update custom third party handlers that rely on specific paths.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileMovedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileProcessingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileProcessingEvent.rst
@@ -10,6 +10,6 @@ This event is fired after a file object has been processed.
 This allows to further customize a file object's processed file.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileProcessingEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRemovedFromIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRemovedFromIndexEvent.rst
@@ -7,10 +7,10 @@
 AfterFileRemovedFromIndexEvent
 ==============================
 
-This event is fired once a file was just removed in the database (sys_file).
+This event is fired once a file was just removed in the database (:sql:`sys_file`).
 *Example* can be to further handle files and manage them separately outside of TYPO3's index.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileRemovedFromIndexEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRenamedEvent.rst
@@ -11,6 +11,6 @@ This event is fired after a file was renamed in order to further process a file 
 or update custom references to a file.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileRenamedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileReplacedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileReplacedEvent.rst
@@ -13,6 +13,6 @@ This event is fired after a file was replaced.
 contents of a file for AI analysis etc.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileReplacedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileUpdatedInIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileUpdatedInIndexEvent.rst
@@ -11,6 +11,6 @@ This event is fired once an index was just updated inside the database (= indexe
 Custom listeners can update further index values when a file was updated.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFileUpdatedInIndexEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderAddedEvent.rst
@@ -11,6 +11,6 @@ This event is fired after a folder was added to the Resource Storage / Driver.
 This allows to customize permissions or set up editor permissions automatically via listeners.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFolderAddedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderCopiedEvent.rst
@@ -8,9 +8,10 @@ AfterFolderCopiedEvent
 ======================
 
 This event is fired after a folder was copied to the Resource Storage / Driver.
+
 *Example*: Custom listeners can analyze contents of a file or add custom permissions to a folder automatically.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFolderCopiedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderDeletedEvent.rst
@@ -12,6 +12,6 @@ Custom listeners can then further clean up permissions or
 third-party processed files with this event.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFolderDeletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderMovedEvent.rst
@@ -11,6 +11,6 @@ This event is fired after a folder was moved within the Resource Storage / Drive
 Custom references can be updated via listeners of this event.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFolderMovedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderRenamedEvent.rst
@@ -8,12 +8,13 @@ AfterFolderRenamedEvent
 =======================
 
 This event is fired after a folder was renamed.
+
 *Examples*: Add custom processing of folders or adjust permissions.
 
 This event is also used by TYPO3 itself to synchronize folder relations in
 records (for example in :sql:`sys_filemounts`) after renaming of folders.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterFolderRenamedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterResourceStorageInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterResourceStorageInitializationEvent.rst
@@ -11,6 +11,6 @@ This event is fired after a resource object was built/created.
 Custom handlers can be initialized at this moment for any kind of resource as well.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/AfterResourceStorageInitializationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a file is about to be added to the Resource Storage /
 This allows to do custom checks to a file or restrict access to a file before the file is added.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileAddedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileContentsSetEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileContentsSetEvent.rst
@@ -11,6 +11,6 @@ This event is fired before the contents of a file gets set / replaced.
 This allows to further analyze or modify the content of a file before it is written by the driver.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileContentsSetEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCopiedEvent.rst
@@ -13,6 +13,6 @@ The folder represents the "target folder".
 This allows to further analyze or modify the file or metadata before it is written by the driver.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileCopiedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCreatedEvent.rst
@@ -13,6 +13,6 @@ The folder represents the "target folder".
 This allows to further analyze or modify the file or filename before it is written by the driver.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileCreatedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileDeletedEvent.rst
@@ -12,6 +12,6 @@ This event is fired before a file is about to be deleted.
 Event listeners can clean up third-party references with this event.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileDeletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileMovedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a file is about to be moved within a Resource Storage
 The folder represents the "target folder".
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileMovedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileProcessingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileProcessingEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a file object is processed.
 Allows to add further information or enrich the file before the processing is kicking in.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileProcessingEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileRenamedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a file is about to be renamed. Custom listeners can f
 according to specific guidelines based on the project.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileRenamedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileReplacedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileReplacedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a file is about to be replaced.
 Custom listeners can check for file integrity or analyze the content of the file before it gets added.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFileReplacedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderAddedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a folder is about to be added to the Resource Storage
 This allows to further specify folder names according to regulations for a specific project.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFolderAddedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderCopiedEvent.rst
@@ -11,6 +11,6 @@ This event is fired before a folder is about to be copied to the Resource Storag
 Listeners could add deferred processing / queuing of large folders.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFolderCopiedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderDeletedEvent.rst
@@ -13,6 +13,6 @@ Listeners can use this event to clean up further external references
 to a folder / files in this folder.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFolderDeletedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderMovedEvent.rst
@@ -12,6 +12,6 @@ Listeners can be used to modify a folder name before it is actually moved or to 
 or specific rules when moving folders.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFolderMovedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderRenamedEvent.rst
@@ -12,6 +12,6 @@ Listeners can be used to modify a folder name before it is actually moved or to 
 or specific rules when renaming folders.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeFolderRenamedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeResourceStorageInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeResourceStorageInitializationEvent.rst
@@ -8,10 +8,11 @@ BeforeResourceStorageInitializationEvent
 ========================================
 
 This event is fired before a resource object is actually built/created.
+
 *Example*: A database record can be enriched to add dynamic values to each resource (file/folder) before
 creation of a storage.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/BeforeResourceStorageInitializationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/EnrichFileMetaDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/EnrichFileMetaDataEvent.rst
@@ -12,6 +12,6 @@ Allows other places to do extension of metadata at runtime or
 for example translation and workspace overlay.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/EnrichFileMetaDataEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/GeneratePublicUrlForResourceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/GeneratePublicUrlForResourceEvent.rst
@@ -13,6 +13,6 @@ This allows for listeners to create custom links to certain files (e.g. restrict
 authorized deeplinks.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/GeneratePublicUrlForResourceEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
@@ -20,14 +20,17 @@ stop the propagation.
 With the event, it's not only possible to reject the file dump request,
 but also to replace the file, which should be dumped.
 
+Example
+=======
+
 Registration of the event in the :file:`Services.yaml`:
 
 .. code-block:: yaml
 
-  MyVendor\MyPackage\Resource\MyEventListener:
-    tags:
-      - name: event.listener
-        identifier: 'my-package/resource/my-event-listener'
+   MyVendor\MyPackage\Resource\MyEventListener:
+     tags:
+       - name: event.listener
+         identifier: 'my-package/resource/my-event-listener'
 
 The corresponding event listener class:
 
@@ -35,7 +38,7 @@ The corresponding event listener class:
 
     use TYPO3\CMS\Core\Resource\Event\ModifyFileDumpEvent;
 
-    class MyEventListener {
+    final class MyEventListener {
 
         public function __invoke(ModifyFileDumpEvent $event): void
         {
@@ -45,6 +48,6 @@ The corresponding event listener class:
     }
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/ModifyFileDumpEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyIconForResourcePropertiesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyIconForResourcePropertiesEvent.rst
@@ -11,6 +11,6 @@ This is an event every time an icon for a resource (file or folder) is fetched, 
 to modify the icon or overlay in an event listener.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/ModifyIconForResourcePropertiesEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/SanitizeFileNameEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/SanitizeFileNameEvent.rst
@@ -11,6 +11,6 @@ This event is fired once an index was just added to the database (= indexed), so
 to modify the file name, and name the files according to naming conventions of a specific project.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/SanitizeFileNameEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Tree/ModifyTreeDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Tree/ModifyTreeDataEvent.rst
@@ -10,6 +10,6 @@ ModifyTreeDataEvent
 Allows to modify tree data for any database tree.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/Core/Resource/ModifyTreeDataEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -32,7 +32,7 @@ The corresponding event listener class:
 
     use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
 
-    class MyEventListener {
+    final class MyEventListener {
 
         public function __invoke(ProcessFileListActionsEvent $event): void
         {

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
@@ -44,7 +44,7 @@ executed after or before the given identifiers.
 
    use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
 
-   class OwnHrefLang
+   final class OwnHrefLang
    {
       public function __invoke(ModifyHrefLangTagsEvent $event): void
       {

--- a/Documentation/ApiOverview/Events/Events/Recordlist/ModifyRecordListTableActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Recordlist/ModifyRecordListTableActionsEvent.rst
@@ -47,7 +47,7 @@ The corresponding event listener class:
     use TYPO3\CMS\Recordlist\Event\ModifyRecordListRecordActionsEvent;
     use TYPO3\CMS\Recordlist\Event\ModifyRecordListTableActionsEvent;
 
-    class MyEventListener {
+    final class MyEventListener {
 
         protected LoggerInterface $logger;
 

--- a/Documentation/ApiOverview/Events/Events/Setup/AddJavaScriptModulesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Setup/AddJavaScriptModulesEvent.rst
@@ -39,7 +39,7 @@ A listener using mentioned PSR-14 event could look like the following.
 
          use TYPO3\CMS\SetupEvent\AddJavaScriptModulesEvent;
 
-         class CustomUserSettingsListener
+         final class CustomUserSettingsListener
          {
              // name of JavaScript module to be loaded
              private const MODULE_NAME = 'TYPO3/CMS/MyExtension/CustomUserSettingsModule';


### PR DESCRIPTION
- Place example before API (as most event pages already have)
- Mark event listeners as final (as most examples already have) . Correct heading types
- Add some missing indexes

Releases: main, 11.5