### PR TITLE
[TASK] Remove all references to TYPO3 v9 and below

### DIFF
--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -80,16 +80,14 @@ Using PSR-4 compatible prefix-based resolving
 Instead of looking up every single class and caching the information
 away, composer works on a “prefix”-based resolution. As an example, the
 Composer class loader only needs to know that all PHP classes starting
-with TYPO3\CMS\Core are located within typo3/sysext/core/Classes. The
+with :php:`TYPO3\CMS\Core` are located within :file:`vendor/typo3/cms-core/Classes`
+(:file:`typo3/sysext/core/Classes` in legacy installations). The
 rest is done by a simple resolution to include the necessary PHP class
 files. This means that the information to be cached away is only the
-list of available namespace-prefixes. All classes inside the TYPO3
-Core are PSR-4 compatible since TYPO3 v6.0 already.
+list of available namespace-prefixes.
 
-The definition of these prefixes is set inside the composer.json of each
-package or distribution / project. In the TYPO3 Core, every system
-extension defined these namespace prefixes already since TYPO3 v7.1
-and TYPO3 v6.2.10.
+The definition of these prefixes is set inside the :file:`composer.json` of each
+package or distribution / project.
 
 Autoloading developer-specific data differently
 -----------------------------------------------

--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -80,8 +80,7 @@ Using PSR-4 compatible prefix-based resolving
 Instead of looking up every single class and caching the information
 away, composer works on a “prefix”-based resolution. As an example, the
 Composer class loader only needs to know that all PHP classes starting
-with :php:`TYPO3\CMS\Core` are located within :file:`vendor/typo3/cms-core/Classes`
-(:file:`typo3/sysext/core/Classes` in legacy installations). The
+with :php:`TYPO3\CMS\Core` are located within :file:`EXT:core/Classes`. The
 rest is done by a simple resolution to include the necessary PHP class
 files. This means that the information to be cached away is only the
 list of available namespace prefixes.

