### PR TITLE
[TASK] Remove "simply" and "just" where not appropriate (#2482)

### DIFF
--- a/Documentation/ApiOverview/Autoloading/Index.rst
+++ b/Documentation/ApiOverview/Autoloading/Index.rst
@@ -139,7 +139,7 @@ If your classes cannot be found, try the following approaches.
         php typo3/sysext/core/bin/typo3 dumpautoload
 
 -   If that command itself fails, please (manually) uninstall the extension and
-    simply try reinstalling it (via the Extension Manager).
+    try reinstalling it (via the Extension Manager).
 
 -   If you are still not lucky, the issue is definitely on your side and you
     should double check the write permissions on :file:`typo3temp`.

--- a/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
@@ -133,7 +133,7 @@ page tree is drawn from the *DB Mounts* which are one or more page ids
 telling the Core from which "start page" to draw the tree(s). Likewise
 is the folder tree drawn based on *filemounts* configured for the user.
 
-**DB mounts** (page mounts) are easily set by simply pointing out the
+**DB mounts** (page mounts) are set by pointing out the
 page that should be mounted for the user (at user or group-level):
 
 .. include:: /Images/AutomaticScreenshots/AccessControl/DbMounts.rst.txt

--- a/Documentation/ApiOverview/Backend/Clipboard.rst
+++ b/Documentation/ApiOverview/Backend/Clipboard.rst
@@ -20,7 +20,7 @@ backend modules:
 
 
 In this simple piece of code we instantiate a clipboard object and make it
-load its content. We then simply dump this content into the BE module's debug
+load its content. We then dump this content into the BE module's debug
 window, with the following result:
 
 .. include:: /Images/AutomaticScreenshots/Examples/Clipboard/ClipboardDump.rst.txt

--- a/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
@@ -24,8 +24,8 @@ Cache Configurations
 Unfortunately in TYPO3, all :file:`ext_localconf.php` files of the extensions are loaded **after** the instance specific
 configuration from :file:`LocalConfiguration.php` and :file:`AdditionalConfiguration.php`. This
 enables extensions to overwrite cache configurations already done for the instance. All extensions
-should avoid this situation and should just define the very bare minimum of cache configurations. This
-boils down to define just the array key to populate a new cache to the system. Without further configuration,
+should avoid this situation and should define the very bare minimum of cache configurations. This
+boils down to define the array key to populate a new cache to the system. Without further configuration,
 the cache system falls back to the default backend and default frontend settings:
 
 .. code-block:: php

--- a/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
@@ -888,7 +888,7 @@ Transient Memory Backend
 
 The transient memory backend stores data in a PHP array. It is only valid for one request. This becomes handy if code
 logic needs to do expensive calculations or must look up identical information from a database over and over again
-during its execution. In this case it is useful to store the data in an array once and just lookup the entry from the
+during its execution. In this case it is useful to store the data in an array once and lookup the entry from the
 cache for consecutive calls to get rid of the otherwise additional overhead. Since caches are available system wide and
 shared between Core and extensions they can profit from each other if they need the same information.
 

--- a/Documentation/ApiOverview/Categories/Index.rst
+++ b/Documentation/ApiOverview/Categories/Index.rst
@@ -32,7 +32,7 @@ Using Categories
 Managing Categories
 -------------------
 
-System categories are defined just like any other record. Each category
+System categories are defined like any other record. Each category
 can have a parent, making a tree-like structure.
 
 .. include:: /Images/AutomaticScreenshots/Categories/Editing.rst.txt

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -161,7 +161,7 @@ must be strings or integers.)
    :Description:
          Defines the type of object.
 
-         - "array" means that the object simply contains a collection of other
+         - "array" means that the object contains a collection of other
            objects defined inside the <el> tag on the same level. If the value is
            "array" you can use the boolean "<section>". See below.
 

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Index.rst
@@ -51,8 +51,8 @@ Some other facts about Data Structures (DS):
   sheets will depend on the application. Basically sheets are like a
   one-dimensional internal categorization of Data Structures.
 
-- Parsing a Data Structure into a PHP array is incredibly easy - just
-  pass it to :php:`GeneralUtility::xml2array()` (see the :ref:`t3ds-parsing` section).
+- Parsing a Data Structure into a PHP array can be achieved by passing it to
+  :php:`GeneralUtility::xml2array()` (see the :ref:`t3ds-parsing` section).
 
 - "DS" is sometimes used as short for Data Structure
 

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -79,7 +79,7 @@ also talk about how to transition away from it towards the core-wide Symfony sol
 Background and history
 ======================
 
-Obtaining object instances in TYPO3 has always been pretty straight: Just call
+Obtaining object instances in TYPO3 has always been straightforward: Call
 :php:`GeneralUtility::makeInstance(\Vendor\MyExtension\Some\Class::class)` and hand over
 mandatory and optional :php:`__construct()` arguments as additional arguments.
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
@@ -13,7 +13,7 @@ Event to alter the hreflang tags just before they get rendered.
 The class :php:`TYPO3\CMS\Seo\HrefLang\HrefLangGenerator` has been
 refactored to be a listener (identifier 'typo3-seo/hreflangGenerator') to the
 newly introduced event. This way the system extension seo still provides
