### PR TITLE
[Backport 11.5] [TASK] Rework assets chapter (#2524)

### DIFF
--- a/Documentation/ApiOverview/Assets/Index.rst
+++ b/Documentation/ApiOverview/Assets/Index.rst
@@ -1,15 +1,22 @@
-.. include:: /Includes.rst.txt
-.. index::
-   ! Assets
-   PageRenderer
-.. _assets:
+..  include:: /Includes.rst.txt
+..  index::
+    ! Assets
+    PageRenderer
+..  _assets:
 
 ===============================
 Assets (CSS, JavaScript, Media)
 ===============================
 
-The TYPO3 component responsible for rendering the HTML and adding assets to a TYPO3
-frontend or backend page is called :php:`PageRenderer`.
+..  contents:: **Table of Contents**
+    :local:
+
+
+Introduction
+============
+
+The TYPO3 component responsible for rendering the HTML and adding assets to a
+TYPO3 frontend or backend page is called :php:`\TYPO3\CMS\Core\Page\PageRenderer`.
 
 The :php:`PageRenderer` collects all assets to be rendered, takes care of
 options such as concatenation or compression and finally generates the necessary
@@ -17,9 +24,9 @@ tags.
 
 There are multiple ways to add assets to the :php:`PageRenderer` in TYPO3.
 For configuration options via TypoScript (usually used for the main theme files),
-see the :ref:`TypoScript Reference <t3tsref:setup-page-includecss-array>`. In extensions,
-both directly using the :php:`PageRenderer` as well as using the more convenient
-:php:`AssetCollector` is possible.
+see the :ref:`TypoScript Reference <t3tsref:setup-page-includecss-array>`. In
+extensions, both directly using the :php:`PageRenderer` as well as using the
+more convenient :php:`AssetCollector` is possible.
 
 .. note::
 
@@ -30,135 +37,146 @@ both directly using the :php:`PageRenderer` as well as using the more convenient
    Fluid; asset.script
    Fluid; asset.css
 
-AssetCollector
-==============
+Asset collector
+===============
 
-The :php:`AssetCollector` is a concept to allow custom CSS/JS code, inline or external, to be added multiple
-times in e.g. a Fluid template (via :html:`<f:asset.script>` or :html:`<f:asset.css>` Viewhelpers)
-but rendered only once in the output.
+With the :php:`\TYPO3\CMS\Core\Page\AssetCollector` class, CSS and JavaScript
+code (inline or external) can be added multiple times, but rendered only once in
+the output. The class may be used directly in PHP code or the assets can be
+added via the :html:`<f:asset.css>` and :html:`<f:asset.script>` ViewHelpers.
 
-The :php:`priority` flag (default: :php:`false`) controls where the asset is included:
+The :php:`priority` flag (default: :php:`false`) controls where the asset is
+inserted:
 
-- JavaScript will be output inside :html:`<head>` if :php:`$priority == true` or at the bottom of the :html:`<body>` tag if :php:`$priority == false`.
-- CSS will always be output inside :html:`<head>`, yet grouped by :php:`$priority`.
+-   JavaScript will be output inside :html:`<head>` if :php:`$priority == true`,
+    or at the bottom of the :html:`<body>` tag if :php:`$priority == false`.
+-   CSS will always be output inside :html:`<head>`, yet grouped by
+    :php:`$priority`.
 
-The :php:`AssetCollector` helps to work with content elements as components, effectively reducing the CSS to be loaded.
-It leverages making use of HTTP/2 which removes the necessity to have all
-files concatenated into one file.
+The asset collector helps to work with content elements as components,
+effectively reducing the CSS to be loaded. It takes advantage of HTTP/2, which
+removes the necessity to concatenate all files in one file.
 
-The :php:`AssetCollector` class is implemented as a singleton (:php:`SingletonInterface`). It replaces various other existing options
-in TypoScript and methods in PHP to insert Javascript code and CSS data.
+The asset collector class is implemented as a singleton
+(:php:`\TYPO3\CMS\Core\SingletonInterface`). It replaces various other existing
+options in TypoScript and :ref:`methods in PHP <assets-other-methods>` for
+inserting JavaScript and CSS code.
 
-Former methods:
+The asset collector also collects information about images on a page,
+which can be used in cached and non-cached components.
 
-.. code-block:: php
-
-   use TYPO3\CMS\Core\Page\PageRenderer;
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
-
-   $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-
-* :php:`$GLOBALS['TSFE']->additionalHeaderData[$name] = $javascriptcode;`
-* :php:`$GLOBALS['TSFE']->setJS($name, $javascriptcode)`
-* :php:`$pageRenderer->addHeaderData($javascriptcode)`
-* :php:`$pageRenderer->addCssFile($file)`
-* :php:`$pageRenderer->addCssInlineBlock($name, $csscode)`
-* :php:`$pageRenderer->addCssLibrary($file)`
-* :php:`$pageRenderer->addJsFile($file)`
-* :php:`$pageRenderer->addJsFooterFile($file)`
-* :php:`$pageRenderer->addJsFooterLibrary($name, $file)`
-* :php:`$pageRenderer->addJsFooterInlineCode($name, $javascriptcode)`
-* :php:`$pageRenderer->addJsInlineCode($name, $javascriptcode)`
-* :php:`$pageRenderer->addJsLibrary($name, $file)`
-
-
-The :php:`AssetCollector` also collects information about "imagesOnPage", which can be used in cached and non-cached components.
 
 The API
 -------
 
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::addJavaScript(string $identifier, string $source, array $attributes, array $options = []): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::addInlineJavaScript(string $identifier, string $source, array $attributes, array $options = []): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::addStyleSheet(string $identifier, string $source, array $attributes, array $options = []): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::addInlineStyleSheet(string $identifier, string $source, array $attributes, array $options = []): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::addMedia(string $fileName, array $additionalInformation): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::removeJavaScript(string $identifier): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::removeInlineJavaScript(string $identifier): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::removeStyleSheet(string $identifier): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::removeInlineStyleSheet(string $identifier): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::removeMedia(string $identifier): self`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::getJavaScripts(?bool $priority = null): array`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::getInlineJavaScripts(?bool $priority = null): array`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::getStyleSheets(?bool $priority = null): array`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::getInlineStyleSheets(?bool $priority = null): array`
-- :php:`\TYPO3\CMS\Core\Page\AssetCollector::getMedia(): array`
+..  include:: /CodeSnippets/Manual/Core/AssetCollector.rst.txt
 
-.. note::
+..  note::
+    If the same asset is registered multiple times using different attributes or
+    options, both sets are merged. If the same attributes or options are given
+    with different values, the most recently registered ones overwrite the
+    existing ones. The :php:`has` methods can be used to check if an asset
+    exists before generating it again, hence avoiding redundancy.
 
-   If the same asset is registered multiple times using different attributes or options, both sets are merged. If the
-   same attributes or options are given with different values, those registered last will overwrite the existing ones.
 
 .. index:: pair: Assets; Viewhelpers
 
 Viewhelper
 ----------
 
-There are also two Viewhelpers, the :ref:`f:asset.css<t3viewhelper:typo3-fluid-asset-css>` and the :ref:`f:asset.script<t3viewhelper:typo3-fluid-asset-script>` Viewhelper which use the :php:`AssetCollector` API.
+There are also two ViewHelpers, the
+:ref:`f:asset.css<t3viewhelper:typo3-fluid-asset-css>` and the
+:ref:`f:asset.script<t3viewhelper:typo3-fluid-asset-script>` ViewHelper which
+use the :php:`AssetCollector` API.
+
 
 .. index:: pair: Assets; Rendering order
 
 Rendering order
 ---------------
 
-Currently, CSS and JavaScript registered with the :php:`AssetCollector` will be rendered after their
-:php:`PageRenderer` counterparts. The order is:
+Currently, CSS and JavaScript registered with the asset collector will be
+rendered after their page renderer counterparts. The order is:
 
-- :html:`<head>`
-- :typoscript:`page.includeJSLibs.forceOnTop`
-- :typoscript:`page.includeJSLibs`
-- :typoscript:`page.includeJS.forceOnTop`
-- :typoscript:`page.includeJS`
-- :php:`AssetCollector::addJavaScript()` with 'priority'
-- :typoscript:`page.jsInline`
-- :php:`AssetCollector::addInlineJavaScript()` with 'priority'
-- :html:`</head>`
+-   :html:`<head>`
+-   :typoscript:`page.includeJSLibs.forceOnTop`
+-   :typoscript:`page.includeJSLibs`
+-   :typoscript:`page.includeJS.forceOnTop`
+-   :typoscript:`page.includeJS`
+-   :php:`AssetCollector::addJavaScript()` with 'priority'
+-   :typoscript:`page.jsInline`
+-   :php:`AssetCollector::addInlineJavaScript()` with 'priority'
+-   :html:`</head>`
 
-- :typoscript:`page.includeJSFooterlibs.forceOnTop`
-- :typoscript:`page.includeJSFooterlibs`
-- :typoscript:`page.includeJSFooter.forceOnTop`
-- :typoscript:`page.includeJSFooter`
-- :php:`AssetCollector::addJavaScript()`
-- :typoscript:`page.jsFooterInline`
-- :php:`AssetCollector::addInlineJavaScript()`
+-   :typoscript:`page.includeJSFooterlibs.forceOnTop`
+-   :typoscript:`page.includeJSFooterlibs`
+-   :typoscript:`page.includeJSFooter.forceOnTop`
+-   :typoscript:`page.includeJSFooter`
+-   :php:`AssetCollector::addJavaScript()`
+-   :typoscript:`page.jsFooterInline`
+-   :php:`AssetCollector::addInlineJavaScript()`
 
-.. note::
-
-   JavaScript registered with AssetCollector is not affected by
-   :typoscript:`config.moveJsFromHeaderToFooter`.
+..  note::
+    JavaScript registered with the asset collector is not affected by
+    :ref:`config.moveJsFromHeaderToFooter <t3tsref:setup-config-movejsfromheadertofooter>`.
 
 Examples
 --------
 
-Add a JavaScript file to the collector with script attribute :code:`data-foo="bar"`:
+The :php:`AssetCollector` can be injected in the constructor of a class via
+:ref:`dependency injection <DependencyInjection>` and then used in methods:
 
-.. code-block:: php
+..  literalinclude:: _MyClassWithAssetCollector.php
+    :caption: EXT:my_extension/Classes/MyClass.php
 
-    GeneralUtility::makeInstance(AssetCollector::class)
-       ->addJavaScript('my_ext_foo', 'EXT:my_ext/Resources/Public/JavaScript/foo.js', ['data-foo' => 'bar']);
+Add a JavaScript file to the collector with script attribute
+:html:`data-foo="bar"`:
 
-Add a JavaScript file to the collector with script attribute :html:`data-foo="bar"` and priority which means rendering before other script tags:
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/MyClass.php
 
-.. code-block:: php
+    $this->assetCollector->addJavaScript(
+        'my_ext_foo',
+        'EXT:my_extension/Resources/Public/JavaScript/foo.js',
+        ['data-foo' => 'bar']
+    );
 
-    GeneralUtility::makeInstance(AssetCollector::class)
-       ->addJavaScript('my_ext_foo', 'EXT:my_ext/Resources/Public/JavaScript/foo.js', ['data-foo' => 'bar'], ['priority' => true]);
+Add a JavaScript file to the collector with script attribute
+:html:`data-foo="bar"` and a priority which means rendering before other script
+tags:
 
-Add a JavaScript file to the collector with :html:`type="module"` (by default, no type= is output for JavaScript):
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/MyClass.php
 
-.. code-block:: php
+    $this->assetCollector->addJavaScript(
+        'my_ext_foo',
+        'EXT:my_extension/Resources/Public/JavaScript/foo.js',
+        ['data-foo' => 'bar'],
+        ['priority' => true]
+    );
 
-    GeneralUtility::makeInstance(AssetCollector::class)
-       ->addJavaScript('my_ext_foo', 'EXT:my_ext/Resources/Public/JavaScript/foo.js', ['type' => 'module']);
+Add a JavaScript file to the collector with :html:`type="module"` (by default,
+no :html:`type=` is output for JavaScript):
+
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/MyClass.php
+
+    $this->assetCollector->addJavaScript(
+        'my_ext_foo',
+        'EXT:my_extension/Resources/Public/JavaScript/foo.js',
+        ['type' => 'module']
+    );
+
+Check if a JavaScript file with the given identifier exists:
+
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/MyClass.php
+
+    if ($this->assetCollector->hasJavaScript($identifier)) {
+        // result: true - JavaScript with identifier $identifier exists
+    } else {
+        // result: false - JavaScript with identifier $identifier does not exist
+    }
 
 
 .. index::
@@ -174,3 +192,45 @@ There are two events available that allow additional adjusting of assets:
 * :ref:`BeforeJavaScriptsRenderingEvent`
 * :ref:`BeforeStylesheetsRenderingEvent`
 
+
+..  _assets-other-methods:
+
+Former methods to add assets
+============================
+
+Using the page renderer
+-----------------------
+
+An instance of the :php:`PageRenderer` class can be injected into the
+class via :ref:`dependency injection <DependencyInjection>`:
+
+..  literalinclude:: _MyClassWithPageRenderer.php
+    :caption: EXT:my_extension/Classes/MyClass.php
+
+The following methods can then be used:
+
+*   :php:`$this->pageRenderer->addHeaderData($javaScriptCode)`
+*   :php:`$this->pageRenderer->addCssFile($file)`
+*   :php:`$this->pageRenderer->addCssInlineBlock($name, $cssCode)`
+*   :php:`$this->pageRenderer->addCssLibrary($file)`
+*   :php:`$this->pageRenderer->addJsFile($file)`
+*   :php:`$this->pageRenderer->addJsFooterFile($file)`
+*   :php:`$this->pageRenderer->addJsFooterLibrary($name, $file)`
+*   :php:`$this->pageRenderer->addJsFooterInlineCode($name, $javaScriptCode)`
+*   :php:`$this->pageRenderer->addJsInlineCode($name, $javaScriptCode)`
+*   :php:`$this->pageRenderer->addJsLibrary($name, $file)`
+
+
+Using the TypoScriptFrontendController
+--------------------------------------
+
+..  code-block:: php
+
+    $GLOBALS['TSFE']->additionalHeaderData[$name] = $javaScriptCode;
+
+..  tip::
+    Instead of using the global variable for retrieving the
+    :php:`TypoScriptFrontendController` you should consider to use the
+    :ref:`PSR-7 request attribute <typo3-request-attributes>`
+    :ref:`frontend.controller <typo3-request-attribute-frontend-controller>`
+    wherever possible.

--- a/Documentation/ApiOverview/Assets/_MyClassWithAssetCollector.php
+++ b/Documentation/ApiOverview/Assets/_MyClassWithAssetCollector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\MyClass;
+
+use TYPO3\CMS\Core\Page\AssetCollector;
+
+final class MyClass
+{
+    private AssetCollector $assetCollector;
+
+    public function __construct(AssetCollector $assetCollector)
+    {
+        $this->assetCollector = $assetCollector;
+    }
+
+    public function doSomething()
+    {
+        // $this->assetCollector can now be used
+        // see examples below
+    }
+}

--- a/Documentation/ApiOverview/Assets/_MyClassWithPageRenderer.php
+++ b/Documentation/ApiOverview/Assets/_MyClassWithPageRenderer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\MyClass;
+
+use TYPO3\CMS\Core\Page\PageRenderer;
+
+final class MyClass
+{
+    private PageRenderer $pageRenderer;
+
+    public function __construct(PageRenderer $pageRenderer)
+    {
+        $this->pageRenderer = $pageRenderer;
+    }
+
+    public function doSomething()
+    {
+        // $this->pageRenderer can now be used
+        // see examples below
+    }
+}

--- a/Documentation/ApiOverview/RequestLifeCycle/Typo3Request.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Typo3Request.rst
@@ -148,6 +148,8 @@ This way, it is only referenced once. It can be cleaned up later easily when
 the request object is made available in that context in a future TYPO3 version.
 
 
+..  _typo3-request-attributes:
+
 Attributes
 ==========
 


### PR DESCRIPTION
Mainly:
- Use dependency injection in examples
- Remove list of former methods (TSFE, page renderer) to the end ($GLOBALS['TSFE']->setJS() does not exist anymore in v11)
- Add TOC
- Adjust wording

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1934 Releases: main, 11.5

Co-authored-by: Lina Wolf <48202465+linawolf@users.noreply.github.com>