### PR TITLE
[TASK] Revise "CLI tools for site handling" chapter

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/Basics.rst
+++ b/Documentation/ApiOverview/SiteHandling/Basics.rst
@@ -74,6 +74,7 @@ backend module, except for custom settings and additional routing configuration.
 
 
 ..  index:: Site handling; Site identifier
+..  _sitehandling-basics-site-identifier:
 
 Site identifier
 ---------------

--- a/Documentation/ApiOverview/SiteHandling/CliTools.rst
+++ b/Documentation/ApiOverview/SiteHandling/CliTools.rst
@@ -1,19 +1,57 @@
-.. include:: /Includes.rst.txt
-.. index:: Site handling; CLI tools
-.. _sitehandling-cliTools:
+..  include:: /Includes.rst.txt
+..  index:: Site handling; CLI tools
+..  _sitehandling-cliTools:
 
 ===========================
 CLI tools for site handling
 ===========================
 
-Two CLI commands are available:
+Two :ref:`CLI commands <symfony-console-commands>` are available:
 
-* site:list
-* site:show
+*   `site:list`
+*   `site:show`
 
-The list command can be executed via `typo3/sysext/core/bin/typo3 site:list` and will list all configured sites
-with their configured Identifier, root page, base URL, languages, locales and a flag whether or not the site is enabled.
 
-The show command can be executed via `typo3/sysext/core/bin/typo3 site:show <identifier>`.
-It needs an identifier of a configured site which must be provided after the command name.
-The command will output the complete configuration for the site in the YAML syntax.
+List all configured sites
+=========================
+
+The following command will list all configured sites with their identifier, root
+page, base URL, languages, locales and a flag whether or not the site is
+enabled.
+
+..  tabs::
+
+    ..  group-tab:: Composer-based installation
+
+        ..  code-block:: bash
+
+            vendor/bin/typo3 site:list
+
+    ..  group-tab:: Legacy installation
+
+        ..  code-block:: bash
+
+            typo3/sysext/core/bin/typo3 site:list
+
+
+Show configuration for one site
+===============================
+
+The show command needs an :ref:`identifier of a configured site
+<sitehandling-basics-site-identifier>` which must be provided after the command
+name. The command will output the complete configuration for the site in YAML
+syntax.
+
+..  tabs::
+
+    ..  group-tab:: Composer-based installation
+
+        ..  code-block:: bash
+
+            vendor/bin/typo3 site:show <identifier>
+
+    ..  group-tab:: Legacy installation
+
+        ..  code-block:: bash
+
+            typo3/sysext/core/bin/typo3 site:show <identifier>


### PR DESCRIPTION
- Structure content via headers
- Differentiate between Composer-based and legacy installation
- Link to appropriate destinations

Releases: main, 11.5