### PR TITLE
Fix use statement in ext_tables.php code example (#2469)

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTables.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTables.rst
@@ -87,7 +87,7 @@ You can register a new backend module for your extension via :php:`ExtensionUtil
 .. code-block:: php
    :caption: EXT:my_extension/ext_tables.php
 
-   // use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+   // use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
    ExtensionUtility::registerModule(
       'ExtensionName', // Extension Name in CamelCase
@@ -104,6 +104,7 @@ You can register a new backend module for your extension via :php:`ExtensionUtil
       ]
    );
 
+There is also a possibility to register modules without Extbase, using core functionality only.
 For more information on backend modules see :ref:`backend module API <backend-modules-api>`.
 
 .. index:: Extension development; allowTableOnStandardPages


### PR DESCRIPTION
Fix use statement to fit the example code. Add a hint that there is also a possibility to register a module without using extbase. Deeper information on that are covered by the already linked article.

Already fixed in 11.5 with https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/commit/a46cfc36b3dcf88f633a54c2ad0c8ad36a377935