-hreflang tags but it is now possible to simply register after or instead
+hreflang tags but it is now possible to register after or instead
 of the implementation.
 
 Example

--- a/Documentation/ApiOverview/Fluid/Syntax.rst
+++ b/Documentation/ApiOverview/Fluid/Syntax.rst
@@ -25,7 +25,7 @@ The result::
 
    <h1>An example title</h1>
 
-In the template's HTML code, simply wrap the variable name into curly
+In the template's HTML code, wrap the variable name into curly
 braces to output it:
 
 .. _fluid-arrays:

--- a/Documentation/ApiOverview/Fluid/UsingTypoScriptCObjectViewHelper.rst
+++ b/Documentation/ApiOverview/Fluid/UsingTypoScriptCObjectViewHelper.rst
@@ -100,7 +100,7 @@ This TypoScript snippet outputs the current number of visits written
 in bold.
 
 Now for example we can output the user counter as image instead of
-text without modifying the Fluid template. We simply have to use the
+text without modifying the Fluid template. We have to use the
 following TypoScript:
 
 .. code-block:: typoscript

--- a/Documentation/ApiOverview/PageTypes/Introduction.rst
+++ b/Documentation/ApiOverview/PageTypes/Introduction.rst
@@ -19,7 +19,7 @@ allowed on a certain page type.
 
 .. note::
    The "default" entry in the :php:`$GLOBALS['PAGES_TYPES']` array is the "base"
-   for all types, and for every type the entries simply overrides the
+   for all types, and for every type the entries overrides the
    entries in the "default" type!!
 
 This is the default array as set in :file:`EXT:core/ext_tables.php`:

--- a/Documentation/ApiOverview/Services/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Services/Introduction/Index.rst
@@ -43,7 +43,7 @@ by another one with improved features or more specific capabilities,
 for example. This can be achieved without having to change the original
 code of TYPO3 or of an extension.
 
-Services are simply PHP classes packaged inside an extension.
+Services are PHP classes packaged inside an extension.
 The usual way to instantiate a class in TYPO3 is:
 
 .. code-block:: php

--- a/Documentation/ApiOverview/Services/UsingServices/SimpleUse.rst
+++ b/Documentation/ApiOverview/Services/UsingServices/SimpleUse.rst
@@ -6,7 +6,7 @@
 Simple usage
 ============
 
-The most basic use is when you just want an object that handles a
+The most basic use is when you want an object that handles a
 given service type:
 
 .. code-block:: php

--- a/Documentation/ApiOverview/SiteHandling/Basics.rst
+++ b/Documentation/ApiOverview/SiteHandling/Basics.rst
@@ -105,7 +105,7 @@ base
 
 The base is the base domain on which a website runs. It accepts either a
 fully qualified URL or a relative segment "/" to react to any domain name.
-It is possible to set a site base prefix to just :samp:`/site1`, :samp:`/site2`
+It is possible to set a site base prefix to :samp:`/site1`, :samp:`/site2`
 or even :samp:`example.com` instead of entering a full URI.
 
 This allows a site base as :samp:`example.com` with http and https protocols to

--- a/Documentation/ApiOverview/SystemRegistry/Index.rst
+++ b/Documentation/ApiOverview/SystemRegistry/Index.rst
@@ -94,7 +94,7 @@ table:
 The Registry API
 ================
 
-There is an easy-to-use API for using the registry. Simply call the following
+There is an easy-to-use API for using the registry. You can use the following
 code to retrieve an instance of the registry. The instance returned will always
 be the same, as the registry is a singleton:
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -23,7 +23,7 @@ create a new record.
 system.
 
 The data and commands are created as multidimensional arrays and to
-understand the API of DataHandler you simply need to understand the
+understand the API of DataHandler you need to understand the
 hierarchy of these two arrays.
 
 .. caution::

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -69,7 +69,7 @@ The most basic form of a preview is when a live record is selected and
 you lookup a future version of that record belonging to the current
 workspace of the logged in backend user. This is very easy as long as
 a record is selected based on its "uid" or "pid" fields which are not
-subject to versioning; You simply call :code:`sys_page->versionOL()` after
+subject to versioning: call :code:`sys_page->versionOL()` after
 record selection.
 
 However, when other fields are involved in the where clause it gets
@@ -425,9 +425,9 @@ will take over the pid / "sortby" value upon publishing.
 Preview of move operations is almost fully functional through the
 :code:`\TYPO3\CMS\Core\Domain\Repository\PageRepository::versionOL()` and
 :code:`\TYPO3\CMS\Backend\Utility\BackendUtility::workspaceOL()` functions.
-When the online placeholder is selected it simply looks up the source
+When the online placeholder is selected it looks up the source
 record, overlays any version on top and displays it. When the source
