### PR TITLE
[Backport 11.5] [TASK] Use "TYPO3" instead of "TYPO3 CMS" (#2272)

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -27,12 +27,12 @@ of choice in your work with TYPO3.
 Intended Audience
 =================
 
-This document is intended to be a reference for TYPO3 CMS developers and partially
+This document is intended to be a reference for TYPO3 developers and partially
 for integrators. The document explains all major parts of TYPO3 and the concepts.
 Some chapters presumes knowledge in the technical end: PHP, MySQL, Unix etc, depending
 on the specific chapter.
 
-The goal is to take you "under the hood" of TYPO3 CMS. To make the
+The goal is to take you "under the hood" of TYPO3. To make the
 principles and opportunities clear and less mysterious. To educate you
 to help continue the development of TYPO3 along the already
 established lines so we will have a consistent CMS application in a

--- a/Documentation/ApiOverview/Authentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/Index.rst
@@ -6,7 +6,7 @@
 Authentication
 ==============
 
-The TYPO3 CMS Core uses :ref:`Services <services>` for the authentication process.
+The TYPO3 Core uses :ref:`Services <services>` for the authentication process.
 This family of services (of type "auth") are the only Core usage that consumes the
 Services API.
 
@@ -26,7 +26,7 @@ process of authentication, where many methods may be desirable
 such as LDAP, etc.) depending on the context.
 
 The ease with which such services can be developed is a strong
-point in favor of TYPO3 CMS, especially in corporate environments.
+point in favor of TYPO3, especially in corporate environments.
 
 Being able to toy with priority and quality allows for
 precise fine-tuning of the authentication chain.
@@ -246,21 +246,21 @@ be able to find examples to inspire and guide you. Anyway authentication
 services can be very different from one another, so it wouldn't make much
 sense to try and provide an example in this manual.
 
-One important thing to know is that the TYPO3 CMS authentication
+One important thing to know is that the TYPO3 authentication
 process *needs* to have users inside database records ("fe_users" or
 "be_users"). This means that if you interface with a third-party
-server, you will need to create records on the TYPO3 CMS side. It is
+server, you will need to create records on the TYPO3 side. It is
 up to you to choose whether this process happens on the fly (during
 authentication) or if you want to create an import process (as a
 Scheduler task, for example) that will synchronize users between
-TYPO3 CMS and the remote system.
+TYPO3 and the remote system.
 
 .. note::
 
    You probably do not want to store the actual password of imported
-   users in the TYPO3 CMS database. It is recommended to store
+   users in the TYPO3 database. It is recommended to store
    an arbitrary string in such case, making sure that such string
-   is random enough for security reasons. TYPO3 CMS provides method
+   is random enough for security reasons. TYPO3 provides method
    :php:`\TYPO3\CMS\Core\Crypto\Random::generateRandomHexString()`
    which can be used for such a purpose.
 
@@ -270,16 +270,16 @@ authority for authentication, it should not only have a high priority,
 but also return values which stop the service chain (i.e.
 a negative value for failed authentication, 200 or more for a
 successful one). On the other hand, if your service is an alternative
-authentication, but should fall back on TYPO3 CMS if unavailable,
+authentication, but should fall back on TYPO3 if unavailable,
 you will want to return 100 on failure, so that the default service
 can take over.
 
 Things can get a bit hairy if you have a scenario with mixed sources,
 for example some users come from a third-party server but others
-exist only in TYPO3 CMS. In such a case, you want to make sure that
+exist only in TYPO3. In such a case, you want to make sure that
 your service returns definite authentication failures only for those
 users which depend on the remote system and let the default
-authentication proceed for "local" TYPO3 CMS users.
+authentication proceed for "local" TYPO3 users.
 
 .. _authentication-advanced-options:
 
@@ -291,7 +291,7 @@ to modify the behaviour of the authentication process. Some
 impact the inner working of the services themselves, others
 influence when services are called.
 
-It is possible to force TYPO3 CMS to go through the
+It is possible to force TYPO3 to go through the
 authentication process for **every** request no matter any
 existing session. By setting the following local configuration
 either for the FE or the BE:
@@ -326,7 +326,7 @@ yet exist. The settings are:
 .. note::
 
    This could be used in a scenario where users go through a login portal
-   and then choose to access the TYPO3 CMS BE, for example. In such a case
+   and then choose to access the TYPO3 backend, for example. In such a case
    we would want the users to be automatically authenticated, but would not
    need to repeat the process upon each request.
 

--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-.. index:: 
+.. index::
    Autoloader; ComposerClassLoader
    ClassLoader
 .. _composer-class-loader:
@@ -8,20 +8,20 @@
 ComposerClassLoader
 ===================
 
-Integrating Composer class loader into TYPO3 CMS
-================================================
+Integrating Composer class loader into TYPO3
+============================================
 
-In our efforts to make the TYPO3 CMS system faster and closer oriented
+In our efforts to make TYPO3 faster and closer oriented
 to common PHP standard systems, we looked into the integration of the
 class loader that is used by all composer-based projects. We consider
-this functionality a crucial feature for the future of TYPO3 CMS on the
+this functionality a crucial feature for the future of TYPO3 on the
 base level, but also as a dramatic increase of the overall performance
-of every request inside TYPO3 CMS.
+of every request inside TYPO3.
 
-Understanding the TYPO3 CMS class loader
-========================================
+Understanding the TYPO3 class loader
+====================================
 
