### PR TITLE
[Backport 11.5] [TASK] Use captions for code snippets in Localization/PHP chapter (#2651)

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -26,7 +26,7 @@ to create a :ref:`LanguageService <LanguageService-api>` from the current
 site language:
 
 ..  literalinclude:: _php/MyUserFunction.php
-    :language: php
+    :caption: EXT:my_extension/Classes/UserFunction/MyUserFunction.php
 
 :ref:`DependencyInjection` should be available in most contexts where you need
 translations. Also the current request is available in entry point such as
@@ -39,7 +39,7 @@ In the backend context you can use the global variable :php:`$GLOBALS['LANG']`
 which contains the :ref:`LanguageService <LanguageService-api>`.
 
 ..  literalinclude:: _php/MyBackendClass.php
-    :language: php
+    :caption: EXT:my_extension/Classes/Backend/MyBackendClass.php
 
 ..  attention::
     During development you are usually logged into the backend. So the global
@@ -54,7 +54,7 @@ If you should happen to be in a context where none of these are available,
 for example a static function, you can still do translations:
 
 ..  literalinclude:: _php/MyUtility.php
-    :language: php
+    :caption: EXT:my_extension/Classes/Utility/MyUtility.php
 
 .. _extension-localization-extbase:
 

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
@@ -3,14 +3,18 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Backend;
 
-/**
- * File EXT:my_extension/Classes/Backend/MyBackendClass.php
- */
+use TYPO3\CMS\Core\Localization\LanguageService;
+
 final class MyBackendClass
 {
-    private function translateSomething(string $lll): string
+    private function translateSomething(string $input): string
     {
-        return $GLOBALS['LANG']->sL($lll);
+        return $this->getLanguageService()->sL($input);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        return $GLOBALS['LANG'];
     }
 
     // ...

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
@@ -7,21 +7,16 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 
-/**
- * File EXT:my_extension/Classes/UserFunction/MyUserFunction.php
- */
 final class MyUserFunction
 {
-    private LanguageService $languageService;
+    private LanguageServiceFactory $languageServiceFactory;
 
-    public function __construct(
-        private readonly LanguageServiceFactory $languageServiceFactory,
-        ) {
+    public function __construct(LanguageServiceFactory $languageServiceFactory) {
+        $this->languageServiceFactory = $languageServiceFactory;
     }
 
-    private function getLanguageService(
-        ServerRequestInterface $request
-    ): LanguageService {
+    private function getLanguageService(ServerRequestInterface $request): LanguageService
+    {
         return $this->languageServiceFactory->createFromSiteLanguage(
             $request->getAttribute('language')
             ?? $request->getAttribute('site')->getDefaultLanguage()
@@ -33,8 +28,7 @@ final class MyUserFunction
         array $conf,
         ServerRequestInterface $request
     ): string {
-        $this->languageService = $this->getLanguageService($request);
-        return $this->languageService->getLL(
+        return $this->getLanguageService($request)->getLL(
             'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:something.'
         );
     }

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
@@ -6,9 +6,6 @@ namespace MyVendor\MyExtension\Utility;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-/**
- * File EXT:my_extension/Classes/Utility/MyUtility.php
- */
 final class MyUtility
 {
 


### PR DESCRIPTION
Additionally, use getLanguageService() in backend context from a method as this makes it clearer what you are getting (mind the return type hint). Also, it is best practise to retrieve global variables this way.

Releases: main, 11.5