### PR TITLE
[TASK] FluidEmail: Use class constant for mail format type (#2444) (#2445)

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -317,7 +317,7 @@ make sure the paths are setup as described in :ref:`mail-configuration-fluid`:
        ->to('contact@example.org')
        ->from(new Address('jeremy@example.org', 'Jeremy'))
        ->subject('TYPO3 loves you - here is why')
-       ->format('both') // send HTML and plaintext mail
+       ->format(FluidEmail::FORMAT_BOTH) // send HTML and plaintext mail
        ->setTemplate('TipsAndTricks')
        ->assign('mySecretIngredient', 'Tomato and TypoScript');
    GeneralUtility::makeInstance(Mailer::class)->send($email);


### PR DESCRIPTION
Releases: main, 11.5