### PR TITLE
[TASK] Replace TYPO3 src links to GitHub with directive

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendRouting.rst
+++ b/Documentation/ApiOverview/Backend/BackendRouting.rst
@@ -156,5 +156,5 @@ Please refer to the following external resources and look at how the TYPO3 sourc
 handles backend routing in your TYPO3 version.
 
 * `PSR-7 <https://www.php-fig.org/psr/psr-7/>`__
-* TYPO3 Core : `backend : AjaxRoutes.php <https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/AjaxRoutes.php>`__ (GitHub)
-* TYPO3 Core : `backend : Routes.php <https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/Routes.php>`__ (GitHub)
+* TYPO3 Core: :t3src:`backend/Configuration/Backend/AjaxRoutes.php`
+* TYPO3 Core: :t3src:`backend/Configuration/Backend/Routes.php`

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -192,7 +192,7 @@ Below is the structure of a basic FlexForm from the example extension
 ..  include:: /CodeSnippets/FlexForms/Simple.rst.txt
 
 For a more elaborate example, have a look at the plugin configuration of
-system extension `felogin` (`Login.xml <https://github.com/TYPO3/typo3/blob/main/typo3/sysext/felogin/Configuration/FlexForms/Login.xml>`__).
+system extension `felogin` (:t3src:`felogin/Configuration/FlexForms/Login.xml`).
 It shows an example of relative complex data structure used in a FlexForm.
 
 More information about such usage of FlexForms can be found in the

--- a/Documentation/ApiOverview/LockingApi/Index.rst
+++ b/Documentation/ApiOverview/LockingApi/Index.rst
@@ -75,8 +75,8 @@ locking strategy supported on system
 Capabilities
 ------------
 
-These are the current capabilities, that can be used (see `LockingStrategyInterface
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/core/Classes/Locking/LockingStrategyInterface.php>`__):
+These are the current capabilities, that can be used (see
+:t3src:`core/Classes/Locking/LockingStrategyInterface.php`:
 
 In general, the concept of locking, using shared or exclusive + blocking or non-blocking
 locks is not TYPO3-specific. You can find more resources under :ref:`locking-api-more-info`.
@@ -218,8 +218,7 @@ Extend locking in Extensions
 
 An extension can extend the locking functionality by adding a new locking
 strategy. This can be done by writing a new class which implements the
-`LockingStrategyInterface
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/core/Classes/Locking/LockingStrategyInterface.php>`__.
+:t3src:`core/Classes/Locking/LockingStrategyInterface.php`.
 
 Each locking strategy has a set of capabilities (getCapabilities()), and a
 priority (getPriority()), so give your strategy a priority higher than 75
@@ -236,10 +235,7 @@ as is done in the TYPO3 Core:
            ?? self::DEFAULT_PRIORITY;
    }
 
-See `FileLockStrategy
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/core/Classes/Locking/FileLockStrategy.php>`__
-for an example.
-
+See :t3src:`core/Classes/Locking/FileLockStrategy.php` for an example.
 
 .. index:: Locking; Caveats
 .. _locking-api-caveats:

--- a/Documentation/ApiOverview/Rte/InTheBackend/PlugRte.rst
+++ b/Documentation/ApiOverview/Rte/InTheBackend/PlugRte.rst
@@ -114,7 +114,7 @@ based on the implementation of ext:rte_ckeditor.
    }
 
 - Next step is to implement the RichtTextElement class. You can look up the
-  code of `\\TYPO3\\CMS\\RteCKEditor\\Form\\Element\\RichTextElement <https://github.com/typo3/typo3/blob/main/typo3/sysext/rte_ckeditor/Classes/Form/Element/RichTextElement.php>`__, which
+  code of :t3src:`rte_ckeditor/Classes/Form/Element/RichTextElement.php`, which
   does the same for ckeditor. What basically happens in its render() function,
   is to apply any settings from the fields TCA config and then printing out all
   of the html markup and javascript necessary for booting up the ckeditor.

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
@@ -7,8 +7,7 @@ Fluid-based error handler
 =========================
 
 The fluid-based error handler is defined in
-`\TYPO3\CMS\Core\Error\PageErrorHandler\FluidPageErrorHandler
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/core/Classes/Error/PageErrorHandler/FluidPageErrorHandler.php>`__.
+:t3src:`core/Classes/Error/PageErrorHandler/FluidPageErrorHandler.php`.
 
 Properties
 ==========

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
@@ -11,8 +11,7 @@ HTTP status. The content of this page is generated via a TYPO3-internal
 sub-request.
 
 The page-based error handler is defined in
-`\\TYPO3\\CMS\\Core\\Error\\PageErrorHandler\\PageContentErrorHandler
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php>`__.
+:t3src:`core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php`.
 
 In order to prevent possible denial-of-service attacks when the page-based error
 handler is used with the curl-based approach, the content of the error page is

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst
@@ -38,7 +38,7 @@ be used.
 Most backend routes defined in the TYPO3 core can be found in the following
 file, which you can use as example:
 
-`typo3/sysext/backend/Configuration/Backend/Routes.php <https://github.com/typo3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/Routes.php>`__
+:t3src:`typo3/sysext/backend/Configuration/Backend/Routes.php`
 
 Read more about :ref:`Backend routing <backend-routing>`.
 

--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -80,10 +80,9 @@ and common package files like :file:`composer.json`.
 
 This "black list" approach needs maintenance: The Core Team tries to keep the template files
 :file:`.htaccess` and :file:`web.config` updated. If running Apache or IIS, administrators
-should compare their specific version with the reference files found at `root-htaccess
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess>`_
-and `root-web-config
-<https://github.com/typo3/typo3/blob/main/typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-web-config>`_
+should compare their specific version with the reference files found at
+:t3src:`install/Resources/Private/FolderStructureTemplateFiles/root-htaccess>`
+and :t3src:`install/Resources/Private/FolderStructureTemplateFiles/root-web-config`
 and adapt or update local versions if needed.
 
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -76,4 +76,4 @@ ext_tea         = https://docs.typo3.org/p/ttn/tea/main/en-us/
 [extlinks]
 
 t3ext = https://extensions.typo3.org/extension/%s | EXT:
-t3src = https://github.com/typo3/typo3/blob/main/typo3/sysext/%s | EXT:%s
+t3src = https://github.com/typo3/typo3/blob/main/typo3/sysext/%s | EXT:

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -76,3 +76,4 @@ ext_tea         = https://docs.typo3.org/p/ttn/tea/main/en-us/
 [extlinks]
 
 t3ext = https://extensions.typo3.org/extension/%s | EXT:
+t3src = https://github.com/typo3/typo3/blob/main/typo3/sysext/%s | EXT:%s


### PR DESCRIPTION
This way we can centrally point the links at the
corresponding branch and adjust all links if they should ever be hosted in another system.

releases: main, 11.5