### PR TITLE
[CI] Use Ubuntu 22.04 for running backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
The used Ubuntu 18.04 is deprecated:
https://github.com/actions/runner-images#available-images