### PR TITLE
[Backport 11.5] [IMPORTANT] #95297 - Strict cHash validation feature flag (#2664)

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -75,7 +75,7 @@ With :ref:`Routing` you can configure TYPO3 not to display the `cHash` in your U
 Routing adds an explicit mapping of incoming readable URL slugs to internal parameter values.
 This both adds an additional layer for validating slugs as well as reduces the parameters to a limited (and predictable) set of values.
 
-Various configuration options exist to configure the `cHash` behavior via :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']`
+Various configuration options exist to configure the `cHash` behavior via :ref:`$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']  <typo3ConfVars_fe_cacheHash>`
 in the file :file:`LocalConfiguration.php` or :file:`AdditionalConfiguration.php`:
 
 .. confval:: cachedParametersWhiteList
@@ -104,6 +104,14 @@ in the file :file:`LocalConfiguration.php` or :file:`AdditionalConfiguration.php
 .. confval:: excludeAllEmptyParameters
 
    If true, all parameters which are relevant for cHash are only considered if they are non-empty.
+
+.. confval:: enforceValidation
+
+   .. versionadded:: 10.4.35/11.5.23
+
+   If this option is enabled, the same validation is used to calculate a "cHash"
+   value as when a valid or invalid "cHash" parameter is given to a request,
+   even when no "cHash" is given.
 
 All properties can be configured with an array of values. Besides exact matches (*equals*) it is possible to apply partial matches at
 the beginning of a parameter (*startsWith*) or inline occurrences (*contains*).

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -676,6 +676,45 @@ _________________________
    If true, all parameters which are relevant for cHash are only considered
    if they are non-empty.
 
+..  index::
+    TYPO3_CONF_VARS FE; cacheHash enforceValidation
+..  _typo3ConfVars_fe_cacheHash_enforceValidation:
+
+enforceValidation
+_________________
+
+..  versionadded:: 10.4.35/11.5.23
+
+..  confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['enforceValidation']
+
+    :type: bool
+    :Default: false (for existing installations), true (for new installations)
+
+    If this option is enabled, the same validation is used to calculate a
+    "cHash" value as when a valid or invalid "cHash" parameter is given to a
+    request, even when no "cHash" is given.
+
+    ..  note::
+        The option is disabled for existing installations, but enabled for new
+        installations. It is also highly recommended to enable this option in
+        your existing installations as well.
+
+    **Details:**
+
+    Since TYPO3 v9 and the :ref:`PSR-15 middleware concept <request-handling>`,
+    cHash validation has been moved outside of plugins and rendering code inside
+    a validation middleware to check if a given "cHash" acts as a signature of
+    other query parameters in order to use a cached version of a frontend page.
+
+    However, the check only provided information about an invalid "cHash" in the
+    query parameters. If no "cHash" was given, the only option was to add a
+    "required list" (global TYPO3 configuration option
+    :ref:`requireCacheHashPresenceParameters <typo3ConfVars_fe_cacheHash_requireCacheHashPresenceParameters>`),
+    but not based on the final
+    :ref:`excludedParameters <typo3ConfVars_fe_cacheHash_excludedParameters>`
+    for the cache hash calculation of the given query parameters.
+
+
 .. index::
    TYPO3_CONF_VARS FE; workspacePreviewLogoutTemplate
 .. _typo3ConfVars_fe_workspacePreviewLogoutTemplate:


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/357
Releases: main, 11.5, 10.4