### PR TITLE
[TASK] Add hooks to RenderAdditionalContentToRecordListEvent (#2365)

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Recordlist/RenderAdditionalContentToRecordListEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Recordlist/RenderAdditionalContentToRecordListEvent.rst
@@ -7,13 +7,19 @@
 RenderAdditionalContentToRecordListEvent
 ========================================
 
-.. versionadded:: 11.0
+..  versionadded:: 11.0
+    This event supersedes the hooks
+
+    -   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['recordlist/Modules/Recordlist/index.php']['drawHeaderHook']`
+    -   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['recordlist/Modules/Recordlist/index.php']['drawFooterHook']`
+
+    The hooks are removed in TYPO3 v12.
 
 Event to add content before or after the main content of the list module.
 
 
 API
----
+===
 
 
 .. include:: /CodeSnippets/Events/RecordList/RenderAdditionalContentToRecordListEvent.rst.txt


### PR DESCRIPTION
This may ease the transition from the hooks to the event as one can search in the docs for the hooks now.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92062-MigrateRecordListControllerHooksToAnPSR-14Event.html

Releases: main, 11.5