--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -84,9 +84,9 @@ with :php:`TYPO3\CMS\Core` are located within :file:`vendor/typo3/cms-core/Class
 (:file:`typo3/sysext/core/Classes` in legacy installations). The
 rest is done by a simple resolution to include the necessary PHP class
 files. This means that the information to be cached away is only the
-list of available namespace-prefixes.
+list of available namespace prefixes.
 
-The definition of these prefixes is set inside the :file:`composer.json` of each
+The definition of these prefixes is set inside the :file:`composer.json` file of each
 package or distribution / project.
 
 Autoloading developer-specific data differently

--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -6,8 +6,8 @@
 Backend layout
 ==============
 
-Backend layouts can be defined as database records or via page TSconfig.
-Page TsConfig should be preferred as it can be stored in the file system and
+Backend layouts can be defined as database records or via :ref:`page TSconfig <t3tsconfig:pagetsconfig>`.
+Page TSconfig should be preferred as it can be stored in the file system and
 be kept under version control.
 
 .. _be-layout-video:

--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -6,11 +6,9 @@
 Backend layout
 ==============
 
-Since TYPO3 v4.5 there has been a database record type "backend layout" to define a combination of rows and columns
-to which content can be added in the page module.
-
-With TYPO3 v7.4 a new feature was introduced to define backend layouts in TYPO3 via page TSconfig. It implements a
-generic page TSconfig provider for backend layouts to make backend layouts reusable across installations.
+Backend layouts can be defined as database records or via page TSconfig.
+Page TsConfig should be preferred as it can be stored in the file system and
+be kept under version control.
 
 .. _be-layout-video:
 

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -407,8 +407,7 @@ Defining the field in the TCE
 An individual modification of the newly added field *tx_examples_main_category*
 to the TCA definition of the table *tt_content* can be done in the TCE
 (TYPO3 Core Engine) TSConfig. In most cases it is necessary to set the page
-id of the general storage folder (available as a plugin select box to select a
-starting point page until TYPO3 v6.2). Then the examples extension will only use
+id of the general storage folder. Then the examples extension will only use
 the content records from the given page id.
 
 .. code-block:: typoscript

--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -18,7 +18,7 @@ available was also dependent on the current request type (frontend or backend), 
 one consistent place where all this data is located.
 
 The context is set up at the very beginning of each TYPO3 entry point, keeping track
-of the current time (formally known as :php:`$GLOBALS['EXEC_TIME']`), 
+of the current time (formally known as :php:`$GLOBALS['EXEC_TIME']`),
 if a user is logged in (formerly known as :php:`$GLOBALS['TSFE']->loginUser`),
 and which workspace is currently accessed.
 
@@ -28,7 +28,7 @@ It can be retrieved anywhere via :php:`GeneralUtility::makeInstance()`:
 
     use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Core\Context\Context;
-    
+
     $context = GeneralUtility::makeInstance(Context::class);
 
 This information is separated in so-called "Aspects", each being responsible for a certain area:
@@ -39,10 +39,6 @@ Date time aspect
 ----------------
 
 Contains time, date and timezone information for the current request.
-
-In comparison to known behaviour until TYPO3 v9, :php:`DateTimeAspect`
-replaces for example :php:`$GLOBALS['SIM_EXEC_TIME']` and :php:`$GLOBALS['EXEC_TIME']`.
-
 
 .. _context_api_aspects_datetime_properties:
 
@@ -79,10 +75,6 @@ Language aspect
 ---------------
 
 Contains information about language settings for the current request, including fallback and overlay logic.
-
-In comparison to known behaviour until TYPO3 v9, :php:`LanguageAspect` replaces various properties related
-to language Id, overlay and fallback logic, mostly within Frontend.
-
 
 .. _context_api_aspects_language_properties:
 
@@ -179,8 +171,6 @@ User aspect
 
 Contains information about authenticated users in the current request. Can be used for frontend and backend users.
 
-In comparison to known behaviour until TYPO3 v9, :php:`UserAspect` replaces various calls and checks on :php:`$GLOBALS['BE_USER']` and :php:`$GLOBALS['TSFE']->fe_user` options when only some information is needed.
-
 
 .. _context_api_aspects_user_properties:
 
@@ -220,9 +210,6 @@ Visibility aspect
 
 The aspect contains whether to show hidden pages, records (content) or even deleted records.
 
-In comparison to known behaviour until TYPO3 v9, :php:`VisibilityAspect` replaces for example 
-:php:`$GLOBALS['TSFE']->showHiddenPages` and :php:`$GLOBALS['TSFE']->showHiddenRecords`.
-
 
 .. _context_api_aspects_visibility_properties:
 
@@ -258,10 +245,6 @@ Workspace aspect
 ----------------
 
 The aspect contains information about the currently accessed workspace
-
-In comparison to known behaviour until TYPO3 v9, :php:`WorkspaceAspect` replaces e.g. 
-:php:`$GLOBALS['BE_USER']->workspace`.
-
 
 .. _context_api_aspects_workspace_properties:
 

--- a/Documentation/ApiOverview/Database/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Database/Introduction/Index.rst
@@ -53,9 +53,6 @@ specific connection objects per configured database connection based on the tabl
 that is queried. This enables instance administrators to configure different database
 engines for different tables while this is transparent for extension developers.
 
-Doctrine DBAL has been introduced with TYPO3 version 8 and substitutes the
-old API based on :php:`$GLOBALS['TYPO3_DB']`.
-
 This document does *not* outline each and every single method the API provides. It
 sticks to those that are commonly used in extensions and some parts like the rewritten
 schema migrator are left out since they are usually of little to no interest for

--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -21,8 +21,8 @@ using this old functionality since deprecated methods will be removed in future 
 Introduction
 ============
 
-Deprecations since TYPO3 v9 use the PHP method :php:`trigger_error('a message', E_USER_DEPRECATED)` and run
-through the logging and exception stack of the TYPO3 Core . There are several methods that help extension developers in
+Deprecations use the PHP method :php:`trigger_error('a message', E_USER_DEPRECATED)` and run
+through the logging and exception stack of the TYPO3 Core. There are several methods that help extension developers in
 dispatching deprecation errors. In development context deprecations are turned into exceptions by default
 and ignored in production context.
 
@@ -60,8 +60,7 @@ For more information on how to configure the writing of deprecation logs see :re
 Finding calls to deprecated functions
 =====================================
 
-The extension scanner which has been introduced with TYPO3 Core version 9 as part of the system
-management (formerly "Install Tool") provides an interactive interface to scan extension code
+The extension scanner provides an interactive interface to scan extension code
 for usage of removed or deprecated TYPO3 Core API. See :ref:`extension-scanner` for more information.
 
 It is also possible to do a file search for "@deprecated" and "E_USER_DEPRECATED". Then using an IDE you can find all

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -67,10 +67,6 @@ In contrast to the removed hooks, this event does not provide the
 :php:`PageLayoutController` as :php:`$parentObject`, since :php:`getModuleTemplate()`
 has been the only public method, which is now directly included in the event.
 
-Additionally, there were three public properties :php:`$id`, :php:`$pageInfo`
-and :php:`$MOD_SETTINGS`, which had been marked as :php:`@internal`
-in TYPO3 v9. If needed, the information can be retrieved from the request directly.
-
 An example to get the current :php:`$id`:
 
 .. code-block:: php

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileSearch.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileSearch.rst
@@ -8,7 +8,7 @@
 Searching for Files
 ===================
 
-Since TYPO3 v9.5.6, there is an API in FAL to search for files in a storage or folder, which includes matches in meta data
+There is an API in FAL to search for files in a storage or folder, which includes matches in meta data
 of those files. The given search term is looked for in all search fields defined in TCA of `sys_file`
 and `sys_file_metadata` tables.
 

--- a/Documentation/ApiOverview/FormEngine/DataCompiling/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/DataCompiling/Index.rst
@@ -69,12 +69,6 @@ The main array is initialized by :php:`FormDataCompiler`, and each :php:`DataPro
    The main data array is prepared by :php:`FormDataCompiler`, each key is well documented in this class. To find out
    which data is expected to reside in this array, those comments are worth a look.
 
-.. note::
-   It may happen in future versions of FormEngine (Core version 9+) that the responsibility for the main structure and integrity
-   of the data array will be moved away from :php:`FormDataCompiler` into the single :php:`FormDataGroup` class. This may even make
-   the :php:`FormDataCompiler` obsolete in total.
-
-
 Data Groups and Providers
 =========================
 

