### PR TITLE
[DEPRECATION] #99120 - TypoScriptParser

### DIFF
--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -61,8 +61,8 @@ Get page TSConfig via PHP in an extension
 The page TSconfig for a specific page can be retrieved via the
 :php:`\TYPO3\CMS\Backend\Utility\BackendUtility::getPagesTSconfig()` method:
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
+..  code-block:: php
+    :caption: EXT:some_extension/Classes/SomeClass.php
 
     // use TYPO3\CMS\Backend\Utility\BackendUtility;
 

--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -55,40 +55,16 @@ in projects running many sites in the same page tree.
 
 .. index:: pair: Page TSconfig; PHP
 
-Get Page TSConfig via PHP in an extension
+Get page TSConfig via PHP in an extension
 -----------------------------------------
 
-..  todo:
-    Revise this section once the new TypoScript parser is stable. The
-    PageTsConfigParser relies on the old TypoScript parser as a constructor
-    argument.
-
-When there is the necessity for fetching and loading PageTSconfig,
-it is recommended for extension developers to make use of the PHP classes:
-
-- :php:`TYPO3\CMS\Core\Configuration\Loader\PageTsConfigLoader`
-- :php:`TYPO3\CMS\Core\Configuration\Parser\PageTsConfigParser`
-
-Usage for fetching all available PageTS in one large string (not parsed yet):
+The page TSconfig for a specific page can be retrieved via the
+:php:`\TYPO3\CMS\Backend\Utility\BackendUtility::getPagesTSconfig()` method:
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
 
-   $loader = GeneralUtility::makeInstance(PageTsConfigLoader::class);
-   $tsConfigString = $loader->load($rootLine);
+    // use TYPO3\CMS\Backend\Utility\BackendUtility;
 
-The string can then be put in proper TSconfig array syntax:
-
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
-
-   $parser = GeneralUtility::makeInstance(
-      PageTsConfigParser::class,
-      $typoScriptParser,
-      $hashCache
-   );
-   $pagesTSconfig = $parser->parse(
-      $tsConfigString,
-      $conditionMatcher
-   );
-
+    // Get the page TSconfig for the page with uid 42
+    $thePageTsConfig = BackendUtility::getPagesTSconfig(42);

--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -58,6 +58,11 @@ in projects running many sites in the same page tree.
 Get Page TSConfig via PHP in an extension
 -----------------------------------------
 
+..  todo:
+    Revise this section once the new TypoScript parser is stable. The
+    PageTsConfigParser relies on the old TypoScript parser as a constructor
+    argument.
+
 When there is the necessity for fetching and loading PageTSconfig,
 it is recommended for extension developers to make use of the PHP classes:
 

--- a/Documentation/Configuration/TypoScriptSyntax/Details/ParsingStoringExecutingTypoScript.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Details/ParsingStoringExecutingTypoScript.rst
@@ -11,6 +11,9 @@ Parsing, Storing and Executing TypoScript
 Parsing TypoScript
 ==================
 
+..  todo:
+    Revise this chapter once the new TypoScript parser is stable.
+
 This means that the TypoScript text content is transformed into a PHP
 array structure by following the rules of the TypoScript syntax. But
 still the meaning of the parsed content is not evaluated.
@@ -25,6 +28,11 @@ errors can therefore be seen only with a tool that analyzes the syntax
 The :php:`\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser` class is used to parse
 TypoScript content. Please see the section :ref:`typoscript-syntax-typoscript-parser-api`
 in this document for details.
+
+..  note::
+    The :php:`\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser` class is
+    deprecated since TYPO3 v12.2. For more information see
+    :ref:`ext_core:breaking-97816-1664800747`.
 
 
 .. index:: TypoScript; Storage

--- a/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Syntax/TypoScriptSyntax.rst
@@ -155,6 +155,13 @@ sortList
 
    Multiple parameters are separated by comma.
 
+
+..  todo:
+    Use new PSR-14 event "EvaluateModifierFunctionEvent":
+    https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98016-PSR-14EvaluateModifierFunctionEvent.html
+    The hook was removed in v12.0:
+    https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98016-RemovedTypoScriptFunctionHook.html
+
 There is a hook inside class :php:`\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser`
 which can be used to define more such functions.
 

--- a/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/CustomTypoScript.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/TypoScriptParserApi/CustomTypoScript.rst
@@ -7,6 +7,14 @@
 Parsing Custom TypoScript
 =========================
 
+..  todo:
+    Revise this chapter once the new TypoScript parser is stable.
+
+..  attention::
+    The :php:`\TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser` class used
+    in this example is deprecated since TYPO3 v12.2. For more information see
+    :ref:`ext_core:breaking-97816-1664800747`.
+
 .. note::
 
    This example will probably seem rather quaint. However it is


### PR DESCRIPTION
Add notes and todos about the deprecation where the old TypoScript parser is explained. This PR is only about the deprecation, once the new TypoScript parser is stable these chapters should be revised.

The transition from the ":=" hook to the PSR-14 event will be addressed in a separate PR.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/287
Releases: main