### PR TITLE
Add clarification for how to use log channels

### DIFF
--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -85,7 +85,7 @@ More examples:
 
     // for class \Documentation\Examples\Controller\FalExampleController
     $GLOBALS['TYPO3_CONF_VARS']['LOG']
-        ['Documentation']['Examples']['Controller']['FalExampleController'] \
+        ['Documentation']['Examples']['Controller']['FalExampleController']
         ['writerConfiguration'] = [
             // ...
     ];

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -77,13 +77,34 @@ use the following configuration:
 This overwrites the default configuration shown in the first example for classes
 located in the namespace :code:`\Documentation\Examples\Controller`.
 
-For extension "foo" with key "tx_foo" (not using namespaces), the configuration would be located at:
+More examples:
 
 .. code-block:: php
 
-   $GLOBALS['TYPO3_CONF_VARS']['LOG']['Tx']['Foo']['writerConfiguration'] = [
-      // ...
-   ];
+    // configure logging ...
+
+    // for class \Documentation\Examples\Controller\FalExampleController
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']
+        ['Documentation']['Examples']['Controller']['FalExampleController'] \
+        ['writerConfiguration'] = [
+            // ...
+    ];
+
+    // for channel "security"
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']
+        ['security']
+        ['writerConfiguration'] = [
+             // ...
+    ];
+
+    // For extension "foo" with key "tx_foo" (not using namespaces):
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']
+        ['Tx']['Foo']
+        ['writerConfiguration'] = [
+            // ...
+    ];
+
+For more information about channels, see :ref:`logging-channels`.
 
 An arbitrary number of writers can be added for every severity level (INFO, WARNING, ERROR, ...).
 The configuration is applied to log entries of the particular severity level

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -85,7 +85,7 @@ More examples:
 
     // for class \T3docs\Examples\Controller\FalExampleController
     $GLOBALS['TYPO3_CONF_VARS']['LOG']
-        ['Documentation']['Examples']['Controller']['FalExampleController']
+        ['T3docs']['Examples']['Controller']['FalExampleController']
         ['writerConfiguration'] = [
             // ...
     ];

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -83,7 +83,7 @@ More examples:
     :caption: config/system/additional.php | typo3conf/system/additional.php
     // configure logging ...
 
-    // for class \Documentation\Examples\Controller\FalExampleController
+    // for class \T3docs\Examples\Controller\FalExampleController
     $GLOBALS['TYPO3_CONF_VARS']['LOG']
         ['Documentation']['Examples']['Controller']['FalExampleController']
         ['writerConfiguration'] = [

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -80,7 +80,7 @@ located in the namespace :code:`\Documentation\Examples\Controller`.
 More examples:
 
 .. code-block:: php
-
+    :caption: config/system/additional.php | typo3conf/system/additional.php
     // configure logging ...
 
     // for class \Documentation\Examples\Controller\FalExampleController

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -81,6 +81,7 @@ More examples:
 
 .. code-block:: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
+
     // configure logging ...
 
     // for class \T3docs\Examples\Controller\FalExampleController

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -264,7 +264,7 @@ injection, overwrites possible class attributes:
      }
    }
 
-The instantiated :php:`LoggerInterface` will now have the name "security",
+The instantiated logger will now have the channel "security",
 instead of the default which would be a combination of namespace and class of
 the instantiating class, such as `MyVendor.MyExtension.Service.MyClass`.
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -228,6 +228,8 @@ Registration via class attribute for :php:`LoggerInterface` injection:
 
 .. code-block:: php
 
+   namespace Myvendor\Myextension\Service\MyClass;
+
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;
    #[Channel('security')]
@@ -241,10 +243,12 @@ Registration via class attribute for :php:`LoggerInterface` injection:
      }
    }
 
-Registration via parameter attribute for :php:`LoggerInterface` injection,
-overwrites possible class attributes:
+Registration via parameter attribute for :php:`LoggerInterface`
+injection, overwrites possible class attributes:
 
 .. code-block:: php
+
+   namespace Myvendor\Myextension\Service\MyClass;
 
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;
@@ -259,6 +263,40 @@ overwrites possible class attributes:
          // do your magic
      }
    }
+
+The instantiated :php:`LoggerInterface` will now have the name "security",
+instead of the default which would be a combination of namespace and class of
+the instantiating class, such as 'Myvendor.Myextension.Service.MyClass".
+
+Using the Channel
+-----------------
+
+The name "security" can then be used in the logging configuration:
+
+.. code-block:: php
+    :caption: typo3conf/system/additional.php
+
+    use TYPO3\CMS\Core\Core\Environment;
+    use TYPO3\CMS\Core\Log\LogLevel;
+    use TYPO3\CMS\Core\Log\Writer\FileWriter;
+
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']['security']['writerConfiguration'] = [
+        LogLevel::DEBUG => [
+            FileWriter::class => [
+                'logFile' => Environment::getVarPath() . '/log/' . 'security.log'
+            ]
+        ],
+    ];
+
+The written log messages will then have the component name "security", such as:
+
+.. code-block:: text
+    :caption: var/log/security.log
+
+    Fri, 21 Oct 2022 16:26:13 +0000 [DEBUG] ... component="security": ...
+
+For more examples for configuring the logging see
+:ref:`logging-configuration-writer`.
 
 .. _logging-logger-examples:
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -280,13 +280,15 @@ The name "security" can then be used in the logging configuration:
     use TYPO3\CMS\Core\Log\LogLevel;
     use TYPO3\CMS\Core\Log\Writer\FileWriter;
 
