### PR TITLE
[Backport 11.5] [TASK] Streamline upgrade wizards section (#2615)

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Concept.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Concept.rst
@@ -1,37 +1,37 @@
-.. include:: /Includes.rst.txt
-.. preferably, use label upgrade-wizards-concept
-.. index:: Upgrade wizards; Concept
-.. _update-wizards-concept:
-.. _upgrade-wizards-concept:
+..  include:: /Includes.rst.txt
+..  preferably, use label upgrade-wizards-concept
+..  index:: Upgrade wizards; Concept
+..  _update-wizards-concept:
+..  _upgrade-wizards-concept:
 
 ==============================
 The concept of upgrade wizards
 ==============================
 
-Upgrade wizards are single PHP classes that provide an automated way to update certain
-parts of a TYPO3 installation. Usually those affected parts are sections of the
-database (e.g. contents of fields change) as well as segments in the file system
-(e.g. locations of files have changed).
+Upgrade wizards are single PHP classes that provide an automated way to update
+certain parts of a TYPO3 installation. Usually those affected parts are sections
+of the database (for example, contents of fields change) as well as segments in
+the file system (for example, locations of files have changed).
 
-Wizards should be provided to ease updates for integrators and administrators. They
-are an addition to the database migration, which is handled by the Core based on
-:file:`ext_tables.sql`.
+Wizards should be provided to ease updates for integrators and administrators.
+They are an addition to the database migration, which is handled by the Core
+based on :ref:`ext_tables.sql <ext-tables-php>`.
 
-The execution order is not defined. Each administrator is able to execute wizards and
-migrations in any order. They are also completely skippable.
+The execution order is not defined. Each administrator is able to execute
+wizards and migrations in any order. They can also be skipped completely.
 
-Each wizard is able to check pre-conditions to prevent execution, if nothing has to
-be updated. The wizard can log information and executed SQL statements, that can be
-displayed after execution.
+Each wizard is able to check pre-conditions to prevent execution, if nothing has
+to be updated. The wizard can log information and executed SQL statements, that
+can be displayed after execution.
 
-Best Practice
+Best practice
 =============
 
-Each extension can provide as many upgrade wizards as necessary. Each wizard should do
-exactly one specific update.
+Each extension can provide as many upgrade wizards as necessary. Each wizard
+should perform exactly one specific update.
 
 Examples
 ========
 
-The TYPO3 Core  itself provides update wizards inside
-:file:`typo3/sysext/install/Classes/Updates/`.
+The TYPO3 Core itself provides upgrade wizards inside
+:t3src:`install/Classes/Updates/`.

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Creation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Creation.rst
@@ -1,9 +1,9 @@
-.. include:: /Includes.rst.txt
-.. preferably, use label "upgrade-wizards-creation"
-.. index:: Upgrade wizards; Creation
-.. _update-wizards-creation-generic:
-.. _upgrade-wizards-creation:
-.. _upgrade-wizard-interface:
+..  include:: /Includes.rst.txt
+..  preferably, use label "upgrade-wizards-creation"
+..  index:: Upgrade wizards; Creation
+..  _update-wizards-creation-generic:
+..  _upgrade-wizards-creation:
+..  _upgrade-wizard-interface:
 
 ========================
 Creating upgrade wizards
@@ -11,22 +11,22 @@ Creating upgrade wizards
 
 These steps create an upgrade wizard:
 
-.. rst-class:: bignums
+..  rst-class:: bignums
 
-#. Add a class implementing :ref:`UpgradeWizardInterface <upgrade-wizards-interface>`
+#.  Add a class implementing :ref:`UpgradeWizardInterface <upgrade-wizards-interface>`
 
-#. The class *may* implement other interfaces (optional):
+#.  The class *may* implement other interfaces (optional):
 
-   *  :ref:`RepeatableInterface <repeatable-interface>` to not mark the wizard
-      as done after execution
+    *   :ref:`RepeatableInterface <repeatable-interface>` to not mark the wizard
+        as done after execution
 
-   *  :ref:`ChattyInterface <uprade-wizards-chatty-interface>` for generating
-      output
+    *   :ref:`ChattyInterface <uprade-wizards-chatty-interface>` for generating
+        output
 
-   *  :php:`ConfirmableInferface` for wizards that need user confirmation
+    *   :php:`ConfirmableInferface` for wizards that need user confirmation
 
-#. :ref:`Register the wizard <upgrade-wizards-register>` in the file
-   :file:`ext_localconf.php`
+#.  :ref:`Register the wizard <upgrade-wizards-register>` in the file
+    :ref:`ext_localconf.php <ext-localconf-php>`
 
 
 .. _upgrade-wizards-interface:
@@ -34,132 +34,60 @@ These steps create an upgrade wizard:
 UpgradeWizardInterface
 ======================
 
-Each upgrade wizard consists of a single PHP file containing a single PHP class. This
-class has to implement :php:`TYPO3\CMS\Install\Updates\UpgradeWizardInterface` and its
-methods:
+Each upgrade wizard consists of a single PHP file containing a single PHP class.
+This class has to implement :php:`TYPO3\CMS\Install\Updates\UpgradeWizardInterface`
+and its methods:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Updates/ExampleUpdateWizard.php
+..  literalinclude:: _ExampleUpgradeWizard.php
+    :caption: EXT:my_extension/Classes/Upgrades/ExampleUpgradeWizard.php
 
-   <?php
-   namespace Vendor\MyExtension\Updates;
+Method :php:`getIdentifier()`
+    Return the identifier for this wizard. This should be the same string as
+    used in the :file:`ext_localconf.php` class registration.
 
-   use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+Method :php:`getTitle()`
+    Return the speaking name of this wizard.
 
-   class ExampleUpdateWizard implements UpgradeWizardInterface
-   {
-       /**
-        * Return the identifier for this wizard
-        * This should be the same string as used in the ext_localconf class registration
-        *
-        * @return string
-        */
-       public function getIdentifier(): string
-       {
-         return 'extName_exampleUpdateWizard';
-       }
+Method :php:`getDescription()`
+    Return the description for this wizard.
 
-       /**
-        * Return the speaking name of this wizard
-        *
-        * @return string
-        */
-       public function getTitle(): string
-       {
-         return 'Title of this updater';
-       }
+Method :php:`executeUpdate()`
+    Is called, if the user triggers the wizard. This method should contain, or
+    call, the code that is needed to execute the upgrade. Therefore, a boolean
+    has to be returned.
 
-       /**
-        * Return the description for this wizard
-        *
-        * @return string
-        */
-       public function getDescription(): string
-       {
-         return 'Description of this updater';
-       }
+Method :php:`updateNecessary()`
+    Is called to check whether the upgrade wizard has to run. Return
+    :php:`true`, if an upgrade is necessary, :php:`false` if not. If
+    :php:`false` is returned, the upgrade wizard will not be displayed in the
+    list of available wizards.
 
-       /**
-        * Execute the update
-        *
-        * Called when a wizard reports that an update is necessary
-        *
-        * @return bool
-        */
-       public function executeUpdate(): bool
-       {
-       }
+Method :php:`getPrerequisites()`
+    Returns an array of class names of prerequisite classes. This way, a wizard
+    can define dependencies before it can be performed. Currently, the following
+    prerequisites exist:
 
-       /**
-        * Is an update necessary?
-        *
-        * Is used to determine whether a wizard needs to be run.
-        * Check if data for migration exists.
-        *
-        * @return bool Whether an update is required (TRUE) or not (FALSE)
-        */
-       public function updateNecessary(): bool
-       {
-       }
+    *   `DatabaseUpdatedPrerequisite`:
+        Ensures that the database table fields are up-to-date.
+    *   `ReferenceIndexUpdatedPrerequisite`:
+        The reference index needs to be up-to-date.
 
-       /**
-        * Returns an array of class names of prerequisite classes
-        *
-        * This way a wizard can define dependencies like "database up-to-date" or
-        * "reference index updated"
-        *
-        * @return string[]
-        */
-       public function getPrerequisites(): array
-       {
-       }
-   }
+    ..  code-block:: php
+        :caption: EXT:my_extension/Classes/Upgrades/ExampleUpgradeWizard.php
 
-Method :php:`getIdentifier`
-   Return the identifier for this wizard. This should be the same string as used
-   in the ext_localconf class registration.
+        use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
+        use TYPO3\CMS\Install\Updates\ReferenceIndexUpdatedPrerequisite;
 
-Method :php:`getTitle`
-   Return the speaking name of this wizard.
-
-Method :php:`getDescription`
-   Return the description for this wizard.
-
-Method :php:`executeUpdate`
-   Is called if the user triggers the wizard. This method should contain, or call,
-   the code that is needed to execute the update. Therefore a boolean has to be
-   returned.
-
-Method :php:`updateNecessary`
-   Is called to check whether the upgrade wizard has to run. Return :php:`true`, if an
-   update is necessary, :php:`false` if not. If :php:`false` is returned, the upgrade
-   wizard will not be displayed in the list of available wizards.
-
-Method :php:`getPrerequisites`
-   Returns an array of class names of prerequisite classes. This way a wizard can
-   define dependencies before it can be run. Currently the following prerequisites exist:
-
-   #. `DatabaseUpdatedPrerequisite`:
-      Ensures that the database table fields are up-to-date.
-   #. `ReferenceIndexUpdatedPrerequisite`:
-      The reference index needs to be up-to-date.
-
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/Updates/ExampleUpdateWizard.php
-   
-   use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
-   use TYPO3\CMS\Install\Updates\ReferenceIndexUpdatedPrerequisite;
-
-   /**
-    * @return string[]
-    */
-   public function getPrerequisites(): array
-   {
-       return [
-           DatabaseUpdatedPrerequisite::class,
-           ReferenceIndexUpdatedPrerequisite::class,
-       ];
-   }
+        /**
+         * @return string[]
+         */
+        public function getPrerequisites(): array
+        {
+            return [
+                DatabaseUpdatedPrerequisite::class,
+                ReferenceIndexUpdatedPrerequisite::class,
+            ];
+        }
 
 
 .. index:: Upgrade wizards; Registration
@@ -171,15 +99,16 @@ Registering wizards
 Once the wizard is created, it needs to be registered. Registration is done in
 :file:`ext_localconf.php`:
 
-.. code-block:: php
-   :caption: EXT:my_extension/ext_localconf.php
+..  code-block:: php
+    :caption: EXT:my_extension/ext_localconf.php
 
-   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['extName_exampleUpdateWizard']
-      = \Vendor\ExtName\Updates\ExampleUpdateWizard::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['myExtension_exampleUpgradeWizard']
+        = \MyVendor\MyExtension\Upgrades\ExampleUpgradeWizard::class;
 
-**Important:** Use the same identifier as key (here: `extName_exampleUpdateWizard`), which
-is returned by :php:`UpgradeWizardInterface::getIdentifier()` in your wizard
-class.
+..  attention::
+    Use the same identifier as key (here: :php:`myExtension_exampleUpgradeWizard`),
+    which is returned by :php:`UpgradeWizardInterface::getIdentifier()` in your
+    wizard class.
 
 .. index:: Upgrade wizards; Identifier
 .. _upgrade-wizards-identifier:
@@ -189,34 +118,34 @@ Wizard identifier
 
 The wizard identifier is used:
 
-*  when calling the wizard from the :ref:`command line <upgrade_wizard_execute>`.
-*  when marking the wizard as done in the table :sql:`sys_registry`
+*   when calling the wizard from the :ref:`command line <upgrade_wizard_execute>`.
+*   when marking the wizard as done in the table :sql:`sys_registry`
 
-Since all upgrade wizards of TYPO3 core and extensions are registered using the
+Since all upgrade wizards of TYPO3 Core and extensions are registered using the
 identifier as key in the global array
 :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']`, it
-is recommended to prepend the wizard identifier with a prefix based on the extension key.
+is recommended to prepend the wizard identifier with a prefix based on the
+extension key.
 
-You SHOULD use the following naming convention for the identifier:
+You **should** use the following naming convention for the identifier:
 
-`extName_wizardName`, for example `bootstrapPackage_addNewDefaultTypes`
+`myExtension_wizardName`, for example `bootstrapPackage_addNewDefaultTypes`
 
-*  extension key and wizard name in lowerCamelCase, separated by underscore
-*  existing underscores in extension keys are replaced by capitalizing the
-   following letter
+*   The extension key and wizard name in lowerCamelCase, separated by underscore
+*   The existing underscores in extension keys are replaced by capitalizing the
+    following letter
 
-.. important::
-
-   Any identifier will still work, using these naming conventions is
-   not enforced. In fact, it is not recommended to change already
-   existing wizard identiers, as the information, that the wizard ran is
-   stored using the identifier in the :sql:`sys_registry` table and this
-   information would then be lost.
+..  attention::
+    Any identifier will still work, using these naming conventions is not
+    enforced. In fact, it is not recommended to change already existing wizard
+    identifiers: The information, that the wizard was performed is stored
+    using the identifier in the :sql:`sys_registry` table and this information
+    would then be lost.
 
 Some examples:
 
 +-------------------+-------------------------------------+
-| extension key     | wizard identifer                    |
+| Extension key     | Wizard identifier                   |
 +===================+=====================================+
 | container         | container_upgradeColumnPositions    |
 +-------------------+-------------------------------------+
@@ -233,12 +162,12 @@ Some examples:
 Marking wizard as done
 ======================
 
-As soon as the wizard has completely finished, for example it detected that no update is
-necessary anymore, the wizard
-is marked as done and won't be checked anymore.
+As soon as the wizard has completely finished, for example, it detected that no
+upgrade is necessary anymore, the wizard is marked as done and will not be
+checked anymore.
 
 To force TYPO3 to check the wizard every time, the interface
-:php:`\TYPO3\CMS\Install\Updates\RepeatableInterface` has to be implemented.
+:t3src:`install/Classes/Updates/RepeatableInterface.php` has to be implemented.
 This interface works as a marker and does not force any methods to be
 implemented.
 
@@ -250,99 +179,105 @@ implemented.
 Generating output
 =================
 
-The :php:`ChattyInterface` can be implemented for wizards which should generate output.
-:php:`ChattyInterface` uses the Symfony interface
-`OutputInterface <https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Output/OutputInterface.php>`__.
+The :php:`ChattyInterface` can be implemented for wizards which should generate
+output. :t3src:`install/Classes/Updates/ChattyInterface.php` uses the Symfony
+interface `OutputInterface`_.
+
+.. _OutputInterface: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Output/OutputInterface.php
 
 Classes using this interface must implement the following method:
 
-.. code-block:: php
-   :caption: vendor/symfony/console/Output/OutputInterface.php
+..  code-block:: php
+    :caption: vendor/symfony/console/Output/OutputInterface.php
 
-   /**
-   * Setter injection for output into upgrade wizards
-   *
-   * @param OutputInterface $output
-   */
-   public function setOutput(OutputInterface $output): void;
+    /**
+     * Setter injection for output into upgrade wizards
+     */
+     public function setOutput(OutputInterface $output): void;
 
+The class :t3src:`install/Classes/Updates/DatabaseUpdatedPrerequisite.php`
+implements this interface. We are showing a simplified example here, based on
+this class:
 
-The class :php:`FormFileExtensionUpdate` in the extension "form" implements this interface.
-We are showing a simplified example here, based on this class:
+..  code-block:: php
+    :caption: EXT:install/Classes/Updates/DatabaseUpdatedPrerequisite.php
+    :emphasize-lines: 8,10-13,20
 
-.. TODO: this class does not exist anymore
+    use Symfony\Component\Console\Output\OutputInterface;
 
-.. code-block:: php
-
-   use Symfony\Component\Console\Output\OutputInterface;
-   use TYPO3\CMS\Install\Updates\ChattyInterface;
-   use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
-
-   class FormFileExtensionUpdate implements ChattyInterface, UpgradeWizardInterface
-   {
+    class DatabaseUpdatedPrerequisite implements PrerequisiteInterface, ChattyInterface
+    {
         /**
-        * @var OutputInterface
-        */
-       protected $output;
+         * @var OutputInterface
+         */
+        protected $output;
 
+        public function setOutput(OutputInterface $output): void
+        {
+            $this->output = $output;
+        }
 
-       public function setOutput(OutputInterface $output): void
-       {
-           $this->output = $output;
-       }
+        public function ensure(): bool
+        {
+            $adds = $this->upgradeWizardsService->getBlockingDatabaseAdds();
+            $result = null;
+            if (count($adds) > 0) {
+                $this->output->writeln('Performing ' . count($adds) . ' database operations.');
+                $result = $this->upgradeWizardsService->addMissingTablesAndFields();
+            }
+            return $result === null;
+        }
 
-       /**
-        * Checks whether updates are required.
-        *
-        * @return bool Whether an update is required (TRUE) or not (FALSE)
-        */
-       public function updateNecessary(): bool
-       {
-           $updateNeeded = false;
+        // ... more logic
+    }
 
-           if (
-               $formDefinitionInformation['hasNewFileExtension'] === false
-               && $formDefinitionInformation['location'] === 'storage'
-           ) {
-               $updateNeeded = true;
-               $this->output->writeln('Form definition files were found that should be migrated to be named .form.yaml.');
-           }
-           // etc.
+..  index:: Upgrade wizards; Execution
 
-           return $updateNeeded;
-       }
-
-       // etc.
-
-   }
-
-.. index:: Upgrade wizards; Execution
-
-.. _upgrade_wizard_execute:
+..  _upgrade_wizard_execute:
 
 Executing the wizard
 ====================
 
-Wizards are listed inside the install tool, inside navigation "Upgrade" and the card "Upgrade Wizard".
-The registered wizard should be shown there, as long as it is not done.
+Wizards are listed in the backend module :guilabel:`Admin Tools > Upgrade` and
+the card :guilabel:`Upgrade Wizard`. The registered wizard should be shown
+there, as long as it is not done.
 
-It is also possible to execute the wizard from the command line.
+It is also possible to execute the wizard from the command line:
 
-.. code-block:: bash
+..  tabs::
 
-   # Run using our identifier 'extName_exampleUpdateWizard'
-   vendor/bin/typo3 upgrade:run extName_exampleUpdateWizard
+    ..  group-tab:: Composer-based installation
 
+        ..  code-block:: bash
 
-.. tip::
+            vendor/bin/typo3 upgrade:run myExtension_exampleUpgradeWizard
 
-   Some existing wizards use the convention of using the fully qualified class
-   name as identifer. You may have to quote the backslashes in the shell, e.g.
+    .. group-tab:: Legacy installation
 
-   .. code-block:: bash
+        .. code-block:: bash
 
-      vendor/bin/typo3 upgrade:run '\\Vendor\\ExtKey\\Upgrade\\ExampleUpgradeWizard'
+            typo3/sysext/core/bin/typo3 upgrade:run myExtension_exampleUpgradeWizard
 
-You can find more information about running upgrade wizards in the
-:ref:`Upgrade wizard section <t3install:use-the-upgrade-wizard>` of the
-Installation Guide.
+..  tip::
+    Some existing wizards use the convention of using the fully-qualified class
+    name as identifier. You may have to quote the backslashes in the shell,
+    for example:
+
+    ..  tabs::
+
+        ..  group-tab:: Composer-based installation
+
+            ..  code-block:: bash
+
+                vendor/bin/typo3 upgrade:run '\\MyVendor\\MyExtension\\Upgrade\\ExampleUpgradeWizard'
+
+        .. group-tab:: Legacy installation
+
+            .. code-block:: bash
+
+                typo3/sysext/core/bin/typo3 '\\MyVendor\\MyExtension\\Upgrade\\ExampleUpgradeWizard'
+
+..  seealso::
+    You can find more information about running upgrade wizards in the
+    :ref:`Upgrade wizard section <t3install:use-the-upgrade-wizard>` of the
+    Installation Guide.

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Index.rst
@@ -1,11 +1,11 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Upgrade wizards
-   Update wizards
-   see: Update wizards; Upgrade wizards
-.. preferably use label "upgrade-wizards"
-.. _update-wizards:
-.. _upgrade-wizards:
+..  include:: /Includes.rst.txt
+..  index::
+    Upgrade wizards
+    Update wizards
+    see: Update wizards; Upgrade wizards
+..  preferably use label "upgrade-wizards"
+..  _update-wizards:
+..  _upgrade-wizards:
 
 ===============
 Upgrade wizards
@@ -16,8 +16,8 @@ extensions. TYPO3 itself provides upgrade wizards to ease updates of TYPO3
 versions. This chapter will explain the concept and how to write upgrade
 wizards.
 
-.. toctree::
-   :titlesonly:
+..  toctree::
+    :titlesonly:
 
-   Concept
-   Creation
+    Concept
+    Creation

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/_ExampleUpgradeWizard.php
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/_ExampleUpgradeWizard.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Upgrades;
+
+use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
+
+final class ExampleUpgradeWizard implements UpgradeWizardInterface
+{
+    /**
+     * Return the identifier for this wizard
+     * This should be the same string as used in the ext_localconf.php class registration
+     */
+    public function getIdentifier(): string
+    {
+        return 'myExtension_exampleUpgradeWizard';
+    }
+
+    /**
+     * Return the speaking name of this wizard
+     */
+    public function getTitle(): string
+    {
+        return 'Title of this updater';
+    }
+
+    /**
+     * Return the description for this wizard
+     */
+    public function getDescription(): string
+    {
+        return 'Description of this updater';
+    }
+
+    /**
+     * Execute the update
+     *
+     * Called when a wizard reports that an update is necessary
+     */
+    public function executeUpdate(): bool
+    {
+        // Add your logic here
+    }
+
+    /**
+     * Is an update necessary?
+     *
+     * Is used to determine whether a wizard needs to be run.
+     * Check if data for migration exists.
+     *
+     * @return bool Whether an update is required (TRUE) or not (FALSE)
+     */
+    public function updateNecessary(): bool
+    {
+        // Add your logic here
+    }
+
+    /**
+     * Returns an array of class names of prerequisite classes
+     *
+     * This way a wizard can define dependencies like "database up-to-date" or
+     * "reference index updated"
+     *
+     * @return string[]
+     */
+    public function getPrerequisites(): array
+    {
+        // Add your logic here
+    }
+}


### PR DESCRIPTION
Mainly:
- Use "upgrade" instead of "update"
- Extract wizard example class into separate file
- Substitute ChattyInterface example class
- Link directly to interface source code

Releases: main, 11.5