-The TYPO3 class loader is instantiated within the TYPO3 CMS Bootstrap at
+The TYPO3 class loader is instantiated within the TYPO3 Bootstrap at
 a very early point. It does a lot of logic (checking :file:`ext_autoload.php`,
 :file:`ClassAliasMap.php), and caches this logic away on a per-class basis by
 default in :file:`typo3temp/Cache/` to store all information for a class. This
@@ -46,7 +46,7 @@ hit, the caching framework does not create the cache files, but fetches
 one by one for each class used in the request via a separate
 :php:`file_get_contents()` call.
 
-When debugging the TYPO3 CMS system on an initial request, there are a
+When debugging TYPO3 on an initial request, there are a
 lot of :file:`file_get_contents()` and :file:`file_put_contents()` calls to
 store and fetch this information. This is quite a lot of overhead for loading
 PHP classes. Even without a lot of class aliases (e.g. in CMS7) this
@@ -60,18 +60,18 @@ ensured.
 Understanding the Composer class loader
 =======================================
 
-Compared to the TYPO3 CMS class loader, the composer class loader
+Compared to the TYPO3 class loader, the composer class loader
 concept differs in the following major points:
 
 Caching on build stage
 ----------------------
 
-When setting up a project, like a TYPO3 CMS project, Composer checks the
+When setting up a project, like a TYPO3 project, Composer checks the
 main composer.json of a project and builds a static file with all PSR-4
 prefixes defined in that json file. Unless in a development environment
 or when updating the source, this file does not need to be rebuilt as
 the PHP classes of the loaded packages won’t change in a regular
-instance. This way all classes available inside TYPO3 CMS are always
+instance. This way all classes available inside TYPO3 are always
 available to the class loader.
 
 Using PSR-4 compatible prefix-based resolving
@@ -83,13 +83,13 @@ Composer class loader only needs to know that all PHP classes starting
 with TYPO3\CMS\Core are located within typo3/sysext/core/Classes. The
 rest is done by a simple resolution to include the necessary PHP class
 files. This means that the information to be cached away is only the
-list of available namespace-prefixes. All classes inside the TYPO3 CMS
-Core are PSR-4 compatible since TYPO3 CMS 6.0 already.
+list of available namespace-prefixes. All classes inside the TYPO3
+Core are PSR-4 compatible since TYPO3 v6.0 already.
 
 The definition of these prefixes is set inside the composer.json of each
-package or distribution / project. In the TYPO3 CMS Core, every system
-extension defined these namespace prefixes already since TYPO3 CMS 7.1
-and TYPO3 CMS 6.2.10.
+package or distribution / project. In the TYPO3 Core, every system
+extension defined these namespace prefixes already since TYPO3 v7.1
+and TYPO3 v6.2.10.
 
 Autoloading developer-specific data differently
 -----------------------------------------------
@@ -104,11 +104,11 @@ Integration Approach
 ====================
 
 The Composer class loader is injected inside the Bootstrap process of
-TYPO3 CMS and registered before the TYPO3 class loader. This means that
+TYPO3 and registered before the TYPO3 class loader. This means that
 a lookup on a class name is first checked via the Composer logic, and if
 none found, the regular TYPO3 class loader takes over.
 
-The support for class aliases is quite important for TYPO3 CMS, but is
+The support for class aliases is quite important for TYPO3, but is
 not supported by Composer by default. There is a separate Composer
 package created by Helmut Hummel (available on `GitHub
 <https://github.com/helhum/class-alias-loader>`_) which serves as a facade

--- a/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
@@ -45,7 +45,7 @@ additional technical details, where necessary.
 .. note::
 
    Access list don't apply to admin users. As mentioned before, admin
-   users have access to every single feature of the TYPO3 CMS backend.
+   users have access to every single feature of the TYPO3 backend.
 
 Modules
    This is a list of submodules a user may be given access to. Access to a main
@@ -92,7 +92,7 @@ Tables for editing
    modification rights.
 
 Page types
-   TYPO3 CMS defines a number of page types. A user can be restricted
+   TYPO3 defines a number of page types. A user can be restricted
    to access only some of them.
 
    For a full discussion on page types, please refer to the
@@ -106,7 +106,7 @@ Excludefields
 
 Explicitly allow/deny field values
    When a field offers a list of options to select from, it is possible
-   to tell TYPO3 CMS that access to these options is restricted and should
+   to tell TYPO3 that access to these options is restricted and should
    be granted explicitly. Such fields and their values appear here.
 
    The related TCA property is :ref:`"authMode" <t3tca:columns-select-properties-authmode>`.
@@ -125,7 +125,7 @@ the groups are "added" together.
 Mounts
 ======
 
-TYPO3 CMS natively supports two kinds of hierarchical tree structures:
+TYPO3 natively supports two kinds of hierarchical tree structures:
 the page tree (typically visible in the :guilabel:`Web` module) and the folder
 tree (typically visible in the :guilabel:`File` module). Each tree is
 generated based on the *mount points* configured for the current user. So a
@@ -154,13 +154,13 @@ This is what the user will see:
 involve several steps. First of all, you need to have at least
 one :ref:`File Storage <fal-concepts-storages-drivers>`. By
 default, you will always have one, pointing
-to the :file:`fileadmin` directory. It is created by TYPO3 CMS
+to the :file:`fileadmin` directory. It is created by TYPO3
 upon installation.
 
 .. note::
 
    The :file:`fileadmin` directory is the default place where
-   TYPO3 CMS expects media resources to be located. It can be
+   TYPO3 expects media resources to be located. It can be
    changed using the global configuration option
    :code:`$GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir']`.
 
@@ -256,7 +256,7 @@ Editing permissions is described in details in the
 A user must be "admin" *or* the owner of a page in order to edit its
 permissions.
 
-When a user creates new pages in TYPO3 CMS they will by default get the
+When a user creates new pages in TYPO3 they will by default get the
 creating user as owner. The owner group will be set to the *first
 listed user group* configured for the users record (if any). These defaults
 can be changed through :ref:`page TSconfig <t3tsconfig:pagetcemain-permissions-user-group>`.
@@ -269,6 +269,6 @@ User TSconfig
 
 User TSconfig is a hierarchical configuration structure entered in
 plain text TypoScript. It can be used by all kinds of applications
-inside of TYPO3 CMS to retrieve customized settings for users which
+inside of TYPO3 to retrieve customized settings for users which
 relates to a certain module or part. The options available are
 described in the :ref:`document TSconfig <t3tsconfig:usertsconfig>` .

--- a/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
@@ -10,7 +10,7 @@ More about file mounts
 ======================
 
 File mounts require a little more description of the concepts provided
-by TYPO3 CMS. All files are handled by an application layer called
+by TYPO3. All files are handled by an application layer called
 the "File Abstraction Layer" (FAL). You can find more information
 about the basic concepts of :ref:`FAL <fal-concepts>`.
 
@@ -29,7 +29,7 @@ Storages
   "directories". The storage configuration depends on the driver it uses.
 
   Thanks to the storage and its driver, the user is able to browse
-  files from within the TYPO3 CMS backend as if they were stored locally.
+  files from within the TYPO3 backend as if they were stored locally.
 
 File mounts
   As discussed before, a file mount is the element which is used to

--- a/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
@@ -112,7 +112,7 @@ equal to :code:`/home/foo/`.
 Home directories
 ================
 
-TYPO3 CMS also features the concept of "home directories". These are paths
+TYPO3 also features the concept of "home directories". These are paths
 that are automatically mounted if they are present at a path
 configured in the global configuration. Thus they don't need to have a file
 mount record representing them - they just need a properly named

--- a/Documentation/ApiOverview/Backend/AccessControl/OtherOptions/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/OtherOptions/Index.rst
@@ -41,7 +41,7 @@ Access options
 
 Lock to domain
    This setting constrains the user to use a specific domain for logging
-   into the TYPO3 CMS backend. This is very useful in setups with multiple
+   into the TYPO3 backend. This is very useful in setups with multiple
    sites.
 
 
@@ -60,7 +60,7 @@ Lock to domain
 
 Hide in lists
   This flag will prevent the group from appearing in various
-  listings in TYPO3 CMS. This includes modules like :guilabel:`System > Access`.
+  listings in TYPO3. This includes modules like :guilabel:`System > Access`.
 
 Inherit settings from groups (Sub Groups)
   Assigns sub-groups to this group. Sub-groups are

--- a/Documentation/ApiOverview/Backend/AccessControl/Roles/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/Roles/Index.rst
@@ -10,10 +10,10 @@ concept is basically about identifying certain roles that users can
 take and then allow for a very easy application of these roles to
 users.
 
-TYPO3 CMS access control is far more flexible and allows for such detailed
+TYPO3 access control is far more flexible and allows for such detailed
 configuration that it lies very far from the simple and straight
 forward concept of roles. This is necessary as the foundation of a
-system like TYPO3 CMS should fit many possible usages.
+system like TYPO3 should fit many possible usages.
 
 However it is perfectly possible to create groups that act like "roles".
 This is what you should do:

--- a/Documentation/ApiOverview/Backend/AccessControl/UsersAndGroups/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/UsersAndGroups/Index.rst
@@ -5,7 +5,7 @@
 Users and groups
 ================
 
-TYPO3 CMS features an access control system based on users and groups.
+TYPO3 features an access control system based on users and groups.
 
 
 .. index:: pair: Backend; Users
@@ -61,7 +61,7 @@ There is a special kind of backend users called "Admin".
 When creating a backend user, just check the "Admin!" box in the
 "General" tab and that user will become an administrator.
 There's no need to set further access options for such a user:
-an admin user can access every single feature of the TYPO3 CMS
+an admin user can access every single feature of the TYPO3
 backend, like the "root" user on a UNIX system.
 
 All systems must have at least one "admin" user and most systems

--- a/Documentation/ApiOverview/Backend/BackendRouting.rst
+++ b/Documentation/ApiOverview/Backend/BackendRouting.rst
@@ -28,7 +28,7 @@ Here is an extract of :file:`typo3/sysext/backend/Configuration/Backend/Routes.p
     * Contains all "regular" routes for entry points
     *
     * Please note that this setup is preliminary until all Core use-cases are set up here.
-    * Especially some more properties regarding modules will be added until TYPO3 CMS 7 LTS, and might change.
+    * Especially some more properties regarding modules will be added until TYPO3 v7 LTS, and might change.
     *
     * Currently the "access" property is only used so no token creation + validation is made,
     * but will be extended further.
@@ -135,7 +135,7 @@ generates and applies the mentioned session token.
    // Using a route identifier
    $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
    $uri = $uriBuilder->buildUriFromRoute('web_layout', ['id' => $pageId]);
-   
+
    // Using a route path
    $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
    $uri = $uriBuilder->buildUriFromRoutePath(

--- a/Documentation/ApiOverview/Backend/ContextualMenu.rst
+++ b/Documentation/ApiOverview/Backend/ContextualMenu.rst
@@ -16,7 +16,7 @@ Context-sensitive menus
    configured in the same way.
 
 
-Contextual menus exist in many places in the TYPO3 CMS backend. Just try your
+Contextual menus exist in many places in the TYPO3 backend. Just try your
 luck clicking on any **icon** that you see. Chances are good that a contextual
 menu will appear, offering useful functions to execute.
 

--- a/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
@@ -115,7 +115,7 @@ The TYPO3 Core  defines and uses several caching framework caches by default.
 This section gives an overview of default caches, its usage and behaviour. If not stated otherwise,
 the default database backend with variable frontend is used.
 
-Since TYPO3 CMS 6.2, the various caches are organized in groups.
+Since TYPO3 v6.2, the various caches are organized in groups.
 Three groups currently exist:
 
 pages
@@ -138,7 +138,7 @@ but such caches should normally be transient anyway.
 There are :ref:`TSconfig options for permissions <t3tsconfig:useroptions>`
 corresponding to each group.
 
-The following caches exist in the TYPO3 CMS Core:
+The following caches exist in the TYPO3 Core:
 
 - `core`
 

--- a/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
@@ -21,7 +21,7 @@ and consists of the single section:
 Cache Configurations
 ====================
 
-Unfortunately in TYPO3 CMS, all :file:`ext_localconf.php` files of the extensions are loaded **after** the instance specific
+Unfortunately in TYPO3, all :file:`ext_localconf.php` files of the extensions are loaded **after** the instance specific
 configuration from :file:`LocalConfiguration.php` and :file:`AdditionalConfiguration.php`. This
 enables extensions to overwrite cache configurations already done for the instance. All extensions
 should avoid this situation and should just define the very bare minimum of cache configurations. This
@@ -65,7 +65,7 @@ How to Disable Specific Caches
 ==============================
 
 During development, it can be convenient to disable certain caches.
-This is especially helpful since TYPO3 CMS 4.6 for central caches like the language or autoloader cache.
+This is especially helpful since TYPO3 v4.6 for central caches like the language or autoloader cache.
 This can be achieved by using the **null** backend (see below) as storage backend.
 
 .. warning::

--- a/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
@@ -12,7 +12,7 @@ This chapter is targeted at extension authors who want to use the caching framew
 for their needs. It is about how to use the framework properly. For details about
 its inner working, please refer to the :ref:`section about architecture <caching-architecture>`.
 
-Example usages can be found throughout the TYPO3 CMS Core, in particular in
+Example usages can be found throughout the TYPO3 Core, in particular in
 system extension `core` and `extbase`.
 
 

--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -294,7 +294,7 @@ per release. In other words, share :file:`var/session`, :file:`var/log`,
 Caching Framework
 -----------------
 
-Since TYPO3 CMS 4.3, the Core contains a data caching framework
+Since TYPO3 v4.3, the Core contains a data caching framework
 which supports a wide variety of storage solutions and options
 for different caching needs. Each cache can be configured individually
 and can implement its own specific storage strategy.

--- a/Documentation/ApiOverview/ContextSensitiveHelp/ImplementingCsh/Index.rst
+++ b/Documentation/ApiOverview/ContextSensitiveHelp/ImplementingCsh/Index.rst
@@ -24,7 +24,7 @@ extension's :file:`ext_tables.php` file:
 	);
 
 
-The rest of the work is automatically handled by the TYPO3 CMS
+The rest of the work is automatically handled by the TYPO3
 form engine.
 
 

--- a/Documentation/ApiOverview/ContextSensitiveHelp/Index.rst
+++ b/Documentation/ApiOverview/ContextSensitiveHelp/Index.rst
@@ -6,7 +6,7 @@
 Context Sensitive Help (CSH)
 ============================
 
-TYPO3 CMS offers a full API for adding Context Sensitive Help to
+TYPO3 offers a full API for adding Context Sensitive Help to
 backend modules and - especially - to all database tables and fields.
 CSH then appears either as a help icon in the docheader (for modules)
 or as a popup on field labels when editing database records.

--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -52,7 +52,7 @@ Remarks:
    connection even for `localhost`, the `IPv4` or `IPv6` address `127.0.0.1` and `::1/128` respectively
    must be used as `host` value.
 
-*  The connect options are hand over to Doctrine DBAL without much manipulation from TYPO3 CMS side.
+*  The connect options are hand over to Doctrine DBAL without much manipulation from TYPO3 side.
    Please refer to the
    `doctrine connection docs <https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html>`__
    for a full overview of settings.

--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -11,7 +11,7 @@ An instance of class :php:`TYPO3\CMS\Core\Database\Connection` is retrieved from
 and handing over the table name a query should executed on.
 
 The class extends the basic Doctrine DBAL `Doctrine\DBAL\Connection` class and is mainly
-used internally within the TYPO3 CMS framework to establish, maintain and terminate
+used internally within the TYPO3 framework to establish, maintain and terminate
 connections to single database endpoints. Those internal methods are not scope of this
 documentation since an extension developer usually doesn't have to deal with that.
 
@@ -193,7 +193,7 @@ argument specifies the quoting of `WHERE` values. There is a pattern ;)
 
 .. note::
 
-    TYPO3 CMS uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
+    TYPO3 uses a "soft delete" approach for many tables. Instead of directly deleting a rows in the database,
     a field - often called `deleted` - is set from 0 to 1. Executing a `DELETE` query circumvents this and really
     removes rows from a table. For most tables, it is better to use the :ref:`DataHandler <tce-database-basics>` API
     to handle deletes instead of executing such low level queries directly.

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -9,7 +9,7 @@
 Database Structure
 ==================
 
-The database tables used by TYPO3 CMS can be divided into two
+The database tables used by TYPO3 can be divided into two
 rough categories:
 
 - Tables that are used by the system internally and are invisible to backend
@@ -17,13 +17,13 @@ rough categories:
   often dedicated PHP API's in the Core extension to manage entries of these
   tables, for instance the :ref:`Caching framework API <caching>`.
 
-- Tables that can be managed via the TYPO3 CMS backend, are shown in the List
+- Tables that can be managed via the TYPO3 backend, are shown in the List
   module and can be edited using :ref:`FormEngine <FormEngine>`.
 
 There are certain requirements for such managed tables:
 
 - The table must be configured in the :doc:`global TCA array <t3tca:Index>`.
-  This will tell TYPO3 CMS things like the table name,
+  This will tell TYPO3 things like the table name,
   features you have configured, the fields of the table and how to
   render these in the backend, relations to other tables, etc.
 
@@ -47,7 +47,7 @@ There are certain requirements for such managed tables:
 
     - A "sorting" field holding an order if records are sorted manually.
 
-    - A "deleted" field which tells TYPO3 CMS that the record is deleted
+    - A "deleted" field which tells TYPO3 that the record is deleted
       (in effect implementing a "soft delete" feature; records with a
       "deleted" field are not truly deleted from the database).
 

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -69,8 +69,8 @@ There are certain requirements for such managed tables:
 The "pages" table
 =================
 
-The `pages` table has a special status: It is the backbone of TYPO3 CMS, as it provides
-the hierarchical page structure into which all other TYPO3 CMS managed records are positioned.
+The `pages` table has a special status: It is the backbone of TYPO3, as it provides
+the hierarchical page structure into which all other TYPO3 managed records are positioned.
 All other managed tables in TYPO3 have a `pid` field that points to a `uid` record in this table.
 So any managed table record in TYPO3 is always positioned on exactly one page in the page tree.
 This makes the `pages` table the mother of all other managed tables. It can be seen as a directory
@@ -95,7 +95,7 @@ table records may only be created on a real page.
 Other Tables
 ============
 
-The tables which are not managed via the TYPO3 CMS backend fill various
+The tables which are not managed via the TYPO3 backend fill various
 roles. Some of the most common are:
 
 - MM relations: when tables are related using a many-to-many relationship,
@@ -108,7 +108,7 @@ roles. Some of the most common are:
   as part of :ref:`inline records <t3tca:columns-inline>`.
 
 - Cache: when a cache is defined as using the database as a cache backend,
-  TYPO3 CMS will automatically create and manage the relevant cache tables.
+  TYPO3 will automatically create and manage the relevant cache tables.
 
 - System information: there exist tables storing information about sessions,
   both frontend and backend ("fe\_sessions" and "be\_sessions" respectively),
@@ -118,7 +118,7 @@ All these tables are not subject to the uid/pid constraint mentioned
 above, but they may have such fields if it is convenient for whatever
 reason.
 
-There is no way such tables can be managed via the TYPO3 CMS
+There is no way such tables can be managed via the TYPO3
 backend unless a specific module provides a form of access to it.
 For example, the :guilabel:`System > Log` module provides an interface
 to browse records from the :sql:`sys_log` table.

--- a/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
@@ -6,7 +6,7 @@
 Upgrade table and field definitions
 ===================================
 
-Each extension in TYPO3 CMS can bring the file :file:`ext_tables.sql` that
+Each extension in TYPO3 can bring the file :file:`ext_tables.sql` that
 defines which tables and fields the extension needs. Gathering all
 :file:`ext_tables.sql` thus defines the full set of tables, fields and
 indexes of a TYPO3 instance to unfold its full feature set. Some functionality
@@ -14,13 +14,13 @@ in the install tool can compare the defined set with the current active
 database schema and shows options to align those two by adding fields,
 removing fields and so on.
 
-When you upgrade to newer versions of the TYPO3 CMS or upgrade an extension,
+When you upgrade to newer versions of TYPO3 or upgrade an extension,
 the data definition of tables and fields might have changed.
-The TYPO3 CMS install tool will detect such changes.
+The TYPO3 install tool will detect such changes.
 
 When you install a new extension, any change to the database
 is automatically performed. When you upgrade to a new major
-version of TYPO3 CMS, you should normally go through the Upgrade
+version of TYPO3, you should normally go through the Upgrade
 Wizard, whose first step is to perform all necessary database
 changes:
 
@@ -45,7 +45,7 @@ very likely break your installation.
 
 .. include:: /Images/AutomaticScreenshots/AdminTools/DatabaseAnalyzer.rst.txt
 
-More information about the process of upgrading TYPO3 CMS can be found in
+More information about the process of upgrading TYPO3 can be found in
 the :doc:`Upgrade Guide <t3install:Index>`.
 
 .. index::

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -12,7 +12,7 @@
 Introduction
 ============
 
-TYPO3 CMS relies on storing its data in a relational database management
+TYPO3 relies on storing its data in a relational database management
 system (RDBMS). The Doctrine DBAL component is used to enable connecting to
 different database management systems. Most used is still MySQL / MariaDB, but
 thanks to Doctrine others like PostgreSQL and SQLServer are also an option.
@@ -53,12 +53,12 @@ doctrine without an extension developer taking care of that specifically.
 
 The API provided by the Core is basically a pretty small and lightweight facade
 in front of Doctrine DBAL that adds some convenient methods as well as some
-TYPO3 CMS specific sugar. The facade additionally provides methods to retrieve
+TYPO3 specific sugar. The facade additionally provides methods to retrieve
 specific connection objects per configured database connection based on the table
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.
 
-Doctrine DBAL has been introduced with TYPO3 CMS version 8 and substitutes the
+Doctrine DBAL has been introduced with TYPO3 version 8 and substitutes the
 old API based on :php:`$GLOBALS['TYPO3_DB']`. Extension authors are encouraged to switch
 away from TYPO3_DB to the new API. A :ref:`dedicated chapter <database-migration>` helps
 with typical migration questions. With database abstraction being built in Doctrine DBAL

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -164,7 +164,7 @@ Default Restrictions
 
 .. note::
 
-   `->select()` and `->count()` queries trigger TYPO3 CMS magic that adds further default where
+   `->select()` and `->count()` queries trigger TYPO3 magic that adds further default where
    clauses if the queried table is also registered via `$GLOBALS['TCA']`. See the
    :ref:`RestrictionBuilder <database-restriction-builder>` section for details on that topic.
 

--- a/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
@@ -7,7 +7,7 @@ Maintenance
 ===========
 
 There are various maintenance tasks which can be performed
-to maintain a healthy TYPO3 CMS installation with the
+to maintain a healthy TYPO3 installation with the
 file abstraction layer.
 
 
@@ -22,11 +22,11 @@ file abstraction layer.
 
 File abstraction layer: Update storage index
   This task goes through a storage and makes sures that every file
-  is properly indexed. When files are manipulated only via the TYPO3 CMS
+  is properly indexed. When files are manipulated only via the TYPO3
   backend, they are always indexed. However if files get added via other
   means (e.g. FTP) or if some storages are based on drivers accessing
   remote systems, it is crucial to run this task regularly so that
-  the TYPO3 CMS installation knows about all existing files in order
+  the TYPO3 installation knows about all existing files in order
   to make them available to users.
 
   This task is defined per storage.

--- a/Documentation/ApiOverview/Fal/Administration/Permissions.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Permissions.rst
@@ -212,7 +212,7 @@ Frontend permissions
 System extension "filemetadata" adds a "fe_groups" field to the
 "sys\_file\_metadata" table. This makes it possible to attach
 frontend permissions to files. However these permissions are not
-enforced in any way by the TYPO3 CMS Core. It is up to extension
+enforced in any way by the TYPO3 Core. It is up to extension
 developers to create tools which make use of these permissions.
 
 As an example, you may want to take a look at extension

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -19,7 +19,7 @@ Is browsable?
 Is publicly available?
   When this box is unchecked, the "publicUrl" property of files is
   replaced by an eID call pointing to a file dumping script provided
-  by the TYPO3 CMS Core. The public URL looks something like
+  by the TYPO3 Core. The public URL looks something like
   :code:`index.php?eID=dumpFile&t=f&f=1230&token=135b17c52f5e718b7cc94e44186eb432e0cc6d2f`.
   Behind the scenes, class :php:`\TYPO3\CMS\Core\Controller\FileDumpController`
   is invoked to manage the download. The class itself does not implement

--- a/Documentation/ApiOverview/Fal/Architecture/Components.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Components.rst
@@ -61,7 +61,7 @@ In the database, each FileReference is represented by a record in the
 :ref:`sys_file_reference table <fal-architecture-database-sys-file-reference>`.
 
 Creating a reference to a file requires the file to be indexed first,
-as the reference is done through the normal record relation handling of TYPO3 CMS.
+as the reference is done through the normal record relation handling of TYPO3.
 
 .. note::
 
@@ -172,7 +172,7 @@ individually, by the selection of a folder or by the selection of one or
 more categories. Collections can be used by content elements or plugins
 for various needs.
 
-The TYPO3 CMS Core makes usage of collections for the "File Links"
+The TYPO3 Core makes usage of collections for the "File Links"
 content object type.
 
 

--- a/Documentation/ApiOverview/Fal/Architecture/Folders.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Folders.rst
@@ -8,12 +8,12 @@ Folders
 
 The actual storage structure depends on which Driver each storage
 is based on. When using the local file system Driver provided by
-the TYPO3 CMS Core, a storage will correspond to some existing
+the TYPO3 Core, a storage will correspond to some existing
 folder on the local storage system (e.g. hard drive). Other
 Drivers may use virtual structures.
 
 By default, a storage pointing to the :file:`fileadmin` folder
-is created automatically in every TYPO3 CMS installation.
+is created automatically in every TYPO3 installation.
 
 
 .. index:: File abstraction layer; Processed files

--- a/Documentation/ApiOverview/Fal/Collections/Index.rst
+++ b/Documentation/ApiOverview/Fal/Collections/Index.rst
@@ -34,7 +34,7 @@ all files inside the folder will be returned when calling that collection.
 Collections API
 ===============
 
-The TYPO3 CMS Core provides an API to enable usage of collections
+The TYPO3 Core provides an API to enable usage of collections
 inside extensions. The most important classes are:
 
 :code:`\TYPO3\CMS\Core\Resource\FileCollectionRepository`

--- a/Documentation/ApiOverview/Fal/Concepts/Index.rst
+++ b/Documentation/ApiOverview/Fal/Concepts/Index.rst
@@ -6,7 +6,7 @@
 Basic concepts
 ==============
 
-This chapter presents the general concepts underlying the TYPO3 CMS
+This chapter presents the general concepts underlying the TYPO3
 file abstraction layer (FAL). The whole point of FAL - as its name
 implies - is to provide information about files abstracted with
 regards to their actual nature and storage.
@@ -29,9 +29,9 @@ these different places requires an appropriate driver.
 
 Each storage relies on a driver to provide the user with the
 ability to use and manipulate the files that exist in the storage.
-By default TYPO3 CMS provides only a local file system driver.
+By default TYPO3 provides only a local file system driver.
 
-A new TYPO3 CMS installation comes with a predefined storage,
+A new TYPO3 installation comes with a predefined storage,
 using the local file system driver and pointing to the
 :file:`fileadmin/` directory, located in your public folder.
 If it's missing/offline after installation you can create it yourself.
@@ -52,7 +52,7 @@ to hold a large variety of additional information about the file
 
 .. tip::
 
-   Although FAL is part of the TYPO3 CMS Core, there is a
+   Although FAL is part of the TYPO3 Core, there is a
    system extension called "filemetadata", which is not installed
    by default. It extends the "sys\_file\_metadata" table with
    fields such as copyright notice, author name, location, etc.
@@ -72,7 +72,7 @@ use for this file just for this reference.
 
 This central reference table ("sys\_file\_reference") makes
 it easy to track every place where a file is used inside a
-TYPO3 CMS installation.
+TYPO3 installation.
 
 All these elements are explored in greater depth in the chapter
 about :ref:`FAL components <fal-architecture-components>`.

--- a/Documentation/ApiOverview/Fal/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Fal/Introduction/Index.rst
@@ -6,7 +6,7 @@ Introduction
 ============
 
 This part of the Core API document contains details about the file abstraction layer (FAL),
-TYPO3 CMS' toolbox for handling media. It explains its architecture and
+TYPO3's toolbox for handling media. It explains its architecture and
 concepts and details what a web site administrator should know about
 FAL maintenance and permissions.
 

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -246,7 +246,7 @@ You are on your own.
 
 The simplest solution is to create a database entry into
 table "sys\_file\_reference" by using the database connection
-class provided by TYPO3 CMS.
+class provided by TYPO3.
 
 A cleaner solution using Extbase requires far more work. An example
 can be found here: https://github.com/helhum/upload_example

--- a/Documentation/ApiOverview/Fal/UsingFal/Index.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/Index.rst
@@ -8,7 +8,7 @@ Using FAL
 
 This chapter explains the principles on how to use FAL in
 various contexts, like the frontend or during extension
-or TYPO3 CMS Core development, by the way of references
+or TYPO3 Core development, by the way of references
 or useful examples for common use-cases.
 
 .. toctree::

--- a/Documentation/ApiOverview/Fal/UsingFal/Tca.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/Tca.rst
@@ -9,7 +9,7 @@ TCA Definition
 This chapter explains how to create a field that makes it possible to
 create relations to files.
 
-TYPO3 CMS provides a convenient API for this.
+TYPO3 provides a convenient API for this.
 Let's look at the TCA configuration the `image` field of the `tt_content`
 table for example (with some parts skipped).
 

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -87,8 +87,8 @@ In your extension, the following directory structure should be used for Fluid fi
         ├── Partials
         └── Templates
 
-This directory structure is the convention used by TYPO3 CMS. When using Fluid outside of
-TYPO3 CMS you can use any folder structure you like.
+This directory structure is the convention used by TYPO3. When using Fluid outside of
+TYPO3 you can use any folder structure you like.
 
 If you are using Extbase controller actions in combination with Fluid,
 Extbase defines how files and directories should be named within these directories.

--- a/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
@@ -36,7 +36,7 @@ FormEngine are abstracted and may come from "elsewhere", still leading to the fo
 This makes FormEngine an incredible flexible construct. The basic idea is "feed something that looks like TCA
 and render forms that have the full power of TCA but look like all other parts of the backend".
 
-The FormEngine code base has been significantly refactored in TYPO3 CMS version 7 and version 8 to be much more
+The FormEngine code base has been significantly refactored in TYPO3 version 7 and version 8 to be much more
 flexible, more easy to use and extend, and much more powerful than before. This is an ongoing process and some
 areas still need a major overhaul. The current state of the documentation aims to explain the main constructs of
 FormEngine and gives an insight on how to re-use, adapt and extend it with extensions. The Core Team expects to see more

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -8,7 +8,7 @@
 Icon API
 ========
 
-TYPO3 CMS provides an icon API for all icons in the TYPO3 backend.
+TYPO3 provides an icon API for all icons in the TYPO3 backend.
 
 .. index:: IconRegistry; registerIcon
 .. _icon-registration:

--- a/Documentation/ApiOverview/Internationalization/Introduction.rst
+++ b/Documentation/ApiOverview/Internationalization/Introduction.rst
@@ -4,7 +4,7 @@
 Introduction
 ============
 
-Except for some low level functions, TYPO3 CMS exclusively uses localizable
+Except for some low level functions, TYPO3 exclusively uses localizable
 strings for all labels displayed in the backend. This means that the whole user
 interface may be translated. The encoding is strictly UTF-8.
 

--- a/Documentation/ApiOverview/Internationalization/TranslationServer/Pootle.rst
+++ b/Documentation/ApiOverview/Internationalization/TranslationServer/Pootle.rst
@@ -15,4 +15,4 @@ To manage translations of extensions uploaded to the TYPO3 Extension Repository 
 the TYPO3 community runs an `official translation server <https://translation.typo3.org/>`_,
 based on `Pootle <https://pootle.translatehouse.org/>`__. Localization files of TER extensions
 in English are uploaded on that server and translations are packaged nightly.
-They can be fetched in the TYPO3 CMS backend, via the Install Tool and on the command line.
+They can be fetched in the TYPO3 backend, via the Install Tool and on the command line.

--- a/Documentation/ApiOverview/JavaScript/RequireJS/Index.rst
+++ b/Documentation/ApiOverview/JavaScript/RequireJS/Index.rst
@@ -6,7 +6,7 @@
 RequireJS in the TYPO3 Backend
 ==============================
 
-Since TYPO3 CMS 7 it is possible to use RequireJS in the backend.
+Since TYPO3 v7 it is possible to use RequireJS in the backend.
 A short explanation: RequireJS enables developers to have some kind of
 dependency handling for JavaScript. The JavaScript is written as so-called
 "Asynchronous Module Definition" (AMD).

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -17,7 +17,7 @@ Mail API
    emails out-of-the-box. The email contents are built with the Fluid Templating Engine.
    :doc:`ext_core:Changelog/10.3/Feature-90266-Fluid-basedTemplatedEmails`
 
-TYPO3 CMS provides a RFC-compliant mailing solution based on
+TYPO3 provides a RFC-compliant mailing solution based on
 `symfony/mailer <https://symfony.com/doc/current/components/mailer.html>`__
 for sending emails and
 `symfony/mime <https://symfony.com/doc/current/components/mime.html>`__
@@ -273,7 +273,7 @@ To send the spooled mails you need to run the following CLI command:
 .. code-block:: bash
 
    vendor/bin/typo3 mailer:spool:send
-   
+
 This command can be set up to be run periodically using the TYPO3 Scheduler.
 
 .. index::

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -5,7 +5,7 @@
 Namespaces
 ==========
 
-Since version 6.0, TYPO3 CMS uses PHP namespaces for all classes in the Core.
+Since version 6.0, TYPO3 uses PHP namespaces for all classes in the Core.
 
 The general structure of namespaces is the following:
 

--- a/Documentation/ApiOverview/PageTypes/Introduction.rst
+++ b/Documentation/ApiOverview/PageTypes/Introduction.rst
@@ -74,7 +74,7 @@ Each array has the following options available:
  - :Key:
          type
    :Description:
-         Can be "sys" or "web". This is purely informative, as TYPO3 CMS does
+         Can be "sys" or "web". This is purely informative, as TYPO3 does
          nothing with that piece of data.
 
 

--- a/Documentation/ApiOverview/ParsingHtml/Index.rst
+++ b/Documentation/ApiOverview/ParsingHtml/Index.rst
@@ -7,7 +7,7 @@
 Parsing HTML
 ============
 
-TYPO3 CMS provides its own HTML parsing class:
+TYPO3 provides its own HTML parsing class:
 :code:`\TYPO3\CMS\Core\Html\HtmlParser`. This chapter
 shows some example uses.
 

--- a/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
@@ -6,7 +6,7 @@
 Bootstrapping
 =============
 
-TYPO3 CMS has a clean bootstrapping process driven mostly
+TYPO3 has a clean bootstrapping process driven mostly
 by class :php:`\TYPO3\CMS\Core\Core\Bootstrap`. This class is initialized by
 calling  :php:`Bootstrap::init()` and serves as an entry point for later calling
 an application class, depending on several context-dependant constraints.
@@ -86,7 +86,7 @@ Example of bootstrapping the TYPO3 Backend:
 Initialization
 ==============
 
-Whenever a call to TYPO3 CMS is made, the application goes through a
+Whenever a call to TYPO3 is made, the application goes through a
 bootstrapping process managed by a dedicated API. This process is also
 used in the frontend, but only the backend process is described here.
 
@@ -194,7 +194,7 @@ Application context
 ===================
 
 Each request, no matter if it runs from the command line or through HTTP,
-runs in a specific *application context*. TYPO3 CMS provides exactly three built-in
+runs in a specific *application context*. TYPO3 provides exactly three built-in
 contexts:
 
 * ``Production`` (default) - should be used for a live site
@@ -206,7 +206,7 @@ The context TYPO3 runs in is specified through the environment variable
 
 .. code-block:: bash
 
-   # run the TYPO3 CMS CLI commands in development context
+   # run the TYPO3 CLI commands in development context
    TYPO3_CONTEXT=Development ./bin/typo3
 
 

--- a/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
@@ -11,7 +11,7 @@
 Middlewares (Request handling)
 ==============================
 
-TYPO3 CMS has implemented `PSR-15`_ for handling incoming HTTP requests. The
+TYPO3 has implemented `PSR-15`_ for handling incoming HTTP requests. The
 implementation within TYPO3 is often called "Middlewares", as PSR-15 consists of
 two interfaces where one is called :php:`Middleware`.
 

--- a/Documentation/ApiOverview/Services/Developer/Implementing.rst
+++ b/Documentation/ApiOverview/Services/Developer/Implementing.rst
@@ -60,7 +60,7 @@ file. Let's look at what is inside.
         )
     );
 