--- a/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
@@ -36,7 +36,7 @@ FormEngine are abstracted and may come from "elsewhere", still leading to the fo
 This makes FormEngine an incredible flexible construct. The basic idea is "feed something that looks like TCA
 and render forms that have the full power of TCA but look like all other parts of the backend".
 
-The current state of the documentation aims to explain the main constructs of
+This chapter explains the main constructs of
 FormEngine and gives an insight on how to re-use, adapt and extend it with extensions. The Core Team expects to see more
 usages of FormEngine within the Core itself and within extensions in the future, and encourages developers to solve
 feature needs based on FormEngine. With the ongoing changes, those areas that may need code adaptions in the

--- a/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
@@ -36,9 +36,7 @@ FormEngine are abstracted and may come from "elsewhere", still leading to the fo
 This makes FormEngine an incredible flexible construct. The basic idea is "feed something that looks like TCA
 and render forms that have the full power of TCA but look like all other parts of the backend".
 
-The FormEngine code base has been significantly refactored in TYPO3 CMS version 7 and version 8 to be much more
-flexible, more easy to use and extend, and much more powerful than before. This is an ongoing process and some
-areas still need a major overhaul. The current state of the documentation aims to explain the main constructs of
+The current state of the documentation aims to explain the main constructs of
 FormEngine and gives an insight on how to re-use, adapt and extend it with extensions. The Core Team expects to see more
 usages of FormEngine within the Core itself and within extensions in the future, and encourages developers to solve
 feature needs based on FormEngine. With the ongoing changes, those areas that may need code adaptions in the

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -54,16 +54,6 @@ array as :php:`$data['renderType']` and then gives the data array to the :php:`N
 an appropriate class name, instantiates and initializes the class, gives it the data array, and calls :php:`render()`
 on it.
 
-.. note::
-   The :php:`SingleFieldContainer` and :php:`FlexFormElementContainer` will probably vanish with Core version 9.
-
-.. note::
-   Data set by containers and given down to children will likely change in Core version 9: All fields not registered
-   in the main data array of :php:`FormDataCompiler` and only added within containers will move into section
-   :php:`renderData`. Furthermore, it is planned to *remove* :php:`parameterArray` and substitute it with something
-   better. This will affect most elements and will probably break a lot of these elements.
-
-
 .. _FormEngine-Rendering-ClassInheritance:
 
 Class Inheritance
@@ -113,8 +103,8 @@ This re-routes the :php:`renderType` "flex" to an own class. If multiple registr
 the one with highest priority wins.
 
 .. note::
-   The :php:`NodeFactory` uses :php:`$data['renderType']`. This has been introduced with Core version 7 in TCA, and
-   a couple of TCA fields actively use this renderType. However, it is important to understand the renderType is *only*
+   The :php:`NodeFactory` uses :php:`$data['renderType']`.
+   A couple of TCA fields actively use this renderType. However, it is important to understand the renderType is *only*
    used within the FormEngine and :php:`type` is still a must-have setting for columns fields in TCA. Additionally,
    :php:`type` can *not* be overridden in :php:`columnsOverrides`. Basically, :php:`type` specifies how the DataHandler
    should put data into the database, while :php:`renderType` specifies how a single field is rendered. This additionally
@@ -301,8 +291,6 @@ Node Expansion
 
 The "node expansion" classes :php:`FieldControl`, :php:`FieldInformation` and :php:`FieldWizard` are called by containers
 and elements and allow "enriching" containers and elements. Which enrichments are called can be configured via TCA.
-
-This API is the substitution of the old "TCA wizards array" and has been introduced with Core version 8.
 
 FieldInformation
   Additional information. In elements, their output is shown between the field label and the element itself. They can

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -43,7 +43,7 @@ The TYPO3 Core ships two icon providers which can be used straight away:
 * :php:`SvgIconProvider` – For SVG icons
 
 .. versionchanged:: 12.0
-   The :php:`FontawesomeIconProvider` has been available since version 7.5 and
+   The :php:`FontawesomeIconProvider`
    was removed from the Core in 12.0. You can use the polyfill extension from
    :t3ext:`fontawesome_provider` which is also compatible with TYPO3 v11 LTS.
 
@@ -180,10 +180,6 @@ markupIdentifier
 
 The method :js:`getIcon()` returns a AjaxResponse Promise object, as internally
 an Ajax request is done.
-
-.. note::
-    Since TYPO3 v9, the icons are cached in the localStorage of the client to
-    reduce the workload off the server.
 
 Here is an example code how a usage of the JavaScript Icon API may look like:
 

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -181,6 +181,7 @@ markupIdentifier
 The method :js:`getIcon()` returns a AjaxResponse Promise object, as internally
 an Ajax request is done.
 
+The icons are cached in the local storage of the client to reduce the workload off the server.
 Here is an example code how a usage of the JavaScript Icon API may look like:
 
 ..  todo: move the example to examples extension

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -53,12 +53,11 @@ The above configuration applies to **all** log entries of level "ERROR" or above
 
 .. attention::
 
-    Since TYPO3 v9 the default folder for log files is :file:`<var-path>/log`.
-    The `<var-path>` in a non-Composer installation (Classic Mode) is :file:`typo3temp/var/`,
-    in a Composer based installation it is :file:`<project-root>/var/` instead, unless configured otherwise.
+    The default folder for log files is :file:`<var-path>/log`.
+    The `<var-path>` is :file:`<project-root>/var/` (legacy installations:
+    :file:`typo3temp/var/`).
+
     See class :php:`\TYPO3\CMS\Core\Core\Environment` for defaults in both cases.
-    Since TYPO3 v9 it is possible (and a good practice) to store temporary files
-    outside the document root.
 
 To apply a special configuration for the controllers of the *examples* extension,
 use the following configuration:

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -6,7 +6,7 @@
 Namespaces
 ==========
 
-Since version 6.0, TYPO3 uses PHP namespaces for all classes in the Core.
+TYPO3 uses PHP namespaces for all classes in the Core.
 
 The general structure of namespaces is the following:
 

--- a/Documentation/ApiOverview/PasswordHashing/Index.rst
+++ b/Documentation/ApiOverview/PasswordHashing/Index.rst
@@ -15,8 +15,8 @@ Introduction
 TYPO3 never stores passwords in plain text in the database. If the latest configured hash algorithm has been changed,
 TYPO3 will update the stored frontend and backend user password hashes upon user login.
 
-TYPO3 uses modern hash algorithms suitable for the given PHP platform, the default being Argon2i since
-the release of TYPO3 Core  version 9.
+TYPO3 uses modern hash algorithms suitable for the given PHP platform, the
+default being Argon2i.
 
 This section is for administrators and users who want to know more about TYPO3 password hashing and
 have a basic understanding of hashing algorithms and configuration in TYPO3.
@@ -84,9 +84,7 @@ approaches: Core version v4.3 from 2009 added salted password storing, v4.5 from
 storing using the algorithm 'phpass' by default, v6.2 from 2014 made salted passwords storing mandatory,
 v8 added the improved hash algorithm 'PBKDF2' and used it by default.
 
-With TYPO3 Core  version 9, the password hashing has been refactored and modern hash algorithms such as
-Argon2i have been added. PHP improved in this area a lot and PHP 7.2 brings `Argon2i` by default, so this
-algorithm could be easily integrated as available Core hash mechanism to the existing hash family.
+Currently Argon2i is the default and provided automatically by PHP.
 Argon2i is rather resilient against GPU and some other attacks, the default TYPO3 Core  configuration even raises
 the default PHP configuration to make attacks on stored Argon2i user password hashes even more unfeasible.
 
@@ -129,15 +127,11 @@ used hash algorithm. In this case it is `$argon2i` which denotes the Argon2i has
 Configuration
 =============
 
-Configuration of password hashing is done by TYPO3 automatically and administrators usually do not need
-to worry about details too much: If installing a TYPO3 instance with Core version v9 or higher, the
-installation process will configure the best available hash algorithm by default. Since Core version v9 requires
-at least PHP version 7.2, this is usually Argon2i. Only if the PHP build is incomplete, some less secure
+Configuration of password hashing is done by TYPO3 automatically and
+administrators usually do not need to worry about details too much: The
+installation process will configure the best available hash algorithm by default.
+This is usually Argon2i. Only if the PHP build is incomplete, some less secure
 fallback will be selected.
-
-If upgrading from a version smaller than v9, the upgrade process will automatically upgrade to the best
-available hash algorithm, which is again usually Argon2i if PHP 7.2 on the server has been set up
-in a sane way.
 
 Switching between hash algorithms in a TYPO3 instance is unproblematic: Password hashes of the old selected
 algorithm are just kept but newly created users automatically use the new hash algorithms. If a user
@@ -153,7 +147,7 @@ comply with the idea of data minimisation of person related data. TYPO3 helps he
 "Table garbage collection" task of the scheduler extension, details on this are however out-of-scope of this section.
 
 To verify and select which specific hash algorithm is currently configured for frontend and backend users, a
-preset of the settings module has been established with Core v9. It can be found in
+preset of the settings module is available. It can be found in
 :guilabel:`Admin Tools > Settings
 > Configuration presets > Password hashing settings`:
 
@@ -198,7 +192,7 @@ Configuration of password hashing is stored in :file:`config/system/settings.php
 Available Hash Algorithms
 =========================
 