-record is selected it should simply be discarded in case shown in
+record is selected it should be discarded in case shown in
 context where ordering or position matters (like in menus or column
 based page content). This is done in the appropriate places.
 

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -97,7 +97,7 @@ will be overridden by the :code:`\T3docs\Examples\Xclass\NewRecordController`
 class, the latter being part of the
 `"examples" extension <https://extensions.typo3.org/extension/examples/>`__ .
 
-When XCLASSing a class that does not use namespaces, simply use that class' name
+When XCLASSing a class that does not use namespaces, use that class name
 in the declaration.
 
 
@@ -113,7 +113,7 @@ XCLASS breaking after a code update.
 .. tip::
 
    You're even safer if you can do your changes before or after the parent method
-   and just call the latter with :code:`parent::`.
+   and call the latter with :code:`parent::`.
 
 The example below extends the new record wizard screen. It first calls the original
 method and then adds its own content:

--- a/Documentation/Configuration/ConfigurationModule/Index.rst
+++ b/Documentation/Configuration/ConfigurationModule/Index.rst
@@ -132,10 +132,10 @@ constructor arguments in the provider classes.
 Displaying values from `$GLOBALS`
 ---------------------------------
 
-If you want to display a custom configuration from the `$GLOBALS` array,
+If you want to display a custom configuration from the :php:`$GLOBALS` array,
 you can also use the already existing
 :php:`TYPO3\CMS\Lowlevel\ConfigurationModuleProvider\GlobalVariableProvider`.
-Simply define the key to be exposed using the `globalVariableKey` attribute.
+Define the key to be exposed using the `globalVariableKey` attribute.
 
 This could look like this:
 

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
@@ -67,7 +67,7 @@ The operator (in the example it is :code:`=`) can be one of the characters
 Value assignment: The "=" operator
 ----------------------------------
 
-This simply assigns a value to an object path.
+This assigns a value to an object path.
 
 
 **Rules:**
@@ -277,7 +277,7 @@ Another example with a copy within a code block:
 
 Here also a copy is made, although inside the :code:`pageObj` object. Note
 that the copied object is referred to with its full path
-(:code:`pageObj.10`). When **copying on the same level**, you can just
+(:code:`pageObj.10`). When **copying on the same level**, you can
 refer to the copied object's name, **prepended by a dot**.
 
 The following produces the same result as above:
@@ -319,7 +319,7 @@ Object references: the equal smaller "=<" sign
 **In the context of TypoScript Templates** it is possible to create
 references from one object to another. References mean that multiple
 positions in an object tree can use the same object at another
-position without making an actual copy of the object but by simply
+position without making an actual copy of the object but by
 pointing to the objects full object path.
 
 The obvious advantage is that a **change of code to the original

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
@@ -294,7 +294,7 @@ Example:
          **Extensions having one folder with classes or single files**
 
          Considering you have an Extbase extension (or an extension where all classes
-         and interfaces reside in a :file:`Classes` folder) or single classes you can simply
+         and interfaces reside in a :file:`Classes` folder) or single classes you can
          add the following to your :file:`ext_emconf.php` file:
 
          .. code-block:: php

--- a/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
@@ -243,7 +243,7 @@ scheme) on the fly.
 Test Your Distribution
 ======================
 
-To test your distribution, simply copy your extension to an empty
+To test your distribution, copy your extension to an empty
 TYPO3 installation and try to install it from the Extension
 Manager.
 

--- a/Documentation/Security/Backups/Index.rst
+++ b/Documentation/Security/Backups/Index.rst
@@ -117,7 +117,7 @@ intervals.
 In case you are also storing backups on the production server, make
 sure that they are placed outside of the root directory of your
 website and cannot be accessed with a browser. Otherwise everybody
-could simply download your backups, including sensitive data, such as
+could download your backups, including sensitive data, such as
 passwords (not revealing the URL is not a sufficient measure from a
 security perspective).
 

--- a/Documentation/Security/GuidelinesIntegrators/AccessPrivileges.rst
+++ b/Documentation/Security/GuidelinesIntegrators/AccessPrivileges.rst
@@ -30,10 +30,10 @@ using DB mounts only is not the best way. In order to really deny
 access, page permissions need to be set correctly.
 
 It is always a good approach to set these permissions on a group level
-(for example use a group such as "editors"), so you can simply create
+(for example use a group such as "editors"), so you can create
 a new user and assign this user to the appropriate group. It is not
 necessary to update the access privileges for every user if you want
-to adjust something in the future – simply update the group's
+to adjust something in the future – update the group's
 permissions instead.
 
 When creating a new user, do not use generic user names such as


### PR DESCRIPTION
Inspired by: https://twitter.com/marcelpociot/status/1594706393696985088

Also, some of the usages are just fillers which does not convey meaning.

Releases: main, 11.5

Co-authored-by: Lina Wolf <48202465+linawolf@users.noreply.github.com>
Co-authored-by: Tom Warwick <tom.warwick@typo3.org>