### PR TITLE
[TASK] Use "TYPO3" instead of "TYPO3 CMS"

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -27,12 +27,12 @@ of choice in your work with TYPO3.
 Intended Audience
 =================
 
-This document is intended to be a reference for TYPO3 CMS developers and partially
+This document is intended to be a reference for TYPO3 developers and partially
 for integrators. The document explains all major parts of TYPO3 and the concepts.
 Some chapters presumes knowledge in the technical end: PHP, MySQL, Unix etc, depending
 on the specific chapter.
 
-The goal is to take you "under the hood" of TYPO3 CMS. To make the
+The goal is to take you "under the hood" of TYPO3. To make the
 principles and opportunities clear and less mysterious. To educate you
 to help continue the development of TYPO3 along the already
 established lines so we will have a consistent CMS application in a

--- a/Documentation/ApiOverview/Authentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/Index.rst
@@ -6,7 +6,7 @@
 Authentication
 ==============
 
-The TYPO3 CMS Core uses :ref:`Services <services>` for the authentication process.
+The TYPO3 Core uses :ref:`Services <services>` for the authentication process.
 This family of services (of type "auth") are the only Core usage that consumes the
 Services API.
 
@@ -26,7 +26,7 @@ process of authentication, where many methods may be desirable
 such as LDAP, etc.) depending on the context.
 
 The ease with which such services can be developed is a strong
-point in favor of TYPO3 CMS, especially in corporate environments.
+point in favor of TYPO3, especially in corporate environments.
 
 Being able to toy with priority and quality allows for
 precise fine-tuning of the authentication chain.
@@ -246,21 +246,21 @@ be able to find examples to inspire and guide you. Anyway authentication
 services can be very different from one another, so it wouldn't make much
 sense to try and provide an example in this manual.
 
-One important thing to know is that the TYPO3 CMS authentication
+One important thing to know is that the TYPO3 authentication
 process *needs* to have users inside database records ("fe_users" or
 "be_users"). This means that if you interface with a third-party
-server, you will need to create records on the TYPO3 CMS side. It is
+server, you will need to create records on the TYPO3 side. It is
 up to you to choose whether this process happens on the fly (during
 authentication) or if you want to create an import process (as a
 Scheduler task, for example) that will synchronize users between
-TYPO3 CMS and the remote system.
+TYPO3 and the remote system.
 
 .. note::
 
    You probably do not want to store the actual password of imported
-   users in the TYPO3 CMS database. It is recommended to store
+   users in the TYPO3 database. It is recommended to store
    an arbitrary string in such case, making sure that such string
-   is random enough for security reasons. TYPO3 CMS provides method
+   is random enough for security reasons. TYPO3 provides method
    :php:`\TYPO3\CMS\Core\Crypto\Random::generateRandomHexString()`
    which can be used for such a purpose.
 
@@ -270,16 +270,16 @@ authority for authentication, it should not only have a high priority,
 but also return values which stop the service chain (i.e.
 a negative value for failed authentication, 200 or more for a
 successful one). On the other hand, if your service is an alternative
-authentication, but should fall back on TYPO3 CMS if unavailable,
+authentication, but should fall back on TYPO3 if unavailable,
 you will want to return 100 on failure, so that the default service
 can take over.
 
 Things can get a bit hairy if you have a scenario with mixed sources,
 for example some users come from a third-party server but others
-exist only in TYPO3 CMS. In such a case, you want to make sure that
+exist only in TYPO3. In such a case, you want to make sure that
 your service returns definite authentication failures only for those
 users which depend on the remote system and let the default
-authentication proceed for "local" TYPO3 CMS users.
+authentication proceed for "local" TYPO3 users.
 
 .. _authentication-advanced-options:
 
@@ -291,7 +291,7 @@ to modify the behaviour of the authentication process. Some
 impact the inner working of the services themselves, others
 influence when services are called.
 
-It is possible to force TYPO3 CMS to go through the
+It is possible to force TYPO3 to go through the
 authentication process for **every** request no matter any
 existing session. By setting the following local configuration
 either for the FE or the BE:
@@ -326,7 +326,7 @@ yet exist. The settings are:
 .. note::
 
    This could be used in a scenario where users go through a login portal
