### PR TITLE
[TASK] Revise chapter "XLIFF format"

### DIFF
--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -23,7 +23,7 @@ The default language is always English, even if you have changed your TYPO3 back
 to another language. It is mandatory to set  :xml:`source-language="en"`.
 
 Keep in mind that the default language is always English, even when you have
-changed your TYPO3 Backend to another language, so the source language must
+changed your TYPO3 backend to another language, so the source language must
 always be :xml:`source-language="en"`.
 
 ..  note::

--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -19,8 +19,8 @@ Localizable data is stored in :xml:`<trans-unit>` elements. :xml:`<trans-unit>`
 contains a :xml:`<source>` element to store the source text and a
 (non-mandatory) :xml:`<target>` element to store the translated text.
 
-The default language is always English, even if you have changed your TYPO3 backend 
-to another language. It is mandatory to set  :xml:`source-language="en"`.
+The default language is always English, even if you have changed your TYPO3
+backend to another language. It is mandatory to set :xml:`source-language="en"`.
 
 Keep in mind that the default language is always English, even when you have
 changed your TYPO3 backend to another language, so the source language must
@@ -57,16 +57,15 @@ Here is a sample XLIFF file:
         </file>
     </xliff>
 
-..  tip::
-    The following attributes should be populated properly in order to get the
-    best support in external translation tools:
+The following attributes should be populated properly in order to get the
+best support in external translation tools:
 
-    :xml:`original` (in :xml:`<file>` tag)
-        This property contains the path to the xlf file.
+:xml:`original` (in :xml:`<file>` tag)
+    This property contains the path to the xlf file.
 
-    :xml:`resname` (in :xml:`<trans-unit>` tag)
-        Its content is shown to translators. It should be a copy of the
-        :xml:`id` property.
+:xml:`resname` (in :xml:`<trans-unit>` tag)
+    Its content is shown to translators. It should be a copy of the
+    :xml:`id` property.
 
 
 ..  _xliff-translated-file-name:
@@ -125,10 +124,10 @@ File locations and naming
 In the TYPO3 Core, XLIFF files are located in the various system extensions
 as needed and are expected to be located in :file:`Resources/Private/Language`.
 
-In :ref:`Extbase <extbase>`, the main file (:file:`locallang.xlf`) will be
-loaded automatically and is available in the controller and Fluid views without
-further work needed. Other files will need to be referred to explicitly using
-the :code:`LLL:EXT:extkey/path/to/file:my.label` syntax.
+In :ref:`Extbase <extbase>`, the main file (:file:`locallang.xlf`) is loaded
+automatically and is available in the controller and Fluid views without any
+further work. Other files must be explicitly referenced with the syntax
+:code:`LLL:EXT:extkey/Resources/Private/Language/myfile.xlf:my.label`.
 
 As :ref:`mentioned above <xliff-translated-file-name>`, the translation files
 follow the same naming conventions, but are prepended with the language code and
@@ -141,8 +140,8 @@ a dot. They are stored alongside the default language files.
 ID naming
 =========
 
-There is no strict rule or guideline for defining identifiers (the :xml:`id`
-attribute). Nevertheless, it is best practice to follow these rules:
+It is recommended to apply the following rules for defining identifiers (the
+:xml:`id` attribute).
 
 Separate by dots
 ----------------

--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -1,104 +1,122 @@
-.. include:: /Includes.rst.txt
-.. index:: ! XLIFF
-.. _xliff:
+..  include:: /Includes.rst.txt
+..  index:: ! XLIFF
+..  _xliff:
 
 ============
 XLIFF Format
 ============
 
-The `XML Localisation Interchange File Format <https://en.wikipedia.org/wiki/XLIFF>`_
+The `XML Localization Interchange File Format <https://en.wikipedia.org/wiki/XLIFF>`_
 (or XLIFF) is an `OASIS-blessed <https://www.oasis-open.org/committees/xliff>`_
 standard format for translations.
 
-In a nutshell an XLIFF document contains one or more :code:`<file>` elements. Each file
-element usually corresponds to a source (file or database table) and contains the source
-of the localizable data. Once translated, the corresponding localized data for one, and
-only one, locale is added.
+In a nutshell, an XLIFF document contains one or more :xml:`<file>` elements.
+Each file element usually corresponds to a source (file or database table) and
+contains the source of the localizable data. Once translated, the corresponding
+localized data is added for one, and only one, locale.
 
-Localizable data are stored in :code:`<trans-unit>` elements. The :code:`<trans-unit>` contains
-a :code:`<source>` element to store the source text and a (non-mandatory) :code:`<target>`
-element to store the translated text.
+Localizable data is stored in :xml:`<trans-unit>` elements. :xml:`<trans-unit>`
+contains a :xml:`<source>` element to store the source text and a
+(non-mandatory) :xml:`<target>` element to store the translated text.
 
-Note that having several :code:`<file>` elements in the same XLIFF document is not
-supported by the TYPO3 CMS Core.
+Remember that the default language is always English, even if you have changed your Typo3 backend to another language, so source-language="en" must be.
 