-A service is registered with TYPO3 CMS by calling
+A service is registered with TYPO3 by calling
 :code:`\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService()`.
 This method takes the following parameters:
 
@@ -200,5 +200,5 @@ should provide the methods mentioned in :ref:`Service Implementation
 
 It should then implement the methods that you defined
 for your service's public API, plus whatever method is
-relevant from the base TYPO3 CMS service API, which is
+relevant from the base TYPO3 service API, which is
 described in details in :ref:`the next chapter <services-developer-service-api>`.

--- a/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
+++ b/Documentation/ApiOverview/Services/Developer/ServiceApi.rst
@@ -173,7 +173,7 @@ checkExec
 
    The method relies on :php:`\TYPO3\CMS\Core\Utility\CommandUtility::checkCommand()`
    to find the executables, so it will search through the paths defined/allowed by
-   the TYPO3 CMS configuration.
+   the TYPO3 configuration.
 
 deactivateService
    Internal method to temporarily deactivate a service at run-time, if it
@@ -193,7 +193,7 @@ cleaning up temporary files.
 
 checkInputFile
    Checks if a file exists and is readable within the paths allowed by
-   the TYPO3 CMS configuration.
+   the TYPO3 configuration.
 
 readFile
    Reads the content of a file and returns it as a string. Calls on

--- a/Documentation/ApiOverview/Services/Developer/ServiceRelatedApi.rst
+++ b/Documentation/ApiOverview/Services/Developer/ServiceRelatedApi.rst
@@ -27,7 +27,7 @@ This extension management class contains three methods related to
 services:
 
 addService
-  This method is used to register services with TYPO3 CMS. It checks for
+  This method is used to register services with TYPO3. It checks for
   availability of a service with regards to OS dependency (if any) and
   fills the :code:`$GLOBALS['T3_SERVICES']` array, where information
   about all registered services is kept.

--- a/Documentation/ApiOverview/Services/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Services/Introduction/Index.rst
@@ -41,10 +41,10 @@ The whole Services API works as a registry. Services are registered
 with a number of parameters, and each service can easily be overridden
 by another one with improved features or more specific capabilities,
 for example. This can be achieved without having to change the original
-code of TYPO3 CMS or of an extension.
+code of TYPO3 or of an extension.
 
 Services are simply PHP classes packaged inside an extension.
-The usual way to instantiate a class in TYPO3 CMS is:
+The usual way to instantiate a class in TYPO3 is:
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php

--- a/Documentation/ApiOverview/Services/UsingServices/ServicePrecedence.rst
+++ b/Documentation/ApiOverview/Services/UsingServices/ServicePrecedence.rst
@@ -8,7 +8,7 @@ Service precedence
 
 Several services may be declared to do the same job. What will
 distinguish them is two intrinsic properties of services: priority and
-quality. Priority tells TYPO3 CMS which service should be called first.
+quality. Priority tells TYPO3 which service should be called first.
 Normal priorities vary between 0 and 100, but can exceptionally be set
 to higher values (no maximum). When two services of equal priority are
 found, the system will use the service with the best quality.
@@ -25,7 +25,7 @@ by the service. There may be several services who can perform the same
 task (e.g. extracting meta data from a file), but one may be able to
 do that much better than the other because it is able to use a third-
 party application. However if that third-party application is not
-available, neither will this service. In this case TYPO3 CMS can fall back
+available, neither will this service. In this case TYPO3 can fall back
 on the lower quality service which will still be better than nothing.
 Quality varies between 0-100.
 

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -8,7 +8,7 @@
 Versioning and Workspaces
 =========================
 
-TYPO3 CMS provides a feature called "workspaces", whereby changes
+TYPO3 provides a feature called "workspaces", whereby changes
 can be made to the content of the web site without affecting the
 currently visible (live) version. Changes can be previewed and
 go through an approval process before publishing.

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -15,7 +15,7 @@ XCLASSes (Extending Classes)
 Introduction
 ============
 
-XCLASSing is a mechanism in TYPO3 CMS to extend classes or overwrite methods from the Core or extensions
+XCLASSing is a mechanism in TYPO3 to extend classes or overwrite methods from the Core or extensions
 with one's own code. This enables a developer to easily change a given functionality,
 if other options like :ref:`hooks <hooks>`, signals, :ref:`events <EventDispatcher>`
 or the dependency injection mechanisms do not work or do not exist.

--- a/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/HandlingDeprecations.rst
+++ b/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/HandlingDeprecations.rst
@@ -9,5 +9,5 @@ Handling Deprecation
 
 .. note::
 
-   How to handle deprecations in TYPO3 CMS is covered in the
+   How to handle deprecations in TYPO3 is covered in the
    Contribution Guide: :ref:`t3contribute:deprecations`.

--- a/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/FileStructure.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/FileStructure.rst
@@ -30,7 +30,7 @@ Namespace
 =========
 
 The namespace declaration of each PHP file in the TYPO3 Core shows
-where the file belongs inside TYPO3 CMS. The namespace starts with
+where the file belongs inside TYPO3. The namespace starts with
 :php:`TYPO3\CMS`, then the extension name in UpperCamelCase, a
 backslash and then the name of the subfolder of :file:`Classes/`, in
 which the file is located (if any). E.g. the file

--- a/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/GeneralRequirementsForPhpFiles.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpFileFormatting/GeneralRequirementsForPhpFiles.rst
@@ -127,5 +127,5 @@ All TYPO3 source files use the UTF-8 character set without byte order
 mark (BOM). Encoding declarations like `declare(encoding = 'utf-8');`
 must not be used. They might lead to problems, especially in
 :file:`ext_tables.php` and :file:`ext_localconf.php` files of extensions, which are
-merged internally in TYPO3 CMS. Files from third-party libraries may
+merged internally in TYPO3. Files from third-party libraries may
 have different encodings.

--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -5,7 +5,7 @@
 Introduction
 ============
 
-This chapter defines coding guidelines for the TYPO3 CMS project.
+This chapter defines coding guidelines for the TYPO3 project.
 Following these guidelines is mandatory for TYPO3 Core  developers and
 contributors to the TYPO3 Core .
 

--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -7,7 +7,7 @@ TSconfig
 ========
 
 "User TSconfig" and "page TSconfig" are very flexible concepts for
-adding fine-grained configuration to the backend of TYPO3 CMS. It is a text-
+adding fine-grained configuration to the backend of TYPO3. It is a text-
 based configuration system where you assign values to keyword strings,
 using the TypoScript syntax. The :doc:`TSconfig Reference <t3tsconfig:Index>`
 describes in detail how this works and what can be done with it.

--- a/Documentation/Configuration/Typo3ConfVars/Index.rst
+++ b/Documentation/Configuration/Typo3ConfVars/Index.rst
@@ -40,11 +40,11 @@ This file overrides default settings from :file:`typo3/sysext/core/Configuration
 .. important::
 
    Since configuration settings can be manipulated from within the