-The list of available hash mechanisms is pretty rich since Core version v9 and may be extended further
+The list of available hash mechanisms is pretty rich and may be extended further
 if better hash algorithms over time. Most algorithms have additional configuration options that may be
 used to increase or lower the needed computation power to calculated hashes. Administrators usually do
 not need to fiddle with these and should go with defaults configured by the Core. If changing these options,

--- a/Documentation/ApiOverview/Routing/Introduction.rst
+++ b/Documentation/ApiOverview/Routing/Introduction.rst
@@ -53,14 +53,12 @@ Slug
     * Slugs must be separated by one or more character like "/", "-", "_" and "&".
       Regular characters like letters should not be used as separators for better readability.
 
-.. note::
+..  note::
 
-   Until TYPO3 v9 routing for TYPO3 was done by using extensions such as `realURL` or `coolURI`.
-   In contrast to concepts within RealURL of "URL segments", a slug is a segment of a URL.
-   Slugs should be separated by slashes, but this is not a strict requirement.
-   Therefore a slug of a record may contain slashes.
-   However the risk of conflicts is higher when using slashes
-   within slugs. For example unrelated page hierarchies and records could have slugs forming the same URL path.
+    A slug of a record may contain slashes but this is not recommended:
+    The risk of conflicts is higher when using slashes within slugs. For
+    example unrelated page hierarchies and records could have slugs
+    forming the same URL path.
 
 
 Routing in TYPO3