-Keep in mind that the default language is always considered to be english,
-even when you have changed your typo3 backend to another language, so
-source-language must always be `source-language="en"`.
+Keep in mind that the default language is always English, even when you have
+changed your TYPO3 Backend to another language, so the source language must
+always be :xml:`source-language="en"`.
+
+..  note::
+    Having several :xml:`<file>` elements in the same XLIFF document is not
+    supported by the TYPO3 Core.
 
 
-.. index:: XLIFF; Basics
-.. _xliff-basics:
+..  index:: XLIFF; Basics
+..  _xliff-basics:
 
 Basics
 ======
 
 Here is a sample XLIFF file:
 
-.. code-block:: xml
+..  code-block:: xml
+    :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
 
-   <?xml version="1.0" encoding="UTF-8"?>
-   <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-      <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
-         <header/>
-         <body>
-            <trans-unit id="headerComment" resname="headerComment">
-               <source>The default Header Comment.</source>
-            </trans-unit>
-            <trans-unit id="generator" resname="generator">
-               <source>The "Generator" Meta Tag.</source>
-            </trans-unit>
-         </body>
-      </file>
-   </xliff>
+    <?xml version="1.0" encoding="UTF-8"?>
+    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+            <header/>
+            <body>
+                <trans-unit id="headerComment" resname="headerComment">
+                    <source>The default Header Comment.</source>
+                </trans-unit>
+                <trans-unit id="generator" resname="generator">
+                    <source>The "Generator" Meta Tag.</source>
+                </trans-unit>
+            </body>
+        </file>
+    </xliff>
 
-.. note::
+..  tip::
+    The following attributes should be populated properly in order to get the
+    best support in external translation tools:
 
-   The following properties should be filled properly to get best support in external translation tools:
+    :xml:`original` (in :xml:`<file>` tag)
+        This property contains the path to the xlf file.
 
-   `original`
-      This property contains the path to the xlf file.
+    :xml:`resname` (in :xml:`<trans-unit>` tag)
+        Its content is shown to translators. It should be a copy of the
+        :xml:`id` property.
 
-   `resname`
-      Its content is shown to translators. It should be a copy of the property `id`.
 
+..  _xliff-translated-file-name:
 
 The translated file is very similar. If the original file was named
-:file:`locallang.xlf`, the translated file for German (code "de") will
-be named :file:`de.locallang.xlf`. Note that the original file must always be in english,
-so it is not allowed to create a file with the prefix "en" e.g. :file:`en.locallang.xlf`.
-Inside the file itself, a :code:`<target-language>` attribute is added in the :code:`<file>` tag to
-indicate the translation language ("de" in our example). Then for each
-:code:`<source>` tag there's a sibling :code:`<target>` tag containing the
-translated string.
+:file:`locallang.xlf`, the translated file for German (code "de") will be named
+:file:`de.locallang.xlf`.
 
-Here is what the translation of our sample file could look like:
+..  note::
+    The original file must always be in English, so it is not allowed to create
+    a file with the prefix "en", for example :file:`en.locallang.xlf`.
 
-.. code-block:: xml
+In the file itself, a :xml:`target-language` attribute is added to the
+:xml:`<file>` tag to indicate the translation language ("de" in our example).
+Then, for each :xml:`<source>` tag there is a sibling :xml:`<target>` tag
+that contains the translated string.
 
-   <?xml version="1.0" encoding="UTF-8"?>
-   <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-      <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<ffile-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
-         <header/>
-         <body>
-            <trans-unit id="headerComment" resname="headerComment">
-               <source>The default Header Comment.</source>
-               <target>Der Standard-Header-Kommentar.</target>
-            </trans-unit>
-            <trans-unit id="generator" resname="generator">
-               <source>The "Generator" Meta Tag.</source>
-               <target>Der "Generator"-Meta-Tag.</target>
-            </trans-unit>
-         </body>
-      </file>
-   </xliff>
+This is how the translation of our sample file might look like:
 
-Only one language can be stored per file and each translation in a different language
-goes to an additional file.
+..  code-block:: xml
+    :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
 
+    <?xml version="1.0" encoding="UTF-8"?>
+    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+        <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+            <header/>
+            <body>
+                <trans-unit id="headerComment" resname="headerComment" approved="yes">
+                    <source>The default Header Comment.</source>
+                    <target>Der Standard-Header-Kommentar.</target>
+                </trans-unit>
+                <trans-unit id="generator" resname="generator" approved="yes">
+                    <source>The "Generator" Meta Tag.</source>
+                    <target>Der "Generator"-Meta-Tag.</target>
+                </trans-unit>
+            </body>
+        </file>
+    </xliff>
 