-    $GLOBALS['TYPO3_CONF_VARS']['LOG']['security']['writerConfiguration'] = [
-        LogLevel::DEBUG => [
-            FileWriter::class => [
-                'logFile' => Environment::getVarPath() . '/log/' . 'security.log'
-            ]
-        ],
-    ];
+    $GLOBALS['TYPO3_CONF_VARS']['LOG']
+        ['security']
+        ['writerConfiguration'] = [
+            LogLevel::DEBUG => [
+                FileWriter::class => [
+                    'logFile' => Environment::getVarPath() . '/log/' . 'security.log'
+                ]
+            ],
+        ];
 
 The written log messages will then have the component name "security", such as:
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -227,6 +227,7 @@ and the classic component name will be used instead.
 Registration via class attribute for :php:`LoggerInterface` injection:
 
 .. code-block:: php
+   :caption: EXT:my_extension/Classes/Service/MyClass.php
 
    namespace Myvendor\Myextension\Service\MyClass;
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -249,6 +249,7 @@ Registration via parameter attribute for :php:`LoggerInterface`
 injection, overwrites possible class attributes:
 
 .. code-block:: php
+   :caption: EXT:my_extension/Service/MyClass.php
 
    namespace Myvendor\Myextension\Service\MyClass;
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -252,6 +252,7 @@ injection, overwrites possible class attributes:
 
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;
+
    class MyClass
    {
      private LoggerInterface $logger;

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -266,7 +266,7 @@ injection, overwrites possible class attributes:
 
 The instantiated :php:`LoggerInterface` will now have the name "security",
 instead of the default which would be a combination of namespace and class of
-the instantiating class, such as 'Myvendor.Myextension.Service.MyClass".
+the instantiating class, such as `MyVendor.MyExtension.Service.MyClass`.
 
 Using the Channel
 -----------------

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -229,7 +229,7 @@ Registration via class attribute for :php:`LoggerInterface` injection:
 .. code-block:: php
    :caption: EXT:my_extension/Classes/Service/MyClass.php
 
-   namespace Myvendor\Myextension\Service\MyClass;
+   namespace MyVendor\MyExtension\Service\MyClass;
 
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -274,7 +274,7 @@ the instantiating class, such as `MyVendor.MyExtension.Service.MyClass`.
 Using the Channel
 -----------------
 
-The name "security" can then be used in the logging configuration:
+The channel "security" can then be used in the logging configuration:
 
 .. code-block:: php
     :caption: config/system/additional.php | typo3conf/system/additional.php

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -274,7 +274,7 @@ Using the Channel
 The name "security" can then be used in the logging configuration:
 
 .. code-block:: php
-    :caption: typo3conf/system/additional.php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
 
     use TYPO3\CMS\Core\Core\Environment;
     use TYPO3\CMS\Core\Log\LogLevel;

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -290,7 +290,7 @@ The name "security" can then be used in the logging configuration:
             ],
         ];
 
-The written log messages will then have the component name "security", such as:
+The written log messages will then have the component name `"security"`, such as:
 
 .. code-block:: text
     :caption: var/log/security.log

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -232,6 +232,7 @@ Registration via class attribute for :php:`LoggerInterface` injection:
 
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;
+
    #[Channel('security')]
    class MyClass
    {

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -288,7 +288,7 @@ The name "security" can then be used in the logging configuration:
         ['writerConfiguration'] = [
             LogLevel::DEBUG => [
                 FileWriter::class => [
-                    'logFile' => Environment::getVarPath() . '/log/' . 'security.log'
+                    'logFile' => Environment::getVarPath() . '/log/security.log'
                 ]
             ],
         ];

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -251,7 +251,7 @@ injection, overwrites possible class attributes:
 .. code-block:: php
    :caption: EXT:my_extension/Service/MyClass.php
 
-   namespace Myvendor\Myextension\Service\MyClass;
+   namespace MyVendor\MyExtension\Service\MyClass;
 
    use Psr\Log\LoggerInterface;
    use TYPO3\CMS\Core\Log\Channel;


### PR DESCRIPTION
This can be merged into v11 but needs a tiny adjustment (Logger/Index.rst: replace typo3conf/system/additional.php with typo3conf/AdditionalConfiguration.php

----

The documentation for the channels contains mostly the information from the changelog
which does not explain how the channel can be used in the logging
configuration.

While on closer look, this may become obvious, there have been questions raised.

Also, in the logging configuration, the further examples are put into one code block, another example is added with the class name and a formatting is used
to highlight the composition of the array keys in $GLOBALS['TYPO3_CONF_VARS']['LOG']. Formatting it
this way should make it much clearer, how the array keys are composed, what is always the same and what contains the component name:

$GLOBALS['TYPO3_CONF_VARS']['LOG']
  ['Documentation']['Examples']['Controller']['FalExampleController']
  ['writerConfiguration'] = [
      // ...
  ];

Resolves: #2315