### PR TITLE
[TASK] Add hooks to RenderAdditionalContentToRecordListEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
@@ -8,6 +8,12 @@ RenderAdditionalContentToRecordListEvent
 ========================================
 
 ..  versionadded:: 11.0
+    This event supersedes the hooks
+
+    -   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['recordlist/Modules/Recordlist/index.php']['drawHeaderHook']`
+    -   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['recordlist/Modules/Recordlist/index.php']['drawFooterHook']`
+
+    The hooks are removed in TYPO3 v12.
 
 ..  versionchanged:: 12.0
     Due to the integration of EXT:recordlist into EXT:backend the namespace of
@@ -18,10 +24,11 @@ RenderAdditionalContentToRecordListEvent
     For TYPO3 v12 the moved class is available as an alias under the old
     namespace to allow extensions to be compatible with TYPO3 v11 and v12.
 
-Event to add content before or after the main content of the list module.
+Event to add content before or after the main content of the :guilabel:`List`
+module.
 
 
 API
----
+===
 
 ..  include:: /CodeSnippets/Events/Backend/RenderAdditionalContentToRecordListEvent.rst.txt


### PR DESCRIPTION
This may ease the transition from the hooks to the event as one can search in the docs for the hooks now.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92062-MigrateRecordListControllerHooksToAnPSR-14Event.html

Releases: main, 11.5