--- a/Documentation/ApiOverview/Routing/Introduction.rst
+++ b/Documentation/ApiOverview/Routing/Introduction.rst
@@ -57,7 +57,7 @@ Slug
 
     A slug of a record may contain slashes but this is not recommended:
     The risk of conflicts is higher when using slashes within slugs. For
-    example unrelated page hierarchies and records could have slugs
+    example, unrelated page hierarchies and records could have slugs
     forming the same URL path.
 
 

--- a/Documentation/ApiOverview/SiteHandling/Basics.rst
+++ b/Documentation/ApiOverview/SiteHandling/Basics.rst
@@ -8,9 +8,6 @@
 Basics
 ======
 
-.. note::
-   Site handling is available since TYPO3 v9 LTS.
-
 TYPO3 site handling and configuration is the starting point for creating new web sites.
 The corresponding modules are found in the TYPO3 backend in the section :guilabel:`Site management`.
 

--- a/Documentation/CodingGuidelines/CglTypoScript/Index.rst
+++ b/Documentation/CodingGuidelines/CglTypoScript/Index.rst
@@ -9,7 +9,7 @@ TypoScript Coding Guidelines
 Directory and File Names
 ========================
 
-* As of TYPO3 v8.7, the file ending can and should be :file:`.typoscript`.
+* The file ending **should** be :file:`.typoscript`.
 
 * TypoScript files are located in the directory :file:`<extension>/Configuration/TypoScript`.
 
@@ -21,11 +21,10 @@ More information about the file ending:
 
 * TypoScript files used to have the ending :file:`.txt`.
 
-* Since TYPO3 v7, it is also possible to use the ending :file:`.ts`. This is
+* It is also possible to use the ending :file:`.ts`. This is
   not recommended because it is also used by TypeScript.
 
-* Therefore, you should use :file:`.typoscript` if you are using TYPO3 v8.7
-  and later.
+* Therefore, you should use :file:`.typoscript`.
 
 
 .. seealso::

--- a/Documentation/CodingGuidelines/CglTypoScript/Index.rst
+++ b/Documentation/CodingGuidelines/CglTypoScript/Index.rst
@@ -9,7 +9,7 @@ TypoScript Coding Guidelines
 Directory and File Names
 ========================
 
-* The file ending **should** be :file:`.typoscript`.
+* The file extension **should** be :file:`.typoscript`.
 
 * TypoScript files are located in the directory :file:`<extension>/Configuration/TypoScript`.
 

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
@@ -10,9 +10,8 @@ You can also add include-instructions in TypoScript code. Availability
 depends on the context, but it works with TypoScript templates, page
 TSconfig and user TSconfig.
 
-Since TYPO3 version 9 a new syntax for importing external TypoScript files has
-been introduced, which acts as a preprocessor before the actual parsing
-(condition evaluation) takes place.
+The syntax for importing external TypoScript files acts as a preprocessor
+before the actual parsing (condition evaluation) takes place.
 
 .. warning::
    Includes of either syntax within multi-line comments are still executed due
@@ -154,18 +153,6 @@ Example:
 .. code-block:: text
 
    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/user.typoscript" condition="[loginUser = *]">