-   TYPO3 CMS backend, the :file:`typo3conf/LocalConfiguration.php`
+   TYPO3 backend, the :file:`typo3conf/LocalConfiguration.php`
    must be writable by the web server user.
 
 The local configuration file is basically a long array which is simply returned
-when the file is included. It represents the global TYPO3 CMS configuration.
+when the file is included. It represents the global TYPO3 configuration.
 This configuration can be modified/extended/overridden by extensions,
 by setting configuration options inside an extension's
 :file:`ext_localconf.php` file. :ref:`See extension files and locations <extension-files-locations>`
@@ -127,7 +127,7 @@ may themselves be arrays.
 The configuration categories are:
 
 BE
-   :ref:`Options related to the TYPO3 CMS backend <typo3ConfVars_be>`.
+   :ref:`Options related to the TYPO3 backend <typo3ConfVars_be>`.
 
 DB
    :ref:`Database connection configuration <typo3ConfVars_db>`.
@@ -209,7 +209,7 @@ values programmatically if needed.
 
 :file:`typo3conf/AdditionalConfiguration.php` is a plain PHP file.
 There are no specific rules about what it may contain. However since
-the code is included on **every** request to TYPO3 CMS
+the code is included on **every** request to TYPO3
 - whether frontend or backend - you should avoid inserting code
 which requires heavy duty processing.
 
