### PR TITLE
[TASK] #98399 - Enable natural ordering of YAML imports

### DIFF
--- a/Documentation/ApiOverview/Routing/Introduction.rst
+++ b/Documentation/ApiOverview/Routing/Introduction.rst
@@ -87,17 +87,28 @@ To ensure Routing in TYPO3 is fully functional the following prerequisites need 
 Tips
 ====
 
-Using imports in yaml files
+Using imports in YAML files
 ---------------------------
 
-As routing configuration (and site configuration in general) can get pretty long fast, you should make use of imports
-in your yaml configuration which allows you to add routing configurations from different files and different extensions.
+As routing configuration (and site configuration in general) can get pretty long
+fast, you should make use of imports in your YAML configuration which allows you
+to add routing configurations from different files and different extensions.
 
-Example - Main :file:`config.yaml`
+Example:
 
-.. code-block:: yaml
+..  code-block:: yaml
+    :caption: config/sites/<site-identifier>/config.yaml
 
-   imports:
-      - { resource: "EXT:myblog/Configuration/Routes/Default.yaml" }
-      - { resource: "EXT:mynews/Configuration/Routes/Default.yaml" }
-      - { resource: "EXT:template/Configuration/Routes/Default.yaml" }
+    imports:
+        - { resource: "EXT:myblog/Configuration/Routes/Default.yaml" }
+        - { resource: "EXT:mynews/Configuration/Routes/Default.yaml" }
+        - { resource: "EXT:template/Configuration/Routes/Default.yaml" }
+
+..  versionchanged:: 12.0
+    In TYPO3 v10.4.14 the feature flag :php:`yamlImportsFollowDeclarationOrder`
+    was introduced to enable natural order of YAML imports. For existing
+    installations it was set to :php:`false` (resources are imported in reverse
+    order), for new installations to :php:`true` (resources are imported in
+    declared order). In TYPO3 v12.0 the feature flag was removed and the
+    resources are now imported in the exact same order as they are configured in
+    the importing file.

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -835,21 +835,6 @@ security.backend.enforceReferrer
 
 
 .. index::
-   TYPO3_CONF_VARS SYS; features yamlImportsFollowDeclarationOrder
-.. _typo3ConfVars_sys_features_yamlImportsFollowDeclarationOrder:
-
-yamlImportsFollowDeclarationOrder
----------------------------------
-
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['yamlImportsFollowDeclarationOrder']
-
-   :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
-   :type: bool
-   :Default: false
-
-   If on, the YAML imports are imported in the order they are defined in the importing YAML configuration.
-
-.. index::
    TYPO3_CONF_VARS SYS; availablePasswordHashAlgorithms
 .. _typo3ConfVars_sys_availablePasswordHashAlgorithms:
 

--- a/Documentation/Configuration/Yaml/YamlApi.rst
+++ b/Documentation/Configuration/Yaml/YamlApi.rst
@@ -53,14 +53,23 @@ to make use of the loader in your extensions:
 
 Configuration files can make use of import functionality to reference to the contents of different files.
 
-Examples:
+Example:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   imports:
-     - { resource: "EXT:rte_ckeditor/Configuration/RTE/Processing.yaml" }
-     - { resource: "misc/my_options.yaml" }
-     - { resource: "../path/to/something/within/the/project-folder/generic.yaml" }
+    imports:
+        - { resource: "EXT:rte_ckeditor/Configuration/RTE/Processing.yaml" }
+        - { resource: "misc/my_options.yaml" }
+        - { resource: "../path/to/something/within/the/project-folder/generic.yaml" }
+
+..  versionchanged:: 12.0
+    In TYPO3 v10.4.14 the feature flag :php:`yamlImportsFollowDeclarationOrder`
+    was introduced to enable natural order of YAML imports. For existing
+    installations it was set to :php:`false` (resources are imported in reverse
+    order), for new installations to :php:`true` (resources are imported in
+    declared order). In TYPO3 v12.0 the feature flag was removed and the
+    resources are now imported in the exact same order as they are configured in
+    the importing file.
 
 
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/184
Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.4.x/Important-92100-YAMLImportsFollowDeclarationOrder.html