### PR TITLE
[BUGFIX] #99835 - Correct name of the removed hook

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
@@ -1,19 +1,19 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterBackendPageRenderEvent
-.. _AfterBackendPageRenderEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterBackendPageRenderEvent
+..  _AfterBackendPageRenderEvent:
 
-====================================
+===========================
 AfterBackendPageRenderEvent
-====================================
+===========================
 
-.. versionadded:: 12.0
+..  versionadded:: 12.0
 
-   The PSR-14 event :php:`AfterBackendPageRenderEvent` has
-   been introduced which serves as a direct replacement for the removed hooks:
+    The PSR-14 event :php:`AfterBackendPageRenderEvent` has
+    been introduced which serves as a direct replacement for the removed hooks:
 
-   *  :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['constructorPostProcess']`
-   *  :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPreProcess']`
-   *  :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPostProcess']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['constructPostProcess']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPreProcess']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPostProcess']`
 
 This event gets triggered after the page in the backend is rendered and includes
 the rendered page body. Listeners may overwrite the page string if desired.
@@ -23,18 +23,18 @@ Example
 
 Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   Vendor\MyExtension\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/backend/after-backend-controller-render'
+    Vendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/after-backend-controller-render'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
     use TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent;
 
@@ -51,4 +51,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/AfterBackendPageRenderEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterBackendPageRenderEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
@@ -26,7 +26,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    Vendor\MyExtension\Backend\MyEventListener:
+    MyVendor\MyExtension\Backend\MyEventListener:
       tags:
         - name: event.listener
           identifier: 'my-extension/backend/after-backend-controller-render'
@@ -35,6 +35,8 @@ The corresponding event listener class:
 
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+
+    namespace MyVendor\MyExtension\Backend;
 
     use TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent;
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/354
Releases: main