-.. index:: ! Path; EXT:{extkey}/Resources/Private/Language
-.. _xliff-files:
+Only one language can be stored per file, and each translation into another
+language is placed in an additional file.
+
+..  note::
+    The optional :xml:`approved` attribute in a :xml:`<trans-unit>` tag
+    indicates whether the translation has been approved by a reviewer.
+    :ref:`Crowdin <crowdin-extension-integration>` supports this attribute.
+    Currently, only approved translations are exported and available via the
+    TYPO3 :ref:`translation server <xliff-translating-servers>`.
+
+..  index:: ! Path; EXT:{extkey}/Resources/Private/Language
+..  _xliff-files:
 
 File locations and naming
 =========================
@@ -106,13 +124,14 @@ File locations and naming
 In the TYPO3 Core, XLIFF files are located in the various system extensions
 as needed and are expected to be located in :file:`Resources/Private/Language`.
 
-In Extbase, the main file (:file:`locallang.xlf`) will be loaded automatically and
-available in the controller and Fluid views without further work needed. Other files will
-need to be referred to explicitly using the :code:`EXT:LLL:extkey/path/to/file:my.label` syntax.
+In :ref:`Extbase <extbase>`, the main file (:file:`locallang.xlf`) will be
+loaded automatically and is available in the controller and Fluid views without
+further work needed. Other files will need to be referred to explicitly using
+the :code:`LLL:EXT:extkey/path/to/file:my.label` syntax.
 
-As mentioned above, the translation files follow the same naming conventions, but
-are prepended with the language code and a dot. They are stored alongside the default
-language files.
+As :ref:`mentioned above <xliff-translated-file-name>`, the translation files
+follow the same naming conventions, but are prepended with the language code and
+a dot. They are stored alongside the default language files.
 
 
 .. index:: XLIFF; ID naming
@@ -121,30 +140,29 @@ language files.
 ID naming
 =========
 
-There is no strict rule or guideline in place for defining identifiers
-(the ``id`` attribute).
-Still it is best practice to follow these rules:
+There is no strict rule or guideline for defining identifiers (the :xml:`id`
+attribute). Nevertheless, it is best practice to follow these rules:
 
-Separate by Dots
+Separate by dots
 ----------------
 
 Use dots to separate logical parts of the identifier.
 
 Good example:
 
-.. code-block:: none
+..  code-block:: none
 
-   CType.menuAbstract
+    CType.menuAbstract
 
 Bad examples:
 
-.. code-block:: none
+..  code-block:: none
 
     CTypeMenuAbstract
     CType-menuAbstract
 
 
-.. index:: XLIFF; Namespace
+..  index:: XLIFF; Namespace
 
 Namespace
 ---------
@@ -153,16 +171,16 @@ Group identifiers together with a useful namespace.
 
 Good example:
 
-.. code-block:: none
+..  code-block:: none
 
-   CType.menuAbstract
+    CType.menuAbstract
 
 This groups all available content types for content elements by using
 the same prefix ``CType.``.
 
 Bad example:
 
-.. code-block:: none
+..  code-block:: none
 
     menuAbstract
 
@@ -177,13 +195,12 @@ Generally, lowerCamelCase should be used:
 
 Good example:
 
-.. code-block:: none
+..  code-block:: none
 
-   frontendUsers.firstName
+    frontendUsers.firstName
 
-Exceptions:
-
-* For some specific cases where the referenced identifier is in a format
-  other than lowerCamelCase, that format can be used:
-  For example, database table or column names often are written in snake_case,
-  and the XLIFF key then might be something like ``fe_users.first_name``.
+..  note::
+    For some specific cases where the referenced identifier is in a format
+    other than lowerCamelCase, that format can be used:
+    For example, database table or column names often are written in snake_case,
+    and the XLIFF key then might be something like ``fe_users.first_name``.

--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -19,7 +19,8 @@ Localizable data is stored in :xml:`<trans-unit>` elements. :xml:`<trans-unit>`
 contains a :xml:`<source>` element to store the source text and a
 (non-mandatory) :xml:`<target>` element to store the translated text.
 
-Remember that the default language is always English, even if you have changed your Typo3 backend to another language, so source-language="en" must be.
+The default language is always English, even if you have changed your TYPO3 backend 
+to another language. It is mandatory to set  :xml:`source-language="en"`.
 
 Keep in mind that the default language is always English, even when you have
 changed your TYPO3 Backend to another language, so the source language must

--- a/Documentation/ApiOverview/Internationalization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Internationalization/XliffFormat.rst
@@ -22,10 +22,6 @@ contains a :xml:`<source>` element to store the source text and a
 The default language is always English, even if you have changed your TYPO3
 backend to another language. It is mandatory to set :xml:`source-language="en"`.
 
-Keep in mind that the default language is always English, even when you have
-changed your TYPO3 backend to another language, so the source language must
-always be :xml:`source-language="en"`.
-
 ..  note::
     Having several :xml:`<file>` elements in the same XLIFF document is not
     supported by the TYPO3 Core.


### PR DESCRIPTION
This is a preparation for the new TYPO3 v12.0 feature "Respect attribute approved in XLF files".

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/211
Releases: main, 11.5