-   and then choose to access the TYPO3 CMS BE, for example. In such a case
+   and then choose to access the TYPO3 backend, for example. In such a case
    we would want the users to be automatically authenticated, but would not
    need to repeat the process upon each request.
 

--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-.. index:: 
+.. index::
    Autoloader; ComposerClassLoader
    ClassLoader
 .. _composer-class-loader:
@@ -8,20 +8,20 @@
 ComposerClassLoader
 ===================
 
-Integrating Composer class loader into TYPO3 CMS
-================================================
+Integrating Composer class loader into TYPO3
+============================================
 
-In our efforts to make the TYPO3 CMS system faster and closer oriented
+In our efforts to make TYPO3 faster and closer oriented
 to common PHP standard systems, we looked into the integration of the
 class loader that is used by all composer-based projects. We consider
-this functionality a crucial feature for the future of TYPO3 CMS on the
+this functionality a crucial feature for the future of TYPO3 on the
 base level, but also as a dramatic increase of the overall performance
-of every request inside TYPO3 CMS.
+of every request inside TYPO3.
 
-Understanding the TYPO3 CMS class loader
-========================================
+Understanding the TYPO3 class loader
+====================================
 
-The TYPO3 class loader is instantiated within the TYPO3 CMS Bootstrap at
+The TYPO3 class loader is instantiated within the TYPO3 Bootstrap at
 a very early point. It does a lot of logic (checking :file:`ext_autoload.php`,
 :file:`ClassAliasMap.php), and caches this logic away on a per-class basis by
 default in :file:`typo3temp/Cache/` to store all information for a class. This
@@ -46,7 +46,7 @@ hit, the caching framework does not create the cache files, but fetches
 one by one for each class used in the request via a separate
 :php:`file_get_contents()` call.
 
-When debugging the TYPO3 CMS system on an initial request, there are a
+When debugging TYPO3 on an initial request, there are a
 lot of :file:`file_get_contents()` and :file:`file_put_contents()` calls to
 store and fetch this information. This is quite a lot of overhead for loading
 PHP classes. Even without a lot of class aliases (e.g. in CMS7) this
@@ -60,18 +60,18 @@ ensured.
 Understanding the Composer class loader
 =======================================
 
-Compared to the TYPO3 CMS class loader, the composer class loader
+Compared to the TYPO3 class loader, the composer class loader
 concept differs in the following major points:
 
 Caching on build stage
 ----------------------
 
-When setting up a project, like a TYPO3 CMS project, Composer checks the
+When setting up a project, like a TYPO3 project, Composer checks the
 main composer.json of a project and builds a static file with all PSR-4
 prefixes defined in that json file. Unless in a development environment
 or when updating the source, this file does not need to be rebuilt as
 the PHP classes of the loaded packages won’t change in a regular
-instance. This way all classes available inside TYPO3 CMS are always
+instance. This way all classes available inside TYPO3 are always
 available to the class loader.
 
 Using PSR-4 compatible prefix-based resolving
@@ -83,13 +83,13 @@ Composer class loader only needs to know that all PHP classes starting
 with TYPO3\CMS\Core are located within typo3/sysext/core/Classes. The
 rest is done by a simple resolution to include the necessary PHP class
 files. This means that the information to be cached away is only the
-list of available namespace-prefixes. All classes inside the TYPO3 CMS
-Core are PSR-4 compatible since TYPO3 CMS 6.0 already.
+list of available namespace-prefixes. All classes inside the TYPO3
+Core are PSR-4 compatible since TYPO3 v6.0 already.
 
 The definition of these prefixes is set inside the composer.json of each
-package or distribution / project. In the TYPO3 CMS Core, every system
-extension defined these namespace prefixes already since TYPO3 CMS 7.1
-and TYPO3 CMS 6.2.10.
+package or distribution / project. In the TYPO3 Core, every system
+extension defined these namespace prefixes already since TYPO3 v7.1
+and TYPO3 v6.2.10.
 
 Autoloading developer-specific data differently
 -----------------------------------------------
@@ -104,11 +104,11 @@ Integration Approach
 ====================
 
 The Composer class loader is injected inside the Bootstrap process of
-TYPO3 CMS and registered before the TYPO3 class loader. This means that
+TYPO3 and registered before the TYPO3 class loader. This means that
 a lookup on a class name is first checked via the Composer logic, and if
 none found, the regular TYPO3 class loader takes over.
 
-The support for class aliases is quite important for TYPO3 CMS, but is
+The support for class aliases is quite important for TYPO3, but is
 not supported by Composer by default. There is a separate Composer
 package created by Helmut Hummel (available on `GitHub
 <https://github.com/helhum/class-alias-loader>`_) which serves as a facade

--- a/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
@@ -10,7 +10,7 @@ More about file mounts
 ======================
 
 File mounts require a little more description of the concepts provided
-by TYPO3 CMS. All files are handled by an application layer called
+by TYPO3. All files are handled by an application layer called
 the "File Abstraction Layer" (FAL). You can find more information
 about the basic concepts of :ref:`FAL <fal-concepts>`.
 
@@ -29,7 +29,7 @@ Storages
   "directories". The storage configuration depends on the driver it uses.
 
   Thanks to the storage and its driver, the user is able to browse
-  files from within the TYPO3 CMS backend as if they were stored locally.
+  files from within the TYPO3 backend as if they were stored locally.
 
 File mounts
   As discussed before, a file mount is the element which is used to

--- a/Documentation/ApiOverview/Backend/AccessControl/OtherOptions/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/OtherOptions/Index.rst
@@ -41,7 +41,7 @@ Access options
 
 Lock to domain
    This setting constrains the user to use a specific domain for logging
-   into the TYPO3 CMS backend. This is very useful in setups with multiple
+   into the TYPO3 backend. This is very useful in setups with multiple
    sites.
 
 
@@ -60,7 +60,7 @@ Lock to domain
 
 Hide in lists
   This flag will prevent the group from appearing in various
-  listings in TYPO3 CMS. This includes modules like :guilabel:`System > Access`.
+  listings in TYPO3. This includes modules like :guilabel:`System > Access`.
 
 Inherit settings from groups (Sub Groups)
   Assigns sub-groups to this group. Sub-groups are

--- a/Documentation/ApiOverview/Backend/AccessControl/Roles/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/Roles/Index.rst
@@ -10,10 +10,10 @@ concept is basically about identifying certain roles that users can
 take and then allow for a very easy application of these roles to
 users.
 
-TYPO3 CMS access control is far more flexible and allows for such detailed
+TYPO3 access control is far more flexible and allows for such detailed
 configuration that it lies very far from the simple and straight
 forward concept of roles. This is necessary as the foundation of a
-system like TYPO3 CMS should fit many possible usages.
+system like TYPO3 should fit many possible usages.
 
 However it is perfectly possible to create groups that act like "roles".
 This is what you should do:

--- a/Documentation/ApiOverview/Backend/AccessControl/UsersAndGroups/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/UsersAndGroups/Index.rst
@@ -5,7 +5,7 @@
 Users and groups
 ================
 
-TYPO3 CMS features an access control system based on users and groups.
+TYPO3 features an access control system based on users and groups.
 
 
 .. index:: pair: Backend; Users
@@ -63,7 +63,7 @@ There is a special kind of backend users called "Admin".
 When creating a backend user, just check the "Admin!" box in the
 "General" tab and that user will become an administrator.
 There's no need to set further access options for such a user:
-an admin user can access every single feature of the TYPO3 CMS
+an admin user can access every single feature of the TYPO3
 backend, like the "root" user on a UNIX system.
 
 All systems must have at least one "admin" user and most systems

--- a/Documentation/ApiOverview/Backend/ContextualMenu.rst
+++ b/Documentation/ApiOverview/Backend/ContextualMenu.rst
@@ -16,7 +16,7 @@ Context-sensitive menus
    configured in the same way.
 
 
-Contextual menus exist in many places in the TYPO3 CMS backend. Just try your
+Contextual menus exist in many places in the TYPO3 backend. Just try your
 luck clicking on any **icon** that you see. Chances are good that a contextual
 menu will appear, offering useful functions to execute.
 

--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -294,7 +294,7 @@ per release. In other words, share :file:`var/session`, :file:`var/log`,
 Caching Framework
 -----------------
 
-Since TYPO3 CMS 4.3, the Core contains a data caching framework
+Since TYPO3 v4.3, the Core contains a data caching framework
 which supports a wide variety of storage solutions and options
 for different caching needs. Each cache can be configured individually
 and can implement its own specific storage strategy.

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -11,7 +11,7 @@ An instance of class :php:`TYPO3\CMS\Core\Database\Connection` is retrieved from
 and handing over the table name a query should executed on.
 
 The class extends the basic Doctrine DBAL `Doctrine\DBAL\Connection` class and is mainly
-used internally within the TYPO3 CMS framework to establish, maintain and terminate
+used internally within the TYPO3 framework to establish, maintain and terminate
 connections to single database endpoints. Those internal methods are not scope of this
 documentation since an extension developer usually doesn't have to deal with that.
 
@@ -193,7 +193,7 @@ argument specifies the quoting of `WHERE` values. There is a pattern ;)
 
 .. note::
 
