### PR TITLE
[TASK] Use captions for code snippets in Localization/PHP chapter

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -26,7 +26,7 @@ to create a :ref:`LanguageService <LanguageService-api>` from the current
 site language:
 
 ..  literalinclude:: _php/MyUserFunction.php
-    :language: php
+    :caption: EXT:my_extension/Classes/UserFunction/MyUserFunction.php
 
 :ref:`DependencyInjection` should be available in most contexts where you need
 translations. Also the current request is available in entry point such as
@@ -39,7 +39,7 @@ In the backend context you can use the global variable :php:`$GLOBALS['LANG']`
 which contains the :ref:`LanguageService <LanguageService-api>`.
 
 ..  literalinclude:: _php/MyBackendClass.php
-    :language: php
+    :caption: EXT:my_extension/Classes/Backend/MyBackendClass.php
 
 ..  attention::
     During development you are usually logged into the backend. So the global
@@ -54,7 +54,7 @@ If you should happen to be in a context where none of these are available,
 for example a static function, you can still do translations:
 
 ..  literalinclude:: _php/MyUtility.php
-    :language: php
+    :caption: EXT:my_extension/Classes/Utility/MyUtility.php
 
 .. _extension-localization-extbase:
 
@@ -113,7 +113,7 @@ by a :ref:`PSR-15 middleware <request-handling>`.
 
 Beside other factories needed by our response, we inject the
 :ref:`LanguageServiceFactory <LanguageServiceFactory-api>` with
-:ref:`constructor dependency injection <Constructor-injection>`. 
+:ref:`constructor dependency injection <Constructor-injection>`.
 
 ..  include:: _php/_LanguageServiceFactoryDI.rst.txt
 

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Backend;
 
-/**
- * File EXT:my_extension/Classes/Backend/MyBackendClass.php
- */
+use TYPO3\CMS\Core\Localization\LanguageService;
+
 final class MyBackendClass
 {
-    private function translateSomething(string $lll): string
+    private function translateSomething(string $input): string
     {
-        return $GLOBALS['LANG']->sL($lll);
+        return $this->getLanguageService()->sL($input);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
     }
 
     // ...

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
@@ -8,9 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 
-/**
- * File EXT:my_extension/Classes/UserFunction/MyUserFunction.php
- */
 final class MyUserFunction
 {
     private LanguageService $languageService;

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
@@ -7,9 +7,6 @@ namespace MyVendor\MyExtension\Utility;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * File EXT:my_extension/Classes/Utility/MyUtility.php
- */
 final class MyUtility
 {
     private static function translateSomething(string $lll): string


### PR DESCRIPTION
Additionally, get LanguageService in backend context from a method as this makes clearer what you are getting (mind the return type hint). Also it is best practise to retrieve global variables this way.

Releases: main, 11.5