### PR TITLE
[TASK] Place information on how to create a command at one place

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -77,37 +77,8 @@ see :ref:`deactivating-the-command-in-scheduler`.
 Create a custom command
 =======================
 
-You can create a custom command by extending
-:php:`\Symfony\Component\Console\Command\Command`.
-
 See the :ref:`Tutorial: Create a console command <console-command-tutorial>`
 for details on how to create commands.
-
-A command has to be registered as a tag of name :yaml:`console.command`:
-
-.. code-block:: yaml
-   :caption: EXT:some_extension/Configuration/Services.yaml
-
-   services:
-     Vendor\SomeExtension\Command\DoThingsCommand:
-       tags:
-         - name: 'console.command'
-           command: 'someextension:dothings'
-           description: 'An example command that demonstrates some stuff'
-           schedulable: true
-           hidden: false
-
-
-.. _deactivating-the-command-in-scheduler:
-.. _schedulable:
-
-:yaml:`schedulable`
-    By default, a command can be used in the scheduler too.
-    This can be disabled by setting :yaml:`schedulable` to :yaml:`false`.
-
-:yaml:`hidden`
-    A command can be hidden from the command list by setting
-    :yaml:`hidden` to :yaml:`true`.
 
 Read more
 ==========

--- a/Documentation/ApiOverview/CommandControllers/Tutorial.rst
+++ b/Documentation/ApiOverview/CommandControllers/Tutorial.rst
@@ -52,6 +52,26 @@ definition for your class as tag :yaml:`console.command`:
             command: 'examples:dosomething'
             description: 'A command that does nothing and always succeeds.'
 
+The following attributes are available:
+
+:yaml:`command`
+    The name under which the command is available.
+
+:yaml:`description`
+    Give a short description. It will be displayed in the list of commands and
+    the help information of the command.
+
+.. _deactivating-the-command-in-scheduler:
+.. _schedulable:
+:yaml:`schedulable`
+    By default, a command can be used in the :doc:`scheduler
+    <ext_scheduler:Index>`, too. This can be disabled by setting
+    :yaml:`schedulable` to :yaml:`false`.
+
+:yaml:`hidden`
+    A command can be hidden from the command list by setting :yaml:`hidden` to
+    :yaml:`true`.
+
 ..  note::
     Despite using :file:`autoconfigure: true` the commands
     have to be explicitly defined in :file:`Configuration/Services.yaml`. It


### PR DESCRIPTION
Currently, a small part can be found on the CLI start page, but the information on how to create a command is available on the tutorial page. That information is now moved to the tutorial.

Releases: main, 11.5