### PR TITLE
[FEATURE] #99713 - Allow blinding site configuration options in configuration module

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
@@ -12,10 +12,17 @@ ModifyBlindedConfigurationOptionsEvent
 
 The PSR-14 event :php:`\TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent`
 is fired in the :php:`\TYPO3\CMS\Lowlevel\ConfigurationModuleProvider\GlobalVariableProvider`
+and the :php:`\TYPO3\CMS\Lowlevel\ConfigurationModuleProvider\SitesYamlConfigurationProvider`
 while building the configuration array to be displayed in the
 :guilabel:`System > Configuration` module. It allows to blind (hide) any
 configuration options. Usually such options are passwords or other sensitive
 information.
+
+Using the :php:`getProviderIdentifier()` method of the event, listeners are able
+to determine the context the event got dispatched in. This is useful to prevent
+duplicate code execution, since the event is dispatched for multiple providers.
+The method returns the identifier of the configuration provider as registered
+in the :ref:`configuration module <config-module>`.
 
 
 Example
@@ -39,6 +46,8 @@ The corresponding event listener:
 
     namespace MyVendor\MyExtension\Backend;
 
+    use TYPO3\CMS\Lowlevel\ConfigurationModuleProvider\GlobalVariableProvider;
+    use TYPO3\CMS\Lowlevel\ConfigurationModuleProvider\SitesYamlConfigurationProvider;
     use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
 
     final class MyEventListener {
@@ -47,7 +56,11 @@ The corresponding event listener:
         {
             $options = $event->getBlindedConfigurationOptions();
 
-            $options['TYPO3_CONF_VARS']['EXTENSIONS']['my_extension']['password'] = '******';
+            if ($event->getProviderIdentifier() === 'sitesYamlConfiguration') {
+                $options['my-site']['settings']['apiKey'] = '***';
+            } elseif ($event->getProviderIdentifier() === 'confVars') {
+                $options['TYPO3_CONF_VARS']['EXTENSIONS']['my_extension']['password'] = '***';
+            }
 
             $event->setBlindedConfigurationOptions($options);
         }

--- a/Documentation/CodeSnippets/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst.txt
@@ -9,8 +9,18 @@
    
    .. php:method:: setBlindedConfigurationOptions(array $blindedConfigurationOptions)
    
+      Allows to define configuration options to be blinded
+      
       :param array $blindedConfigurationOptions: the blindedConfigurationOptions
       
    .. php:method:: getBlindedConfigurationOptions()
    
+      Returns the blinded configuration options
+      
       :returntype: array
+      
+   .. php:method:: getProviderIdentifier()
+   
+      Returns the configuration provider identifier, dispatching the event
+      
+      :returntype: string


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/343
Releases: main