-
-
-.. attention::
-
-   Please note that since TYPO3 v9.4, the syntax of condition has switched to the `symfony expression language <https://symfony.com/doc/4.1/components/expression_language.html>`__ which :ref:`is covered in this section of TSref <t3tsref:conditions>`. If the condition requires double quotes, they must be converted to single quotes or escaped, e.g.:
-
-   .. code-block:: text
-
-      <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/some.typoscript" condition="[applicationContext == 'Development']">
-
-	  <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/some.typoscript" condition="[applicationContext == \"Development\"]">
-
 
 .. _typoscript-syntax-includes-best-practices:
 

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/Includes.rst
@@ -154,6 +154,13 @@ Example:
 
    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/user.typoscript" condition="[loginUser = *]">
 
+The syntax of condition has switched to the `symfony expression language <https://symfony.com/doc/4.1/components/expression_language.html>`__ which :ref:`is covered in this section of TSref <t3tsref:conditions>`. If the condition requires double quotes, they must be converted to single quotes or escaped, e.g.:
+
+..  code-block:: typoscript
+
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/some.typoscript" condition="[applicationContext == 'Development']">
+    
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:my_extension/Configuration/TypoScript/some.typoscript" condition="[applicationContext == \"Development\"]">
 .. _typoscript-syntax-includes-best-practices:
 
 Best practices

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
@@ -435,15 +435,9 @@ Single line comments
 When a line starts with :code:`//` or :code:`#` it is considered to be a comment
 and will be ignored.
 
-
 **Example:**
 
 .. include:: /CodeSnippets/TypoScriptSyntax/Syntax/CommentsSingleLine.rst.txt
-
-Up to TYPO3 v7.6, a line starting with only one single slash,
-:code:`/`, has also been considered a comment. Since TYPO3 v8, this
-style however is deprecated and should not be used.
-
 
 .. index::
    TypoScript; Operator "/*"

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/ExtensionScanner.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/ExtensionScanner.rst
@@ -10,8 +10,7 @@ Extension scanner
 Introduction
 ============
 
-The extension scanner which has been introduced with TYPO3 Core version 9 as part of the system
-management (formerly "Install Tool") provides an interactive interface to scan extension code
+The extension scanner provides an interactive interface to scan extension code
 for usage of TYPO3 Core API which has been removed or deprecated.
 
 .. include:: /Images/AutomaticScreenshots/AdminTools/ExtensionScanner.rst.txt
@@ -73,7 +72,7 @@ Goals and non goals
 
 * Implementation within the TYPO3 Core backend has been primary goal. While it might be possible, integration
   into IDEs like PhpStorm has not been a design goal. Also, matcher configuration is bound to the Core version,
-  e.g. tests concerning v9 are not intended to be executed on v8.
+  e.g. tests concerning v12 are not intended to be executed on v11.
 
 * Some of reST files that document a breaking change or deprecated API can be used to scan extensions.
   If those find no matches, the reST documentation files are tagged with a "no match" label telling integrators

--- a/Documentation/Security/GeneralGuidelines/Index.rst
+++ b/Documentation/Security/GeneralGuidelines/Index.rst
@@ -136,10 +136,10 @@ Keep the TYPO3 Core up-to-date
 ==============================
 
 As described in :ref:`TYPO3 versions <security-typo3-versions>` chapter, a
-new version of TYPO3 can either be a major update (e.g. from version 7.x.x to
-version 8.x.x), a minor update (e.g. from version 8.4.x to version
-8.5.x) or a maintenance/bugfix/security release (e.g. from version
-8.7.11 to 8.7.12).
+new version of TYPO3 can either be a major update (e.g. from version 10.x.x to
+version 11.x.x), a minor update (e.g. from version 11.4.x to version
+11.5.x) or a maintenance/bugfix/security release (e.g. from version
+11.5.11 to 11.5.12).
 
 In most cases, a maintenance/bugfix/security update is a no-brainer,
 see :doc:`TYPO3 Installation and Upgrade Guide <t3install:Index>`

--- a/Documentation/Security/GeneralInformation/Index.rst
+++ b/Documentation/Security/GeneralInformation/Index.rst
@@ -20,31 +20,31 @@ TYPO3 is offered in Long Term Support (LTS) and Sprint Release versions.
 
 The first versions of each branch are Sprint Release versions. A Sprint Release
 version only receives support until the next Sprint Release got published. E.g.
-TYPO3 `9.0.0` was the first Sprint Release of the `9` branch and its support
-ended when TYPO3 `9.1.0` got released.
+TYPO3 `11.0.0` was the first Sprint Release of the `11` branch and its support
+ended when TYPO3 `11.1.0` got released.
 
 An LTS version is planned to be created every 18 months. LTS versions are created
 from a branch in order to finalize it: Prior to reaching LTS status, a number of
 Sprint Releases has been created from that branch and the release of an LTS version
 marks the point after which no new features will be added to this branch. LTS
 versions get full support (bug fixes and security fixes) for at least three years.
-TYPO3 version 8 (`v8`) and v9 are such LTS versions.
+TYPO3 version 10 (`v10`) and v11 are such LTS versions.
 
-Starting with TYPO3 v7 the minor-versions are skipped in the official
-naming. 7 LTS is version` 7.6` internally, 8 LTS is `8.7` and 9 LTS is `9.5`. Versions inside a
-major-version have minor-versions as usual (`9.0`, `9.1`, ...) until at some
+The minor-versions are skipped in the official
+naming. 11 LTS is version`11.5` internally and 10 LTS is `10.4`. Versions inside a
+major-version have minor-versions as usual (`11.0`, `11.1`, ...) until at some
 point the branch receives LTS-status.
 
 Support and security fixes are provided for the current as well as the
-preceding LTS release. For example, when TYPO3 v9 is the current LTS release,
-TYPO3 v8 is still actively supported, including security updates.
+preceding LTS release. For example, when TYPO3 v11 is the current LTS release,
+TYPO3 v10 is still actively supported, including security updates.
 
-For users of v8 an update to v9 is recommended. All versions below TYPO3 v8 are
+For users of v10 an update to v11 is recommended. All versions below TYPO3 v10 are
 outdated and the regular support of these versions has ended, including security updates.
 Users of these versions are strongly encouraged to update their systems
 as soon as possible.
 
-In cases where users can't yet upgrade to a supported version, the TYPO3 GmbH is offering
+In cases where users cannot yet upgrade to a supported version, the TYPO3 GmbH is offering
 an Extended Long Term Support (ELTS) service for up to three years after the regular support has ended.
 Subscribers to the ELTS plans receive security and compatibility updates.
 
@@ -56,17 +56,23 @@ backend may be changed and appropriate training for editors may be
 required. The content rendering may change, so that updates in
 `TypoScript`, templates or `CSS` code may be necessary. With LTS and
 Sprint Releases also the system requirements (for example PHP or MySQL
-version) may change. For a patch level releases (i.e.
-changing from release `9.5.0` to `9.5.1`) the database structure and
+version) may change. For a patch level release (i.e.
+changing from release `11.5.0` to `11.5.1`) the database structure and
 backend will usually not change and an update will only require the
 new version of the source code.
 
 List of TYPO3 LTS releases:
 
-* v7 (7.6.0 LTS): versions 7.0 through 7.5 do not receive security upgrades any longer
-* v8 (8.7.0 LTS): versions 8.0 through 8.6 do not receive security upgrades any longer
-* v9 (9.5.0 LTS): versions 9.0 through 9.4 do not receive security upgrades any longer
-* v10 (10.4.0 LTS): versions 10.0 through 10.3 do not receive security upgrades any longer
+*   v7 (7.6.0 eLTS): No free security updated. Extended Long Term support can
+    be ordered at https://typo3.com/services/extended-support-elts
+*   v8 (8.7.0 eLTS): No free security updated. Extended Long Term support
+    can be ordered at https://typo3.com/services/extended-support-elts
+*   v9 (9.5.0 eLTS): No free security updated. Extended Long Term support
+    can be ordered at https://typo3.com/services/extended-support-elts
+*   v10 (10.4.0 LTS): Versions v10.0 through v10.3 do not receive security
+    upgrades any longer
+*   v11 (11.5.0 LTS): Versions v11.0 through v11.4 do not receive security
+    upgrades any longer
 
 
 .. _security-difference-core-extensions:

--- a/Documentation/Security/GeneralInformation/Index.rst
+++ b/Documentation/Security/GeneralInformation/Index.rst
@@ -63,9 +63,9 @@ new version of the source code.
 
 List of TYPO3 LTS releases:
 
-*   v8 (8.7.0 eLTS): No free security updated. Extended Long Term support
+*   v8 (8.7 ELTS): No free bugfix/security update. Extended long term support
     can be ordered at https://typo3.com/services/extended-support-elts
-*   v9 (9.5.0 eLTS): No free security updated. Extended Long Term support
+*   v9 (9.5 ELTS): No free bugfix/security update. Extended long term support
     can be ordered at https://typo3.com/services/extended-support-elts
 *   v10 (10.4 LTS): Versions 10.0 through 10.3 do not receive security
     updates any longer

--- a/Documentation/Security/GeneralInformation/Index.rst
+++ b/Documentation/Security/GeneralInformation/Index.rst
@@ -63,16 +63,14 @@ new version of the source code.
 
 List of TYPO3 LTS releases:
 
-*   v7 (7.6.0 eLTS): No free security updated. Extended Long Term support can
-    be ordered at https://typo3.com/services/extended-support-elts
 *   v8 (8.7.0 eLTS): No free security updated. Extended Long Term support
     can be ordered at https://typo3.com/services/extended-support-elts
 *   v9 (9.5.0 eLTS): No free security updated. Extended Long Term support
     can be ordered at https://typo3.com/services/extended-support-elts
-*   v10 (10.4.0 LTS): Versions v10.0 through v10.3 do not receive security
-    upgrades any longer
-*   v11 (11.5.0 LTS): Versions v11.0 through v11.4 do not receive security
-    upgrades any longer
+*   v10 (10.4 LTS): Versions 10.0 through 10.3 do not receive security
+    updates any longer
+*   v11 (11.5 LTS): Versions 11.0 through 11.4 do not receive security
+    updates any longer
 
 
 .. _security-difference-core-extensions:

--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -68,7 +68,7 @@ Apache and Microsoft IIS web servers
 ====================================
 
 To increase protection of TYPO3 instances, the Core Team however decided to
-install default web server configuration files since TYPO3 Core  version v9 under certain
+install default web server configuration files under certain
 circumstances: If an Apache web server is detected by the web based installation
 procedure, a default :file:`.htaccess` file is written to the document root, and if
 a Microsoft IIS web server is detected, a default :file:`web.config` file is written

--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -105,7 +105,7 @@ TYPO3 Core updates
 ==================
 
 In legacy installations the Install Tool allows integrators to update the
-TYPO3 Core with a click of a button. This feature can be found under
+TYPO3 Core with a click on a button. This feature can be found under
 "Important actions" and it checks/installs revision updates only (e.g.
 bug fixes and security updates).
 

--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -61,7 +61,7 @@ in the global configuration file :file:`config/system/settings.php`:
        ],
    ];
 
