### PR TITLE
[TASK] Add anchor for blinding options in configuration module

### DIFF
--- a/Documentation/Configuration/ConfigurationModule/Index.rst
+++ b/Documentation/Configuration/ConfigurationModule/Index.rst
@@ -141,6 +141,8 @@ you can use:
               disabled: true
 
 
+.. _config-module-blind-options:
+
 Blinding configuration options
 ==============================
 


### PR DESCRIPTION
This is needed to link from the v12 documentation to v11.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/345
Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/2644
Releases: 11.5