-    TYPO3 CMS uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
+    TYPO3 uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
     a field - often called `deleted` - is set from 0 to 1. Executing a `DELETE` query circumvents this and really
     removes rows from a table. For most tables, it is better to use the :ref:`DataHandler <tce-database-basics>` API
     to handle deletes instead of executing such low level queries directly.

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -9,7 +9,7 @@
 Database Structure
 ==================
 
-The database tables used by TYPO3 CMS can be divided into two
+The database tables used by TYPO3 can be divided into two
 rough categories:
 
 - Tables that are used by the system internally and are invisible to backend
@@ -17,13 +17,13 @@ rough categories:
   often dedicated PHP API's in the Core extension to manage entries of these
   tables, for instance the :ref:`Caching framework API <caching>`.
 
-- Tables that can be managed via the TYPO3 CMS backend, are shown in the List
+- Tables that can be managed via the TYPO3 backend, are shown in the List
   module and can be edited using :ref:`FormEngine <FormEngine>`.
 
 There are certain requirements for such managed tables:
 
 - The table must be configured in the :doc:`global TCA array <t3tca:Index>`.
-  This will tell TYPO3 CMS things like the table name,
+  This will tell TYPO3 things like the table name,
   features you have configured, the fields of the table and how to
   render these in the backend, relations to other tables, etc.
 
