### PR TITLE
[TASK] Add hint about tagging a data processor to avoid setting public

### DIFF
--- a/Documentation/ApiOverview/ContentElements/CustomDataProcessing.rst
+++ b/Documentation/ApiOverview/ContentElements/CustomDataProcessing.rst
@@ -72,6 +72,12 @@ like in the TypoScript example above.
     an existing alias (form TYPO3 Core or a third-party extension) as this may
     cause errors.
 
+..  tip::
+    It is recommended to tag a custom data processors as this will
+    automatically add them to the internal :php:`DataProcessorRegistry`,
+    enabling :ref:`dependency injection <DependencyInjection>` by default.
+    Otherwise, the service would need to be set :ref:`public <What-to-make-public>`.
+
 
 ..  index::
     Custom data processor; Impementation

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -618,6 +618,8 @@ marked as public:
 *   Classes registered in :ref:`hooks <hooks-general>`
 *   :ref:`Authentication services <authentication>`
 *   :ref:`Fluid data processors <content-elements-custom-data-processor>`
+    (only necessary if not tagged as
+    :ref:`data.processor <content-elements-custom-data-processor_alias>`).
 
 For such classes, an extension can override the global configuration
 :yaml:`public: false` in :file:`Configuration/Services.yaml` for each affected


### PR DESCRIPTION
See the note in the according changelog:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.1/Feature-96005-AllowTaggingandAliasingOfDataProcessors.html

Releases: main