@@ -232,7 +232,7 @@ which requires heavy duty processing.
 File DefaultConfiguration.php
 =============================
 
-TYPO3 CMS comes with some default settings, which are defined in
+TYPO3 comes with some default settings, which are defined in
 file :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`.
 
 This is the base configuration, the other files like :file:`LocalConfiguration.php`

--- a/Documentation/Configuration/TypoScriptSyntax/Details/MythsFaqAcknowledgements.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Details/MythsFaqAcknowledgements.rst
@@ -23,7 +23,7 @@ when the TypoScript syntax is applied to create TypoScript Templates
 then it begins to look like programming.
 
 In any case TypoScript is **not** comparable to a scripting language like
-PHP or JavaScript. In fact, if TYPO3 CMS offers any scripting language it
+PHP or JavaScript. In fact, if TYPO3 offers any scripting language it
 is PHP itself! TypoScript is only an API which is often used to
 configure underlying PHP code.
 

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/Contexts.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/Contexts.rst
@@ -7,13 +7,13 @@ Contexts
 ========
 
 There are two contexts where TypoScript is used: templates, where
-TypoScript is used to actually define what will appear in the TYPO3 CMS
+TypoScript is used to actually define what will appear in the TYPO3
 frontend, and TSconfig, where it is used to configure settings of the
 TYPO3 backend. TSconfig is further subdivided into **user TSconfig**
 (defined for backend users or user groups) and **page TSconfig** (defined
 for pages in the page tree).
 
-Page TSconfig is used for customizing the TYPO3 CMS backend according
+Page TSconfig is used for customizing the TYPO3 backend according
 to where users will be working along the page tree. User TSconfig
 is used to customize what elements are visible for users and groups
 or change the behavior of some elements.
@@ -27,6 +27,6 @@ this manual).
 
 .. note::
 
-   TYPO3 CMS provides a :ref:`TypoScript parser <typoscript-syntax-typoscript-parser-api>`
+   TYPO3 provides a :ref:`TypoScript parser <typoscript-syntax-typoscript-parser-api>`
    whose API can be used by any developer. In theory this means that new
-   contexts of TypoScript usage can be created by TYPO3 CMS extensions.
+   contexts of TypoScript usage can be created by TYPO3 extensions.

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
@@ -145,7 +145,7 @@ DIR      This includes all files from a directory relative to :php:`\TYPO3\CMS\C
 Conditions
 ==========
 