@@ -47,7 +47,7 @@ There are certain requirements for such managed tables:
 
     - A "sorting" field holding an order if records are sorted manually.
 
-    - A "deleted" field which tells TYPO3 CMS that the record is deleted
+    - A "deleted" field which tells TYPO3 that the record is deleted
       (in effect implementing a "soft delete" feature; records with a
       "deleted" field are not truly deleted from the database).
 

--- a/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
@@ -6,7 +6,7 @@
 Upgrade table and field definitions
 ===================================
 
-Each extension in TYPO3 CMS can bring the file :file:`ext_tables.sql` that
+Each extension in TYPO3 can bring the file :file:`ext_tables.sql` that
 defines which tables and fields the extension needs. Gathering all
 :file:`ext_tables.sql` thus defines the full set of tables, fields and
 indexes of a TYPO3 instance to unfold its full feature set. Some functionality
@@ -14,13 +14,13 @@ in the install tool can compare the defined set with the current active
 database schema and shows options to align those two by adding fields,
 removing fields and so on.
 
-When you upgrade to newer versions of the TYPO3 CMS or upgrade an extension,
+When you upgrade to newer versions of TYPO3 or upgrade an extension,
 the data definition of tables and fields might have changed.
-The TYPO3 CMS install tool will detect such changes.
+The TYPO3 install tool will detect such changes.
 
 When you install a new extension, any change to the database
 is automatically performed. When you upgrade to a new major
-version of TYPO3 CMS, you should normally go through the Upgrade
+version of TYPO3, you should normally go through the Upgrade
 Wizard, whose first step is to perform all necessary database
 changes:
 
@@ -45,7 +45,7 @@ very likely break your installation.
 
 .. include:: /Images/AutomaticScreenshots/AdminTools/DatabaseAnalyzer.rst.txt
 
-More information about the process of upgrading TYPO3 CMS can be found in
+More information about the process of upgrading TYPO3 can be found in
 the :doc:`Upgrade Guide <t3install:Index>`.
 
 .. index::

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -11,7 +11,7 @@
 Introduction
 ============
 