-Since TYPO3 version 6.2, the Install Tool password is set during the
+The Install Tool password is set during the
 installation process. This means, in the case that a system administrator
 hands over the TYPO3 instance to you, it should also provide you
 with the appropriate password.
@@ -72,8 +72,8 @@ Log-in to the Install Tool and change it there.
 
 .. include:: /Images/AutomaticScreenshots/AdminTools/ChangeInstallToolPassword.rst.txt
 
-Since TYPO3 v9, the role of system maintainer has been introduced. It allows for selected
-BE users to access the Install Tool components from within the backend without further
+The role of system maintainer allows for selected
+backend users to access the :guilabel:`Admin Tools` components from within the backend without further
 security measures.
 The number of system maintainers should be as small as possible to mitigate the risks of corrupted accounts.
 
@@ -104,7 +104,7 @@ definitely discuss your intention with the team.
 TYPO3 Core updates
 ==================
 
-Since TYPO3 v6.2, the Install Tool allows integrators to update the
+In legacy installations the Install Tool allows integrators to update the
 TYPO3 Core with a click of a button. This feature can be found under
 "Important actions" and it checks/installs revision updates only (e.g.
 bug fixes and security updates).

--- a/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
+++ b/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
@@ -193,7 +193,7 @@ The following TypoScript adds the appropriate line to the HTTP header:
 Integrity of external JavaScript files
 ======================================
 
