### PR TITLE
[BREAKING] Register extbase type converters as services

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/Index.rst
@@ -16,3 +16,4 @@ Controller
     ActionController
     ErrorAction
     PropertyMapping
+    TypeConverter

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -28,7 +28,7 @@ Custom type converters
 ======================
 
 ..  versionchanged:: 12.0
-    Starting with TYPO3 12.0 a type converter does not have to be registered
+    Starting with TYPO3 v12.0 a type converter does not have to be registered
     via the now deprecated method :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter()`.
     Remove calls to this method when dropping TYPO3 v11 support. It will be
     removed with TYPO3 13. Register a type converter in your extension's

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -1,0 +1,57 @@
+.. include:: /Includes.rst.txt
+.. index::
+   Extbase; Type converters
+.. _extbase_Type_converters:
+
+===============
+Type converters
+===============
+
+Type converters are commonly used when it is necessary to convert from one type
+into another. They are usually applied in the controller in the method
+:php:`initialize<actionName>Action()` method.
+
+For example a date might be given as string in some language,
+:php:`"Freitag, 7. Oktober 2022"` or as UNIX time stamp: :php:`1665159559`.
+Your action method, however, expects a :php:`\Date` object. Extbase tries to
+match the data coming from the frontend automatically.
+
+When matching the data formats is expected to fail you can use one of type
+converters provided by Extbase or implement a type converter yourself
+by extending :php:`TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter`.
+
+You can find the type converters provided by Extbase in the directory
+`EXT:extbase/Classes/Property/TypeConverter
+<https://github.com/TYPO3/typo3/tree/main/typo3/sysext/extbase/Classes/Property/TypeConverter>`__.
+
+Custom type converters
+======================
+
+..  versionchanged:: 12.0
+    Starting with TYPO3 12.0 a type converter does not have to be registered
+    via the now deprecated method :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter()`.
+    Remove calls to this method when dropping TYPO3 v11 support. It will be
+    removed with TYPO3 13. Register a type converter in your extension's
+    :file:`Services.yaml` instead.
+
+A custom type converter must extend the abstract class
+:php:`TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter` and
+implement the method :php:`convertFrom()`, which is defined in the interface
+:php:`TYPO3\CMS\Extbase\Property\TypeConverterInterface`.
+
+All type converters **should** have **no internal state**, such that they
+can be used as singletons and multiple times in succession.
+
+The registration and configuration of a type converter is done in the extension's
+file:`Services.yaml`:
+
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Sevices.yaml
+
+    services:
+      MyVendor\MyExtension\Property\TypeConverter\MyBooleanConverter:
+        tag:
+          - name: extbase.type_converter
+            priority: 10
+            target: boolean
+            sources: boolean,string

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -12,13 +12,14 @@ into another. They are usually applied in the Extbase controller in the
 :php:`initialize<actionName>Action()` method.
 
 For example a date might be given as string in some language,
-:php:`"Freitag, 7. Oktober 2022"` or as UNIX time stamp: :php:`1665159559`.
+:php:`"October 7th, 2022"` or as UNIX time stamp: :php:`1665159559`.
 Your action method, however, expects a :php:`\DateTime` object. Extbase tries to
 match the data coming from the frontend automatically.
 
 When matching the data formats is expected to fail you can use one of the type
 converters provided by Extbase or implement a type converter yourself
-by extending :php:`TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter`.
+by implementing the interface
+:php:`\TYPO3\CMS\Extbase\Property\TypeConverterInterface`.
 
 You can find the type converters provided by Extbase in the directory
 `EXT:extbase/Classes/Property/TypeConverter
@@ -30,14 +31,15 @@ Custom type converters
 ..  versionchanged:: 12.0
     Starting with TYPO3 v12.0 a type converter does not have to be registered
     via the now deprecated method :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter()`.
-    Remove calls to this method when dropping TYPO3 v11 support. It will be
+    Remove calls to this method when dropping TYPO3 v11 support. This method will be
     removed with TYPO3 v13.0. Register a type converter in your extension's
     :file:`Services.yaml` instead.
 
-A custom type converter must extend the abstract class
-:php:`TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter` and
-implement the method :php:`convertFrom()`, which is defined in the interface
-:php:`TYPO3\CMS\Extbase\Property\TypeConverterInterface`.
+A custom type converter must implement the interface
+:php:`\TYPO3\CMS\Extbase\Property\TypeConverterInterface`. In most use cases
+it will extend the abstract class
+:php:`\TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter`, which
+already implements this interface.
 
 All type converters **should** have **no internal state**, such that they
 can be used as singletons and multiple times in succession.
@@ -49,9 +51,9 @@ file:`Services.yaml`:
     :caption: EXT:my_extension/Configuration/Sevices.yaml
 
     services:
-      MyVendor\MyExtension\Property\TypeConverter\MyBooleanConverter:
+      MyVendor\MyExtension\Property\TypeConverter\MyCustomDateTimeConverter:
         tag:
           - name: extbase.type_converter
             priority: 10
-            target: boolean
-            sources: boolean,string
+            target: \DateTime
+            sources: int,string

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -31,7 +31,7 @@ Custom type converters
     Starting with TYPO3 v12.0 a type converter does not have to be registered
     via the now deprecated method :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter()`.
     Remove calls to this method when dropping TYPO3 v11 support. It will be
-    removed with TYPO3 13. Register a type converter in your extension's
+    removed with TYPO3 v13.0. Register a type converter in your extension's
     :file:`Services.yaml` instead.
 
 A custom type converter must extend the abstract class

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -16,7 +16,7 @@ For example a date might be given as string in some language,
 Your action method, however, expects a :php:`\DateTime` object. Extbase tries to
 match the data coming from the frontend automatically.
 
-When matching the data formats is expected to fail you can use one of type
+When matching the data formats is expected to fail you can use one of the type
 converters provided by Extbase or implement a type converter yourself
 by extending :php:`TYPO3\CMS\Extbase\Property\TypeConverter\AbstractTypeConverter`.
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -8,7 +8,7 @@ Type converters
 ===============
 
 Type converters are commonly used when it is necessary to convert from one type
-into another. They are usually applied in the controller in the method
+into another. They are usually applied in the Extbase controller in the
 :php:`initialize<actionName>Action()` method.
 
 For example a date might be given as string in some language,

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -13,7 +13,7 @@ into another. They are usually applied in the Extbase controller in the
 
 For example a date might be given as string in some language,
 :php:`"Freitag, 7. Oktober 2022"` or as UNIX time stamp: :php:`1665159559`.
-Your action method, however, expects a :php:`\Date` object. Extbase tries to
+Your action method, however, expects a :php:`\DateTime` object. Extbase tries to
 match the data coming from the frontend automatically.
 
 When matching the data formats is expected to fail you can use one of type


### PR DESCRIPTION
I will add an elaborate example in a follow up.

Needs to be backported manually to 11.5

Releases: main

resolves https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/36