-TYPO3 CMS relies on storing its data in a relational database management
+TYPO3 relies on storing its data in a relational database management
 system (RDBMS). The Doctrine DBAL component is used to enable connecting to
 different database management systems. Most used is still MySQL / MariaDB, but
 thanks to Doctrine others like PostgreSQL and SQLite are also an option.
@@ -48,12 +48,12 @@ doctrine without an extension developer taking care of that specifically.
 
 The API provided by the Core is basically a pretty small and lightweight facade
 in front of Doctrine DBAL that adds some convenient methods as well as some
-TYPO3 CMS specific sugar. The facade additionally provides methods to retrieve
+TYPO3 specific sugar. The facade additionally provides methods to retrieve
 specific connection objects per configured database connection based on the table
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.
 
-Doctrine DBAL has been introduced with TYPO3 CMS version 8 and substitutes the
+Doctrine DBAL has been introduced with TYPO3 version 8 and substitutes the
 old API based on :php:`$GLOBALS['TYPO3_DB']`.
 
 This document does *not* outline each and every single method the API provides. It

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -168,7 +168,7 @@ Default Restrictions
 
 .. note::
 
-   `->select()` and `->count()` queries trigger TYPO3 CMS magic that adds further default where
+   `->select()` and `->count()` queries trigger TYPO3 magic that adds further default where
    clauses if the queried table is also registered via `$GLOBALS['TCA']`. See the
    :ref:`RestrictionBuilder <database-restriction-builder>` section for details on that topic.
 

--- a/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
@@ -7,7 +7,7 @@ Maintenance
 ===========
 
 There are various maintenance tasks which can be performed
-to maintain a healthy TYPO3 CMS installation with the
+to maintain a healthy TYPO3 installation with the
 file abstraction layer.
 
 
@@ -22,11 +22,11 @@ file abstraction layer.
 
 File abstraction layer: Update storage index
   This task goes through a storage and makes sures that every file
-  is properly indexed. When files are manipulated only via the TYPO3 CMS
+  is properly indexed. When files are manipulated only via the TYPO3
   backend, they are always indexed. However if files get added via other
   means (e.g. FTP) or if some storages are based on drivers accessing
   remote systems, it is crucial to run this task regularly so that
-  the TYPO3 CMS installation knows about all existing files in order
+  the TYPO3 installation knows about all existing files in order
   to make them available to users.
 
   This task is defined per storage.

--- a/Documentation/ApiOverview/Fal/Administration/Permissions.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Permissions.rst
@@ -212,7 +212,7 @@ Frontend permissions
 System extension "filemetadata" adds a "fe_groups" field to the
 "sys\_file\_metadata" table. This makes it possible to attach
 frontend permissions to files. However these permissions are not
-enforced in any way by the TYPO3 CMS Core. It is up to extension
+enforced in any way by the TYPO3 Core. It is up to extension
 developers to create tools which make use of these permissions.
 
 As an example, you may want to take a look at extension

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -19,7 +19,7 @@ Is browsable?
 Is publicly available?
   When this box is unchecked, the "publicUrl" property of files is
   replaced by an eID call pointing to a file dumping script provided
-  by the TYPO3 CMS Core. The public URL looks something like
+  by the TYPO3 Core. The public URL looks something like
   :code:`index.php?eID=dumpFile&t=f&f=1230&token=135b17c52f5e718b7cc94e44186eb432e0cc6d2f`.
   Behind the scenes, class :php:`\TYPO3\CMS\Core\Controller\FileDumpController`
   is invoked to manage the download. The class itself does not implement

--- a/Documentation/ApiOverview/Fal/Architecture/Components.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Components.rst
@@ -61,7 +61,7 @@ In the database, each FileReference is represented by a record in the
 :ref:`sys_file_reference table <fal-architecture-database-sys-file-reference>`.
 
 Creating a reference to a file requires the file to be indexed first,
-as the reference is done through the normal record relation handling of TYPO3 CMS.
+as the reference is done through the normal record relation handling of TYPO3.
 
 .. note::
 
@@ -172,7 +172,7 @@ individually, by the selection of a folder or by the selection of one or
 more categories. Collections can be used by content elements or plugins
 for various needs.
 