-Since TYPO3 CMS 7, it is possible to use conditions on include directives.
+Since TYPO3 v7, it is possible to use conditions on include directives.
 The conditions are the same as was presented in the :ref:`previous chapter <typoscript-syntax-conditions>`.
 The files or directories will be included only if the condition is met.
 
@@ -173,7 +173,7 @@ Best practices
 ==============
 
 The option to filter by extension has been included exactly for the
-purpose of covering as many use cases as possible. In TYPO3 CMS we often
+purpose of covering as many use cases as possible. In TYPO3 we often
 have many different ways of configuring something, with pros and cons
 and the extended inclusion command serves this purpose of letting you
 organize your files with different directories using whichever extension

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/Introduction.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/Introduction.rst
@@ -25,7 +25,7 @@ Referring to :code:`myObject` we might call it: "*an object with the value
 Furthermore 'myProperty' has its own two properties, 'firstProperty'
 and 'secondProperty' with a value each ([value 3] and [value 4]).*"
 
-The TYPO3 CMS backend contains tools that can be used to visualize the
+The TYPO3 backend contains tools that can be used to visualize the
 tree structure of TypoScript. They are described in the relevant
 section further of the two using reference documents
 :ref:`TypoScript Reference <t3tsref:typoscript-syntax-typoscript-templates>` and

