### PR TITLE
[TASK] Move file list events code snippets into separate files

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
@@ -11,7 +11,7 @@ ModifyEditFileFormDataEvent
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/file_edit.php']['preOutputProcessingHook']`
     hook.
 
-The PSR-14 event :php:`TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent`
+The PSR-14 event :php:`\TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent`
 allows to modify the form data, used to render the file edit form in the
 :guilabel:`File > Filelist` module using
 :ref:`FormEngine data compiling <FormEngine-DataCompiling>`.
@@ -22,38 +22,13 @@ Example
 
 Registration of the event in your extension's :file:`Services.yaml`:
 
-..  code-block:: yaml
-    :caption: EXT:my_package/Configuration/Services.yaml
-
-    MyVendor\MyPackage\EventListener\ModifyEditFileFormDataEventListener:
-        tags:
-            - name: event.listener
-              identifier: 'my-package/modify-edit-file-form-data-event-listener'
+..  literalinclude:: _Snippets/_ModifyEditFileFormDataEvent.yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
 The corresponding event listener class:
 
-..  code-block:: php
-   :caption: EXT:my_package/Classes/EventLister/ModifyEditFileFormDataEventListener.php
-
-    use TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent;
-
-    final class ModifyEditFileFormDataEventListener
-    {
-        public function __invoke(ModifyEditFileFormDataEvent $event): void
-        {
-            // Get current form data
-            $formData = $event->getFormData();
-
-            // Change TCA "renderType" based on the file extension
-            $fileExtension = $event->getFile()->getExtension();
-            if ($fileExtension === 'ts') {
-                $formData['processedTca']['columns']['data']['config']['renderType'] = 'tsRenderer';
-            }
-
-            // Set updated form data
-            $event->setFormData($formData);
-        }
-    }
+..  literalinclude:: _Snippets/_ModifyEditFileFormDataEventListener.php
+    :caption: EXT:my_extension/Classes/FileList/ModifyEditFileFormDataEventListener.php
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -16,29 +16,18 @@ This event can be used to manipulate the icons/actions, used for the edit contro
 section in the files and folders listing within the :guilabel:`File > Filelist`
 module.
 
+Example
+=======
+
 Registration of the event in the extension's :file:`Services.yaml`:
 
-..  code-block:: yaml
-
-    MyVendor\MyPackage\FileList\MyEventListener:
-        tags:
-            - name: event.listener
-              identifier: 'my-package/filelist/my-event-listener'
+..  literalinclude:: _Snippets/_ProcessFileListActionsEvent.yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
 The corresponding event listener class:
 
-..  code-block:: php
-
-    use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
-
-    final class MyEventListener {
-
-        public function __invoke(ProcessFileListActionsEvent $event): void
-        {
-            // do your magic
-        }
-
-    }
+..  literalinclude:: _Snippets/_ProcessFileListActionsEventListener.php
+    :caption: EXT:my_extension/Classes/FileList/ProcessFileListActionsEventListener.php
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEvent.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEvent.yaml
@@ -1,0 +1,4 @@
+MyVendor\MyExtension\FileList\ModifyEditFileFormDataEventListener:
+  tags:
+    - name: event.listener
+      identifier: 'my-extension/modify-edit-file-form-data-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEventListener.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\FileList;
+
+use TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent;
+
+final class ModifyEditFileFormDataEventListener
+{
+    public function __invoke(ModifyEditFileFormDataEvent $event): void
+    {
+        // Get current form data
+        $formData = $event->getFormData();
+
+        // Change TCA "renderType" based on the file extension
+        $fileExtension = $event->getFile()->getExtension();
+        if ($fileExtension === 'ts') {
+            $formData['processedTca']['columns']['data']['config']['renderType'] = 'tsRenderer';
+        }
+
+        // Set updated form data
+        $event->setFormData($formData);
+    }
+}

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEvent.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEvent.yaml
@@ -1,0 +1,4 @@
+MyVendor\MyExtension\FileList\MyEventListener:
+  tags:
+    - name: event.listener
+      identifier: 'my-extension/filelist/my-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEventListener.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\FileList;
+
+use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
+
+final class ProcessFileListActionsEventListener
+{
+    public function __invoke(ProcessFileListActionsEvent $event): void
+    {
+        // do your magic
+    }
+}


### PR DESCRIPTION
This is the first PR in a series to move the code snippets into separate files. This way, we can adapt coding styles easily and migrate PHP code to newer PHP versions via Rector automatically.

- YAML configuration is moved into separate files
- PHP classes are moved into separate files
- Namespaces are adjusted (from EventListener -> FileList)
- Avoid class name "MyEventListener", instead use the event name in class name
- Extension key is moved from "my_package" to "my_extension" to be more generic (and to avoid similarity with site package)

If this PR gets merged, the other events are adjusted in the same manner.

Releases: main, 11.5