-The TYPO3 CMS Core makes usage of collections for the "File Links"
+The TYPO3 Core makes usage of collections for the "File Links"
 content object type.
 
 

--- a/Documentation/ApiOverview/Fal/Architecture/Folders.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Folders.rst
@@ -8,12 +8,12 @@ Folders
 
 The actual storage structure depends on which Driver each storage
 is based on. When using the local file system Driver provided by
-the TYPO3 CMS Core, a storage will correspond to some existing
+the TYPO3 Core, a storage will correspond to some existing
 folder on the local storage system (e.g. hard drive). Other
 Drivers may use virtual structures.
 
 By default, a storage pointing to the :file:`fileadmin` folder
-is created automatically in every TYPO3 CMS installation.
+is created automatically in every TYPO3 installation.
 
 
 .. index:: File abstraction layer; Processed files

--- a/Documentation/ApiOverview/Fal/Collections/Index.rst
+++ b/Documentation/ApiOverview/Fal/Collections/Index.rst
@@ -34,7 +34,7 @@ all files inside the folder will be returned when calling that collection.
 Collections API
 ===============
 
-The TYPO3 CMS Core provides an API to enable usage of collections
+The TYPO3 Core provides an API to enable usage of collections
 inside extensions. The most important classes are:
 
 :code:`\TYPO3\CMS\Core\Resource\FileCollectionRepository`

--- a/Documentation/ApiOverview/Fal/Concepts/Index.rst
+++ b/Documentation/ApiOverview/Fal/Concepts/Index.rst
@@ -6,7 +6,7 @@
 Basic concepts
 ==============
 
-This chapter presents the general concepts underlying the TYPO3 CMS
+This chapter presents the general concepts underlying the TYPO3
 file abstraction layer (FAL). The whole point of FAL - as its name
 implies - is to provide information about files abstracted with
 regards to their actual nature and storage.
@@ -29,9 +29,9 @@ these different places requires an appropriate driver.
 
 Each storage relies on a driver to provide the user with the
 ability to use and manipulate the files that exist in the storage.
-By default TYPO3 CMS provides only a local file system driver.
+By default TYPO3 provides only a local file system driver.
 
-A new TYPO3 CMS installation comes with a predefined storage,
+A new TYPO3 installation comes with a predefined storage,
 using the local file system driver and pointing to the
 :file:`fileadmin/` directory, located in your public folder.
 If it's missing/offline after installation you can create it yourself.
@@ -52,7 +52,7 @@ to hold a large variety of additional information about the file
 
 .. tip::
 
-   Although FAL is part of the TYPO3 CMS Core, there is a
+   Although FAL is part of the TYPO3 Core, there is a
    system extension called "filemetadata", which is not installed
    by default. It extends the "sys\_file\_metadata" table with
    fields such as copyright notice, author name, location, etc.
@@ -72,7 +72,7 @@ use for this file just for this reference.
 
 This central reference table ("sys\_file\_reference") makes
 it easy to track every place where a file is used inside a
-TYPO3 CMS installation.
+TYPO3 installation.
 
 All these elements are explored in greater depth in the chapter
 about :ref:`FAL components <fal-architecture-components>`.

--- a/Documentation/ApiOverview/Fal/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Fal/Introduction/Index.rst
@@ -6,7 +6,7 @@ Introduction
 ============
 
 This part of the Core API document contains details about the file abstraction layer (FAL),
-TYPO3 CMS' toolbox for handling media. It explains its architecture and
+TYPO3's toolbox for handling media. It explains its architecture and
 concepts and details what a web site administrator should know about
 FAL maintenance and permissions.
 

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -246,7 +246,7 @@ You are on your own.
 
 The simplest solution is to create a database entry into
 table "sys\_file\_reference" by using the database connection
-class provided by TYPO3 CMS.
+class provided by TYPO3.
 
 A cleaner solution using Extbase requires far more work. An example
 can be found here: https://github.com/helhum/upload_example

--- a/Documentation/ApiOverview/Fal/UsingFal/Index.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/Index.rst
@@ -8,7 +8,7 @@ Using FAL
 
 This chapter explains the principles on how to use FAL in
 various contexts, like the frontend or during extension
