### PR TITLE
[TASK] Adapt docs about constant FILE_DENY_PATTERN_DEFAULT

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
@@ -62,32 +62,14 @@ Security related constant
 FILE_DENY_PATTERN_DEFAULT
 -------------------------
 
-Default value of fileDenyPattern.
+Default value of :ref:`$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
+<typo3ConfVars_be_fileDenyPattern>`.
 
 Defined in:
-   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
+   :php:`\TYPO3\CMS\Core\Resource\Security\FileNameValidator::FILE_DENY_PATTERN_DEFAULT`
 
 Example:
-   :php:`'\\.(php[3-7]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$'`
-
-Available in Frontend:
-   Yes
-
-
-.. index::
-   Security; PHP_EXTENSIONS_DEFAULT
-   Constants; PHP_EXTENSIONS_DEFAULT
-
-PHP_EXTENSIONS_DEFAULT
-----------------------
-
-List of file extensions that should be registered as php script file extensions.
-
-Defined in:
-   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
-
-Example:
-   :php:`'php,php3,php4,php5,php6,php7,phpsh,inc,phtml,pht,phar'`
+   :php:`\\.(php[3-8]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$`
 
 Available in Frontend:
    Yes

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -818,7 +818,8 @@ fileDenyPattern
    handler in an arbitrary position. Also, ".htaccess" files have to be denied.
    Matching is done case-insensitive.
 
-   Default value is stored in PHP constant :php:`FILE_DENY_PATTERN_DEFAULT`
+   Default value is stored in class constant
+   :php:`\TYPO3\CMS\Core\Resource\Security\FileNameValidator::FILE_DENY_PATTERN_DEFAULT`.
 
    Have also a look into the :ref:`security guidelines
    <security-global-typo3-options-fileDenyPattern>`.

--- a/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst
+++ b/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst
@@ -71,8 +71,9 @@ Perl-compatible regular expression that (if it matches a file name) will prevent
 TYPO3 from accessing or processing this file (deny uploading, renaming, etc).
 For security reasons, PHP files as well as Apache's :file:`.htaccess` file
 should be included in this regular expression string. The default value is:
-:php:`\\.(php[3-7]?|phpsh|phtml|pht)(\\..*)?$|^\\.htaccess$`, initially defined
-in constant :php:`FILE_DENY_PATTERN_DEFAULT`.
+:php:`\\.(php[3-8]?|phpsh|phtml|pht|phar|shtml|cgi)(\\..*)?$|\\.pl$|^\\.htaccess$`,
+initially defined in constant
+:php:`\TYPO3\CMS\Core\Resource\Security\FileNameValidator::FILE_DENY_PATTERN_DEFAULT`.
 
 There are only a very few scenarios imaginable where it makes sense to
 allow access to those files. In most cases backend users such as


### PR DESCRIPTION
Additionally, PHP_EXTENSIONS_DEFAULT was removed without substitution.

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/2264