--- a/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/CustomTypoScript.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/CustomTypoScript.rst
@@ -12,7 +12,7 @@ Parsing Custom TypoScript
    This example will probably seem rather quaint. However it is
    still useful to illustrate this topic.
 
-Let's imagine that you have created an application in TYPO3 CMS, for
+Let's imagine that you have created an application in TYPO3, for
 example a plug-in. You have defined certain parameters editable
 directly in the form fields of the plug-in content element. However
 you want advanced users to be able to set up more detailed parameters.

--- a/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/Introduction.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/Introduction.rst
@@ -7,7 +7,7 @@
 Introduction
 ============
 
-If you want to deploy TypoScript in your own TYPO3 CMS applications it is
+If you want to deploy TypoScript in your own TYPO3 applications it is
 really easy. The TypoScript parser is readily available to you and the
 only thing that may take a little more effort than the instantiation
 of PHP is if you want to define conditions for TypoScript.
@@ -19,6 +19,6 @@ TypoScript.
 
 .. note::
 
-   The following pages are for experienced TYPO3 CMS developers
+   The following pages are for experienced TYPO3 developers
    and require a good knowledge of PHP.
 

--- a/Documentation/ExtensionArchitecture/Concepts/Introduction.rst
+++ b/Documentation/ExtensionArchitecture/Concepts/Introduction.rst
@@ -5,7 +5,7 @@
 Introduction
 ============
 
-TYPO3 CMS is entirely built around the concept of extensions. The Core itself
+TYPO3 is entirely built around the concept of extensions. The Core itself
 is entirely comprised of extensions, called "system extensions".
 Some are required and will always be activated. Others can be activated
 or deactivated at will.
@@ -16,7 +16,7 @@ Many more extensions - developed by the community - are available in the
 Yet more extensions are not officially published and are available straight
 from source code repositories like `GitHub <https://github.com/>`_.
 
-It is also possible to set up TYPO3 CMS using Composer. This opens
+It is also possible to set up TYPO3 using Composer. This opens
 the possibility of including any library published on
 `Packagist <https://packagist.org/>`_.
 
@@ -41,7 +41,7 @@ standards or recommendations. Some of these types by convention are:
    CSS, JavaScript, Fluid templating files, TypoScript etc.). The
    :ref:`Sitepackage Tutorial <t3sitepackage:introduction>` covers this in depth.
 
--  **Distributions** are fully packaged TYPO3 CMS web installations,
+-  **Distributions** are fully packaged TYPO3 web installations,
    complete with files, templates, extensions, etc. Distributions are
    covered :ref:`in their own chapter <distribution>`.
 
@@ -99,7 +99,7 @@ what main resources and libraries they contain. The system extensions
 are located in directory :file:`typo3/sysext`.
 
 Core