-or TYPO3 CMS Core development, by the way of references
+or TYPO3 Core development, by the way of references
 or useful examples for common use-cases.
 
 .. toctree::

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -87,8 +87,8 @@ In your extension, the following directory structure should be used for Fluid fi
         ├── Partials
         └── Templates
 
-This directory structure is the convention used by TYPO3 CMS. When using Fluid outside of
-TYPO3 CMS you can use any folder structure you like.
+This directory structure is the convention used by TYPO3. When using Fluid outside of
+TYPO3 you can use any folder structure you like.
 
 If you are using Extbase controller actions in combination with Fluid,
 Extbase defines how files and directories should be named within these directories.

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -8,7 +8,7 @@
 Icon API
 ========
 
-TYPO3 CMS provides an icon API for all icons in the TYPO3 backend.
+TYPO3 provides an icon API for all icons in the TYPO3 backend.
 
 .. index:: IconRegistry; registerIcon
 .. _icon-registration:

--- a/Documentation/ApiOverview/Internationalization/Introduction.rst
+++ b/Documentation/ApiOverview/Internationalization/Introduction.rst
@@ -4,7 +4,7 @@
 Introduction
 ============
 
-Except for some low level functions, TYPO3 CMS exclusively uses localizable
+Except for some low level functions, TYPO3 exclusively uses localizable
 strings for all labels displayed in the backend. This means that the whole user
 interface may be translated. The encoding is strictly UTF-8.
 

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -5,7 +5,7 @@
 Namespaces
 ==========
 
-Since version 6.0, TYPO3 CMS uses PHP namespaces for all classes in the Core.
+Since version 6.0, TYPO3 uses PHP namespaces for all classes in the Core.
 
 The general structure of namespaces is the following:
 

--- a/Documentation/ApiOverview/PageTypes/Introduction.rst
+++ b/Documentation/ApiOverview/PageTypes/Introduction.rst
@@ -74,7 +74,7 @@ Each array has the following options available:
  - :Key:
          type
    :Description:
-         Can be "sys" or "web". This is purely informative, as TYPO3 CMS does
+         Can be "sys" or "web". This is purely informative, as TYPO3 does
          nothing with that piece of data.
 
 

--- a/Documentation/ApiOverview/ParsingHtml/Index.rst
+++ b/Documentation/ApiOverview/ParsingHtml/Index.rst
@@ -7,7 +7,7 @@
 Parsing HTML
 ============
 
-TYPO3 CMS provides its own HTML parsing class:
+TYPO3 provides its own HTML parsing class:
 :code:`\TYPO3\CMS\Core\Html\HtmlParser`. This chapter
 shows some example uses.
 

--- a/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
@@ -6,7 +6,7 @@
 Bootstrapping
 =============
 
-TYPO3 CMS has a clean bootstrapping process driven mostly
+TYPO3 has a clean bootstrapping process driven mostly
 by class :php:`\TYPO3\CMS\Core\Core\Bootstrap`. This class is initialized by
 calling  :php:`Bootstrap::init()` and serves as an entry point for later calling
 an application class, depending on several context-dependant constraints.
@@ -86,7 +86,7 @@ Example of bootstrapping the TYPO3 Backend:
 Initialization
 ==============
 
-Whenever a call to TYPO3 CMS is made, the application goes through a
+Whenever a call to TYPO3 is made, the application goes through a
 bootstrapping process managed by a dedicated API. This process is also
 used in the frontend, but only the backend process is described here.
 
@@ -194,7 +194,7 @@ Application context
 ===================
 
 Each request, no matter if it runs from the command line or through HTTP,
-runs in a specific *application context*. TYPO3 CMS provides exactly three built-in
+runs in a specific *application context*. TYPO3 provides exactly three built-in
 contexts:
 
 * ``Production`` (default) - should be used for a live site
@@ -206,7 +206,7 @@ The context TYPO3 runs in is specified through the environment variable
 
 .. code-block:: bash
 
-   # run the TYPO3 CMS CLI commands in development context
+   # run the TYPO3 CLI commands in development context
    TYPO3_CONTEXT=Development ./bin/typo3
 
 

--- a/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
@@ -11,7 +11,7 @@
 Middlewares (Request handling)
 ==============================
 
