### PR TITLE
[TASK] Streamline database result chapter

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -185,6 +185,8 @@ Default Restrictions
     <database-restriction-builder>` section for details on that topic.
 
 
+..  _database-query-builder-count:
+
 count()
 =======
 
@@ -925,6 +927,8 @@ Remarks:
     <database-query-builder-get-sql>` to see the string with placeholders, which
     is used as a prepared statement.
 
+
+..  _database-query-builder-execute:
 
 execute(), executeQuery() and executeStatement()
 ================================================

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -206,7 +206,7 @@ The following code example is probably outdated:
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
 
-Looking at a mysql debug log:
+Looking at a MySQL debug log:
 
 ..  code-block:: none
 


### PR DESCRIPTION
Note: In v11.5 the Statement object is explained instead of the Result object. In recent v11 versions the Result object is available, therefore this patch can also be backported to v11.

The todo in the "Reuse prepared statement" section will be addressed in a separate patch.

Releases: main, 11.5