### PR TITLE
[TASK] Remove warning about non-existing document (#2586)

### DIFF
--- a/Documentation/ApiOverview/Database/Index.rst
+++ b/Documentation/ApiOverview/Database/Index.rst
@@ -23,6 +23,5 @@ Database (Doctrine DBAL)
    ExpressionBuilder/Index
    RestrictionBuilder/Index
    Statement/Index
-   QueryHelper/Index
    Migration/Index
    TipsAndTricks/Index


### PR DESCRIPTION
Warning:
./Documentation/ApiOverview/Database/Index.rst:11: WARNING: toctree contains reference to nonexisting document 'ApiOverview/Database/QueryHelper/Index'

Releases: main, 11.5