-TYPO3 CMS has implemented `PSR-15`_ for handling incoming HTTP requests. The
+TYPO3 has implemented `PSR-15`_ for handling incoming HTTP requests. The
 implementation within TYPO3 is often called "Middlewares", as PSR-15 consists of
 two interfaces where one is called :php:`Middleware`.
 

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -8,7 +8,7 @@
 Versioning and Workspaces
 =========================
 
-TYPO3 CMS provides a feature called "workspaces", whereby changes
+TYPO3 provides a feature called "workspaces", whereby changes
 can be made to the content of the web site without affecting the
 currently visible (live) version. Changes can be previewed and
 go through an approval process before publishing.

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -15,7 +15,7 @@ XCLASSes (Extending Classes)
 Introduction
 ============
 
-XCLASSing is a mechanism in TYPO3 CMS to extend classes or overwrite methods from the Core or extensions
+XCLASSing is a mechanism in TYPO3 to extend classes or overwrite methods from the Core or extensions
 with one's own code. This enables a developer to easily change a given functionality,
 if other options like :ref:`hooks <hooks>`, signals, :ref:`events <EventDispatcher>`
 or the dependency injection mechanisms do not work or do not exist.

--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -5,7 +5,7 @@
 Introduction
 ============
 
-This chapter defines coding guidelines for the TYPO3 CMS project.
+This chapter defines coding guidelines for the TYPO3 project.
 Following these guidelines is mandatory for TYPO3 Core  developers and
 contributors to the TYPO3 Core .
 

--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -7,7 +7,7 @@ TSconfig
 ========
 
 "User TSconfig" and "page TSconfig" are very flexible concepts for
-adding fine-grained configuration to the backend of TYPO3 CMS. It is a text-
+adding fine-grained configuration to the backend of TYPO3. It is a text-
 based configuration system where you assign values to keyword strings,
 using the TypoScript syntax. The :doc:`TSconfig Reference <t3tsconfig:Index>`
 describes in detail how this works and what can be done with it.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -67,13 +67,13 @@ A basic installation
 ====================
 
 To follow this document, it might help to have a totally trimmed down
-installation of TYPO3 CMS with *only* the Core and the required system
+installation of TYPO3 with *only* the Core and the required system
 extensions at hand.
 
 The installation process is covered in the :doc:`Getting started
 Guide <t3start:Index>`.
 You should perform the basic installation steps and not install any
-distribution. This will give you the "lightest" possible version of TYPO3 CMS.
+distribution. This will give you the "lightest" possible version of TYPO3.
 
 In your basic installation, go to the :guilabel:`Admin Tools > Extensions`
 module. You will see all extensions installed by Composer are activated by

--- a/Documentation/Security/GuidelinesEditors/Index.rst
+++ b/Documentation/Security/GuidelinesEditors/Index.rst
@@ -115,7 +115,7 @@ should get in touch with the system provider to solve this issue.
 Notify at login
 ---------------
 
-TYPO3 CMS offers the feature to notify backend users by email, when
+TYPO3 offers the feature to notify backend users by email, when
 somebody logs in from your account. If you set this option in your
 user settings, you will receive an email from TYPO3 each time you (or
 "someone") logs in using your login details. Receiving such a

--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -98,7 +98,7 @@ definitely discuss your intention with the team.
 TYPO3 Core updates
 ==================
 
-Since TYPO3 CMS 6.2, the Install Tool allows integrators to update the
+Since TYPO3 v6.2, the Install Tool allows integrators to update the
 TYPO3 Core with a click of a button. This feature can be found under
 "Important actions" and it checks/installs revision updates only (e.g.
 bug fixes and security updates).

--- a/Documentation/Security/SecurityTeam/Index.rst
+++ b/Documentation/Security/SecurityTeam/Index.rst
@@ -64,7 +64,7 @@ of the appropriate component of the system, after verifying the
 problem. A fix for the vulnerability will be developed, carefully
 tested and reviewed. Together with a public security bulletin, a TYPO3
 Core update will be released. Please see next chapter for further
-details about TYPO3 CMS versions and security bulletins.
+details about TYPO3 versions and security bulletins.
 
 
 Security issues in TYPO3 extensions


### PR DESCRIPTION
Releases: main, 11.5