### PR TITLE
[TASK] Do not recommend to inject query builder via DI

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -544,29 +544,29 @@ the desired classes. This can be done in chronological order or by naming.
       arguments:
         - '@TYPO3\CMS\Core\Database\ConnectionPool'
 
-This allows you to inject concrete objects like the :php:`QueryBuilder`:
+This allows you to inject concrete objects like the :ref:`Connection
+<database-connection>`:
 
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    querybuilder.pages:
-      class: 'TYPO3\CMS\Core\Database\Query\QueryBuilder'
+    connection.pages:
+      class: 'TYPO3\CMS\Core\Database\Connection'
       factory:
         - '@TYPO3\CMS\Core\Database\ConnectionPool'
-        - 'getQueryBuilderForTable'
+        - 'getConnectionForTable'
       arguments:
         - 'pages'
 
     Vendor\MyExtension\UserFunction\ClassA:
       public: true
       arguments:
-        - '@querybuilder.pages'
+        - '@connection.pages'
 
-Now you can access the :php:`QueryBuilder` instance within :php:`ClassA`. This
-allows you to call your queries without further instantiation. Be aware to clone
-your object or reset the query parts to avoid side effects when using them more
-than once. For example, this method of injecting objects also works with
-extension configurations and with TypoScript settings.
+Now you can access the :php:`Connection` instance within :php:`ClassA`. This
+allows you to execute your queries without further instantiation. For example,
+this method of injecting objects also works with extension configurations and
+with TypoScript settings.
 
 
 Public


### PR DESCRIPTION
Injecting the query builder is error-prone as it contains state. The user must clone the object or reset the query parts to avoid side effects. Therefore we should not recommend this and show as best practise.

The query builder should be retrieved via ConnectionPool or Connection object to avoid these errors.

The example uses the Connection class instead.

Releases: main, 11.5