### PR TITLE
[TASK] Streamline extension manager events

### DIFF
--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionDatabaseContentHasImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionDatabaseContentHasImportedEvent.rst
@@ -1,15 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterExtensionDatabaseContentHasBeenImportedEvent
-.. _AfterExtensionDatabaseContentHasBeenImportedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterExtensionDatabaseContentHasBeenImportedEvent
+..  _AfterExtensionDatabaseContentHasBeenImportedEvent:
 
 
 =================================================
 AfterExtensionDatabaseContentHasBeenImportedEvent
 =================================================
 
-Event that is triggered after a package has imported the database file shipped within a t3d/xml import file.
+Event that is triggered after a package has imported the database file shipped
+within a t3d/xml import file.
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/ExtensionManager/AfterExtensionDatabaseContentHasBeenImportedEvent.rst.txt
+..  include:: /CodeSnippets/Events/ExtensionManager/AfterExtensionDatabaseContentHasBeenImportedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst
@@ -1,15 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterExtensionFilesHaveBeenImportedEvent
-.. _AfterExtensionFilesHaveBeenImportedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterExtensionFilesHaveBeenImportedEvent
+..  _AfterExtensionFilesHaveBeenImportedEvent:
 
 
 ========================================
 AfterExtensionFilesHaveBeenImportedEvent
 ========================================
 
-Event that is triggered after a package has imported all extension files (from `Initialisation/Files`).
+Event that is triggered after a package has imported all extension files
+(from :file:`Initialisation/Files/`).
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst.txt
+..  include:: /CodeSnippets/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionStaticDatabaseContentHasBeenImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionStaticDatabaseContentHasBeenImportedEvent.rst
@@ -1,15 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterExtensionStaticDatabaseContentHasBeenImportedEvent
-.. _AfterExtensionStaticDatabaseContentHasBeenImportedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterExtensionStaticDatabaseContentHasBeenImportedEvent
+..  _AfterExtensionStaticDatabaseContentHasBeenImportedEvent:
 
 
 =======================================================
 AfterExtensionStaticDatabaseContentHasBeenImportedEvent
 =======================================================
 
-Event that is triggered after a package has imported the database file shipped within "ext_tables_static+adt.sql".
+Event that is triggered after a package has imported the database file shipped
+within :file:`ext_tables_static+adt.sql`.
 
 API
----
+===
 
 .. include:: /CodeSnippets/Events/ExtensionManager/AfterExtensionStaticDatabaseContentHasBeenImportedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AvailableActionsForExtensionEvent
-.. _AvailableActionsForExtensionEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AvailableActionsForExtensionEvent
+..  _AvailableActionsForExtensionEvent:
 
 
 =================================
@@ -8,29 +8,9 @@ AvailableActionsForExtensionEvent
 =================================
 
 Event that is triggered when rendering an additional action (currently within
-a Fluid ViewHelper) in the Extension Manager.
-
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/EventListener/MyEventListener.php
-
-
-   public function getActions(): array
-   {
-       return $this->actions;
-   }
-
-   public function addAction(string $actionKey, string $content): void
-   {
-       $this->actions[$actionKey] = $content;
-   }
-
-   public function setActions(array $actions): void
-   {
-       $this->actions = $actions;
-   }
-
+a Fluid ViewHelper) in the extension manager.
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst.txt
+..  include:: /CodeSnippets/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst.txt


### PR DESCRIPTION
- Adjust indentations
- Adjust header chars
- Remove snippet from AvailableActionsForExtensionEvent as it only repeats the included API methods

Releases: main, 11.5