-  As its name implies, this extension is crucial to the working of TYPO3 CMS.
+  As its name implies, this extension is crucial to the working of TYPO3.
   It defines the main database tables (BE users, BE groups, pages and all the
   "sys\_*" tables. It also contains the default global configuration
   (in :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`). Last
@@ -107,7 +107,7 @@ Core
   to describe here.
 
 backend
-  This system extension provides all that is necessary to run the TYPO3 CMS
+  This system extension provides all that is necessary to run the TYPO3
   backend. This means quite a few PHP classes, a lot of controllers and Fluid templates.
 
 frontend
@@ -119,7 +119,7 @@ frontend
 
 Extbase
   Extbase is an MVC framework, with the "View" part being actually the system extension "fluid".
-  Not all of the TYPO3 CMS backend is written in Extbase, but some modules are.
+  Not all of the TYPO3 backend is written in Extbase, but some modules are.
 
 Fluid
   Fluid is a templating engine. It forms the "View" part of the MVC framework.
@@ -131,5 +131,5 @@ Fluid
   with Extbase (where it is the default template engine), but also in non-extbase extensions.
 
 install
-  This system extension is the package containing the TYPO3 CMS Install Tool.
+  This system extension is the package containing the TYPO3 Install Tool.
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendModulesWithExtbase/BackendTemplateViewWithExtbase.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendModulesWithExtbase/BackendTemplateViewWithExtbase.rst
@@ -97,5 +97,5 @@ the "beuser" extension:
 
 
 The best resources for learning is to look at existing modules
-from TYPO3 CMS. With the information given here, you should be
+from TYPO3. With the information given here, you should be
 able to find your way around the code.

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/General/BackendInterface.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/General/BackendInterface.rst
@@ -34,7 +34,7 @@ Module menu
 
   .. note::
 
-     In the TYPO3 CMS world, "module" is typically used for
+     In the TYPO3 world, "module" is typically used for
      the backend. Extension components which add features in the frontend
      are referred to as "plugins".
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/Index.rst
@@ -6,7 +6,7 @@
 Backend modules
 ===============
 
-TYPO3 CMS offers a number of ways to attach custom functionality to the
+TYPO3 offers a number of ways to attach custom functionality to the
 backend. They are described in this chapter.
 
 GENERAL

--- a/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
@@ -14,8 +14,8 @@ This chapter describes the main steps in creating a new distribution.
 Concept of distributions
 ========================
 
-The distributions are full TYPO3 CMS websites that only need to be unpacked.
-They offer a simple and quick introduction to the use of the TYPO3 CMS. The
+The distributions are full TYPO3 websites that only need to be unpacked.
+They offer a simple and quick introduction to the use of the TYPO3. The
 best known distribution is the `Introduction Package <https://extensions.typo3.org/extension/introduction/>`__.
 Distributions are easiest to install via the :ref:`Extension Manager <extension-manager>` (EM)
 under "Get preconfigured distribution".
@@ -123,7 +123,7 @@ to :file:`Initialisation/Site/<SITE_IDENTIFIER>/config.yaml`.
 Database Data
 -------------
 
-The database data is delivered as TYPO3 CMS export file under :file:`Initialisation/data.xml`.
+The database data is delivered as TYPO3 export file under :file:`Initialisation/data.xml`.
 
 Generate this file by exporting your whole TYPO3 instance
 from the root of the page tree using the :ref:`export module <ext_impexp:export>`:
@@ -244,7 +244,7 @@ Test Your Distribution
 ======================
 
 To test your distribution, simply copy your extension to an empty
-TYPO3 CMS installation and try to install it from the Extension
+TYPO3 installation and try to install it from the Extension
 Manager.
 
 To test a distribution locally without uploading to TER, just install
@@ -266,7 +266,7 @@ locally *without* uploading to TER first.
 .. warning::
 
    It is not enough to clean all files and the page tree if you want to
-   try again to install your distribution. Indeed, TYPO3 CMS remembers that it
+   try again to install your distribution. Indeed, TYPO3 remembers that it
    previously imported your distribution and will skip any known files and
    the database import. Make sure to clean the table "sys_registry" if you want
    to work around that, or, even better, install a new blank TYPO3 to test again.

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
@@ -9,7 +9,7 @@ Storing the changes
 
 There are various ways to store changes to :php:`$GLOBALS['TCA']`. They
 depend - partly - on what you are trying to achieve and - a lot -
-on the version of TYPO3 CMS which you are targeting. The TCA can only be 
+on the version of TYPO3 which you are targeting. The TCA can only be
 changed from within an extension.
 
 
@@ -51,7 +51,7 @@ Core APIs.
 Storing in the overrides folder
 -------------------------------
 
-Since TYPO3 CMS 6.2 (6.2.1 to be precise) changes to :php:`$GLOBALS['TCA']`
+Since TYPO3 v6.2 (v6.2.1 to be precise) changes to :php:`$GLOBALS['TCA']`
 must be stored inside a folder called :file:`Configuration/TCA/Overrides`.
 For clarity files should be named along the pattern
 :file:`<tablename>.php`.
@@ -94,9 +94,9 @@ The advantage of this method is that all such changes are incorporated into
 Storing in ext_tables.php files
 -------------------------------
 
-Until TYPO3 CMS 6.1 (still supported for 6.2) changes to :php:`$GLOBALS['TCA']` are packaged
+Until TYPO3 v6.1 (still supported for v6.2) changes to :php:`$GLOBALS['TCA']` are packaged
 into an extension's :file:`ext_tables.php` file. This is strongly discouraged in more recent
-versions of TYPO3 CMS.
+versions of TYPO3.
 
 Nowadays the only usecase for TCA changes in :file:`ext_tables.php` is to override TCA definitions
 done in the :file:`ext_tables.php` of a legacy extension. TCA overrides cannot be used in this case

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Index.rst
@@ -16,7 +16,7 @@ Upgrade wizards
    :doc:`ext_core:Changelog/9.4/Feature-86076-NewAPIForUpgradeWizards`
    This chapter was updated to use the new API.
 
-TYPO3 CMS offers a way for extension authors to provide automated updates for
+TYPO3 offers a way for extension authors to provide automated updates for
 extensions. TYPO3 itself provides upgrade wizards to ease updates of TYPO3
 versions. This chapter will explain the concept and how to write upgrade
 wizards.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -67,13 +67,13 @@ A basic installation
 ====================
 
 To follow this document, it might help to have a totally trimmed down
-installation of TYPO3 CMS with *only* the Core and the required system
+installation of TYPO3 with *only* the Core and the required system
 extensions at hand.
 
 The installation process is covered in the :doc:`Getting started
 Guide <t3start:Index>`.
 You should perform the basic installation steps and not install any
-distribution. This will give you the "lightest" possible version of TYPO3 CMS.
+distribution. This will give you the "lightest" possible version of TYPO3.
 
 In your basic installation, go to the :guilabel:`Admin Tools > Extensions`
 module. You will see all extensions installed by Composer are activated by

--- a/Documentation/Security/GuidelinesEditors/Index.rst
+++ b/Documentation/Security/GuidelinesEditors/Index.rst
@@ -115,7 +115,7 @@ should get in touch with the system provider to solve this issue.
 Notify at login
 ---------------
 
-TYPO3 CMS offers the feature to notify backend users by email, when
+TYPO3 offers the feature to notify backend users by email, when
 somebody logs in from your account. If you set this option in your
 user settings, you will receive an email from TYPO3 each time you (or
 "someone") logs in using your login details. Receiving such a

--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -98,7 +98,7 @@ definitely discuss your intention with the team.
 TYPO3 Core updates
 ==================
 
-Since TYPO3 CMS 6.2, the Install Tool allows integrators to update the
+Since TYPO3 v6.2, the Install Tool allows integrators to update the
 TYPO3 Core with a click of a button. This feature can be found under
 "Important actions" and it checks/installs revision updates only (e.g.
 bug fixes and security updates).

--- a/Documentation/Security/SecurityTeam/Index.rst
+++ b/Documentation/Security/SecurityTeam/Index.rst
@@ -64,7 +64,7 @@ of the appropriate component of the system, after verifying the
 problem. A fix for the vulnerability will be developed, carefully
 tested and reviewed. Together with a public security bulletin, a TYPO3
 Core update will be released. Please see next chapter for further
-details about TYPO3 CMS versions and security bulletins.
+details about TYPO3 versions and security bulletins.
 
 
 Security issues in TYPO3 extensions


### PR DESCRIPTION
Releases: main, 11.5