### PR TITLE
[BUGFIX] Namespace imports are not recommended in TCA overrides

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TypoScript/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TypoScript/Index.rst
@@ -33,9 +33,7 @@ These two files will be included via
 .. code-block:: php
    :caption: EXT:my_extension/Configuration/TCA/Overrides/sys_template.php
 
-   use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
-   ExtensionManagementUtility::addStaticFile(
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
        'Configuration/TypoScript/',
        'Examples TypoScript'
@@ -69,21 +67,19 @@ for each folder that should be available in the TypoScript template record:
 .. code-block:: php
    :caption: EXT:my_extension/Configuration/TCA/Overrides/sys_template.php
 
-   use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
-   ExtensionManagementUtility::addStaticFile(
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
        'Configuration/TypoScript/',
        'My Extension - Main TypoScript'
    );
 
-   ExtensionManagementUtility::addStaticFile(
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
        'Configuration/TypoScript/Example1/',
        'My Extension - Additional example 1'
    );
 
-   ExtensionManagementUtility::addStaticFile(
+   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
        'Configuration/TypoScript/SpecialFeature2/',
        'My Extension - Some special feature'


### PR DESCRIPTION
The wrapping of configuration in the global namespace is only done for ext_tables.php and ext_localconf.php, not for TCA. In TCA this can cause problems when the same class name with different namespace imports is used in the merged TCA configuration.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Important-94280-MoveContentsOfExtPhpIntoLocalScopes.html

Releases: main, 11.5