-The TypoScript property :code:`integrity`
+The TypoScript property :typoscript:`integrity`
 allows integrators to specify a SRI hash in order to allow a verification
 of the integrity of externally hosted JavaScript files. SRI (Sub-Resource Integrity) is a
 `W3C specification <https://www.w3.org/TR/SRI/>`_ that allows web developers to ensure

--- a/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
+++ b/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
@@ -193,8 +193,8 @@ The following TypoScript adds the appropriate line to the HTTP header:
 Integrity of external JavaScript files
 ======================================
 
-The TypoScript property :code:`integrity` has been introduced with TYPO3 v7. This
-configuration allows integrators to specify a SRI hash in order to allow a verification
+The TypoScript property :code:`integrity`
+allows integrators to specify a SRI hash in order to allow a verification
 of the integrity of externally hosted JavaScript files. SRI (Sub-Resource Integrity) is a
 `W3C specification <https://www.w3.org/TR/SRI/>`_ that allows web developers to ensure
 that resources hosted on third-party servers have not been tampered with.

--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -9,9 +9,11 @@ Core testing
 Introduction
 ============
 
-This chapter is about executing TYPO3 Core tests locally and is intended to give you a better understanding of testing within TYPO3's Core. A full Core git checkout comes with everything needed
-to run tests in TYPO3 as of version 9. We don't use older versions in this chapter
-since Core development is most likely bound to the Core `main` branch - back porting patches to older
+This chapter is about executing TYPO3 Core tests locally and is intended to give
+you a better understanding of testing within TYPO3's Core. A full Core git checkout comes with everything needed
+to run tests in TYPO3.
+
+Core development is most likely bound to the Core `main` branch - back porting patches to older
 branches are usually handled by Core maintainers and often don't affect other Core contributors.
 
 Note, the main script

--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -13,7 +13,7 @@ This chapter is about executing TYPO3 Core tests locally and is intended to give
 you a better understanding of testing within TYPO3's Core. A full Core git checkout comes with everything needed
 to run tests in TYPO3.
 
-Core development is most likely bound to the Core `main` branch - back porting patches to older
+Core development is most likely bound to the Core `main` branch - backporting patches to older
 branches are usually handled by Core maintainers and often don't affect other Core contributors.
 
 Note, the main script

--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -9,9 +9,9 @@ Extension testing
 ..  attention::
     The example in this chapter covers only outdated TYPO3 and PHP versions. Help us bring
     it up to date: See :ref:`h2document:contribute`.
-    
+
     The general principles demonstrated here still apply.
-    
+
 ..  todo: Update the examples bellow
 
 Introduction
@@ -42,8 +42,8 @@ About this chapter and what it does *not* cover, first.
   development of that package is closely bound to Core development and has a relatively high
   development speed. It does contain breaking patches per major Core versions, but it should
   not contain breaking patches for existing major Core branches. If you now set up testing
-  using `typo3/testing-framework` with TYPO3 Core version 9, it should not break within v9's
-  lifetime. But it is likely to break if you upgrade to version 10 or later and may need adaption
+  using `typo3/testing-framework` with TYPO3 Core version 11, it should not break within v11's
+  lifetime. But it is likely to break if you upgrade to version 12 or later and may need adaption
   in your extension codes or setup.
 
   If you are looking for test setups that support multiple Core versions at once,

--- a/Documentation/Testing/WritingUnit.rst
+++ b/Documentation/Testing/WritingUnit.rst
@@ -210,10 +210,10 @@ General hints
 * Only use :php:`getAccessibleMock()` if parts of the system under test class itself needs to be
   mocked. Never use it for an object that is created by the system under test itself.
 
-* Since TYPO3 v9, unit tests are by default configured to fail if a notice level PHP error is triggered.
+* Unit tests are by default configured to fail if a notice level PHP error is triggered.
   This has been used in the Core to slowly make the framework notice free. Extension authors may fall
   into a trap here: First, the unit test code itself, or the system under test may trigger notices.
-  Developers should fix that. But, TYPO3 v9 is not yet fully notice free, and it may happen a Core
+  Developers should fix that. But it may happen a Core
   dependency triggers a notice that in turn lets the extensions unit test fail. At best, the extension
   developer pushes a patch to the Core to fix that notice. Another solution is to mock the dependency
   away, which may however not be desired or possible - especially with static dependencies.


### PR DESCRIPTION
Exceptions:
* History sections
* Explaining eLTS
* Extensions Testing (to be handled separately as there are news examples needed)

directives (.. versionadded:: 9.5) are taken care of in #2428