### PR TITLE
[TASK] Streamline backend events

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
@@ -15,8 +15,9 @@ AfterBackendPageRenderEvent
     *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPreProcess']`
     *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['renderPostProcess']`
 
-This event gets triggered after the page in the backend is rendered and includes
-the rendered page body. Listeners may overwrite the page string if desired.
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent`
+gets triggered after the page in the backend is rendered and includes the
+rendered page body. Listeners may overwrite the page string if desired.
 
 Example
 =======
@@ -29,7 +30,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
     MyVendor\MyExtension\Backend\MyEventListener:
       tags:
         - name: event.listener
-          identifier: 'my-extension/backend/after-backend-controller-render'
+          identifier: 'my-extension/backend/after-backend-page-render'
 
 The corresponding event listener class:
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterFormEnginePageInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterFormEnginePageInitializedEvent.rst
@@ -1,15 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterFormEnginePageInitializedEvent
-.. _AfterFormEnginePageInitializedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterFormEnginePageInitializedEvent
+..  _AfterFormEnginePageInitializedEvent:
 
-
-====================================
+===================================
 AfterFormEnginePageInitializedEvent
-====================================
+===================================
 
-Event to listen to after the form engine has been initialized (= all data has been persisted).
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\AfterFormEnginePageInitializedEvent`
+is available to listen for after the :ref:`form engine <FormEngine>` has been
+initialized (all data has been persisted).
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/Backend/AfterFormEnginePageInitializedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterFormEnginePageInitializedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterHistoryRollbackFinishedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterHistoryRollbackFinishedEvent.rst
@@ -1,14 +1,15 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterHistoryRollbackFinishedEvent
-.. _AfterHistoryRollbackFinishedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterHistoryRollbackFinishedEvent
+..  _AfterHistoryRollbackFinishedEvent:
 
 =================================
 AfterHistoryRollbackFinishedEvent
 =================================
 
-This event is fired after a history record rollback finished.
+The PSR-14 event :php:`\TYPO3\CMS\Backend\History\Event\AfterHistoryRollbackFinishedEvent`
+is fired after a history record rollback finished.
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/Backend/AfterHistoryRollbackFinishedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterHistoryRollbackFinishedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst
@@ -1,34 +1,38 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Events; AfterPageColumnsSelectedForLocalizationEvent
-   Events; LocalizationController
-.. _AfterPageColumnsSelectedForLocalizationEvent:
+..  include:: /Includes.rst.txt
+..  index::
+    Events; AfterPageColumnsSelectedForLocalizationEvent
+    Events; LocalizationController
+..  _AfterPageColumnsSelectedForLocalizationEvent:
 
 ============================================
 AfterPageColumnsSelectedForLocalizationEvent
 ============================================
 
-Event to listen to after the form engine has been initialized (and all data has been persisted).
-
-The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\AfterPageColumnsSelectedForLocalizationEvent`
-will be dispatched after records and columns are collected in the :php:`LocalizationController`.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\AfterPageColumnsSelectedForLocalizationEvent`
+is available to listen for after the :ref:`form engine <FormEngine>` has been
+initialized (and all data has been persisted). It will be dispatched after
+records and columns are collected in the
+:php:`\TYPO3\CMS\Backend\Controller\Page\LocalizationController`.
 
 The event receives:
 
-* The default columns and columns list built by :php:`LocalizationController`
-* The list of records that were analyzed to create the columns manifest
-* The parameters received by the :php:`LocalizationController`
+*   The default columns and columns list built by :php:`LocalizationController`
+*   The list of records that were analyzed to create the columns manifest
+*   The parameters received by the :php:`LocalizationController`
 
 The event allows changes to:
 
-* the columns
-* the columns list
+*   the columns
+*   the columns list
 
-This allows third party code to read or manipulate the "columns manifest" that gets displayed in the
-translation modal when a user has clicked the ``Translate`` button in the page module, by implementing a listener for the event.
+This allows third-party code to read or manipulate the "columns manifest" that
+gets displayed in the translation modal when a user has clicked the
+:guilabel:`Translate` button in the page module, by implementing a listener for
+the event.
 
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
@@ -1,59 +1,59 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterPagePreviewUriGeneratedEvent
-.. _AfterPagePreviewUriGeneratedEvent:
-
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterPagePreviewUriGeneratedEvent
+..  _AfterPagePreviewUriGeneratedEvent:
 
 =================================
 AfterPagePreviewUriGeneratedEvent
 =================================
 
-.. versionadded:: 12.0
-   This PSR-14 event replaces the
-   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']`
-   postProcess hook.
+..  versionadded:: 12.0
+    This PSR-14 event replaces the
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']`
+    postProcess hook.
 
 The :php:`\TYPO3\CMS\Backend\Routing\Event\AfterPagePreviewUriGeneratedEvent`
 is executed in :php:`\TYPO3\CMS\Backend\Routing->buildUri()`, after the preview
 URI has been built - or set by an event listener to
 :ref:`BeforePagePreviewUriGeneratedEvent`. It allows to overwrite the built
-preview URI. This event however does not feature the possibility to modify the
-parameters, since this won't have any effect as the preview URI is directly
+preview URI. However, this event does not feature the possibility to modify the
+parameters, since this will not have any effect, as the preview URI is directly
 returned after event dispatching and no further action is done by the
-:php:`PreviewUriBuilder`.
+:php:`\TYPO3\CMS\Backend\Routing\PreviewUriBuilder`.
 
 Example
 =======
 
 Registration of the event in your extensions' :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/backend/modify-preview-uri'
-         method: 'modifyPreviewUri'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-preview-uri'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Routing\Event\AfterPagePreviewUriGeneratedEvent;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener
-   {
-       public function modifyPreviewUri(AfterPagePreviewUriGeneratedEvent $event): void
-       {
-           // Add custom fragment to built preview URI
-           $uri = $event->getPreviewUri();
-           $uri = $uri->withFragment('#customFragment');
-           $event->setPreviewUri($uri);
-       }
-   }
+    use TYPO3\CMS\Backend\Routing\Event\AfterPagePreviewUriGeneratedEvent;
+
+    final class MyEventListener
+    {
+        public function __invoke(AfterPagePreviewUriGeneratedEvent $event): void
+        {
+            // Add custom fragment to built preview URI
+            $uri = $event->getPreviewUri();
+            $uri = $uri->withFragment('#customFragment');
+            $event->setPreviewUri($uri);
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
@@ -1,61 +1,64 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; AfterPageTreeItemsPreparedEvent
-.. _AfterPageTreeItemsPreparedEvent:
-
+..  include:: /Includes.rst.txt
+..  index:: Events; AfterPageTreeItemsPreparedEvent
+..  _AfterPageTreeItemsPreparedEvent:
 
 ===============================
 AfterPageTreeItemsPreparedEvent
 ===============================
 
-.. versionadded:: 12.0
-   This PSR-14 event replaces the following hooks:
+..  versionadded:: 12.0
+    This PSR-14 event replaces the following hooks:
 
-   *  :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Workspaces\Service\WorkspaceService']['hasPageRecordVersions']`
-   *  :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Workspaces\Service\WorkspaceService']['fetchPagesWithVersionsInTable']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Workspaces\Service\WorkspaceService']['hasPageRecordVersions']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Workspaces\Service\WorkspaceService']['fetchPagesWithVersionsInTable']`
 
-This event allows prepared page tree items to be modified.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\AfterPageTreeItemsPreparedEvent`
+allows prepared page tree items to be modified.
 
-It is dispatched in the :php:`TYPO3\CMS\Backend\Controller\Page\TreeController`
+It is dispatched in the :php:`\TYPO3\CMS\Backend\Controller\Page\TreeController`
 class after the page tree items have been resolved and prepared. The event
-provides the current PSR-7 request as well as the page tree items. All items
-contain the corresponding page record in the special :php:`_page` key.
+provides the current PSR-7 request object as well as the page tree items. All
+items contain the corresponding page record in the special :php:`_page` key.
 
 Example
 =======
 
-Registration of the event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Workspaces\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/workspaces/modify-page-tree-items'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-page-tree-items'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Workspaces/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Controller\Event\AfterPageTreeItemsPreparedEvent;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener
-   {
-       public function __invoke(AfterPageTreeItemsPreparedEvent $event): void
-       {
-           $items = $event->getItems();
-           foreach ($items as $item) {
-               // Setting special item for page with id 123
-               if ($item['_page']['uid'] === 123) {
-                   $item['icon'] = 'my-special-icon';
-               }
-           }
-           $event->setItems($items);
-       }
-   }
+    use TYPO3\CMS\Backend\Controller\Event\AfterPageTreeItemsPreparedEvent;
+
+    final class MyEventListener
+    {
+        public function __invoke(AfterPageTreeItemsPreparedEvent $event): void
+        {
+            $items = $event->getItems();
+            foreach ($items as $item) {
+                // Setting special item for page with id 123
+                if ($item['_page']['uid'] === 123) {
+                    $item['icon'] = 'my-special-icon';
+                }
+            }
+            $event->setItems($items);
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/AfterPageTreeItemsPreparedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterPageTreeItemsPreparedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
@@ -8,7 +8,9 @@ AfterRecordSummaryForLocalizationEvent
 
 ..  versionadded:: 12.0
 
-The event is fired in the
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\AfterRecordSummaryForLocalizationEvent`
+is fired in the
 :php:`\TYPO3\CMS\Backend\Controller\Page\RecordSummaryForLocalization` class
 and allows extensions to modify the payload of the :php:`JsonResponse`.
 
@@ -21,7 +23,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    Vendor\MyExtension\EventListener\Backend\MyEventListener:
+    MyVendor\MyExtension\EventListener\Backend\MyEventListener:
         tags:
             - name: event.listener
               identifier: 'my-extension/backend/after-record-summary-for-localization'
@@ -30,6 +32,8 @@ The corresponding event listener class:
 
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+
+    namespace MyVendor\MyExtension\EventListener\Backend;
 
     use TYPO3\CMS\Backend\Controller\Event\AfterRecordSummaryForLocalizationEvent;
 
@@ -58,4 +62,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeFormEnginePageInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeFormEnginePageInitializedEvent.rst
@@ -1,14 +1,17 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; BeforeFormEnginePageInitializedEvent
-.. _BeforeFormEnginePageInitializedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; BeforeFormEnginePageInitializedEvent
+..  _BeforeFormEnginePageInitializedEvent:
 
 ====================================
 BeforeFormEnginePageInitializedEvent
 ====================================
 
-Event to listen to before the form engine has been initialized (= before all data will be persisted).
+The PSR-14 event
+:php:`TYPO3\CMS\Backend\Controller\Event\BeforeFormEnginePageInitializedEvent`
+allows to listen for before the :ref:`form engine <FormEngine>` has been
+initialized (before all data will be persisted).
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/Backend/BeforeFormEnginePageInitializedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/BeforeFormEnginePageInitializedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeHistoryRollbackStartEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeHistoryRollbackStartEvent.rst
@@ -1,14 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; BeforeHistoryRollbackStartEvent
-.. _BeforeHistoryRollbackStartEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; BeforeHistoryRollbackStartEvent
+..  _BeforeHistoryRollbackStartEvent:
 
 ===============================
 BeforeHistoryRollbackStartEvent
 ===============================
 
-This event is fired before a history record rollback starts.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\History\Event\BeforeHistoryRollbackStartEvent`
+is fired before a history record rollback starts.
 
 API
----
+===
 
-.. include:: /CodeSnippets/Events/Backend/BeforeHistoryRollbackStartEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/BeforeHistoryRollbackStartEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
@@ -1,47 +1,47 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; BeforeModuleCreationEvent
-.. _BeforeModuleCreationEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; BeforeModuleCreationEvent
+..  _BeforeModuleCreationEvent:
 
 =========================
 BeforeModuleCreationEvent
 =========================
 
-The PSR-14 event :ref:`BeforeModuleCreationEvent` allows extension authors
-to manipulate the module configuration, before it is used to create and
-register the module.
+The PSR-14 event :ref:`\TYPO3\CMS\Backend\Module\BeforeModuleCreationEvent`
+allows extension authors to manipulate the :ref:`module configuration
+<backend-modules-configuration>`, before it is used to create and register the
+module.
 
 Example
 =======
 
-Registration of an event listener in the :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\ModifyModuleIcon:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/backend/modify-module-icon'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-module-icon'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/ModifyModuleIcon.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Module\BeforeModuleCreationEvent;
+    use TYPO3\CMS\Backend\Module\BeforeModuleCreationEvent;
 
-   final class ModifyModuleIcon {
-
-       public function __invoke(BeforeModuleCreationEvent $event): void
-       {
-           // Change module icon of page module
-           if ($event->getIdentifier() === 'web_layout') {
-               $event->setConfigurationValue('iconIdentifider', 'my-custom-icon-identifier');
-           }
-       }
-   }
+    final class MyEventListener {
+        public function __invoke(BeforeModuleCreationEvent $event): void
+        {
+            // Change module icon of page module
+            if ($event->getIdentifier() === 'web_layout') {
+                $event->setConfigurationValue('iconIdentifier', 'my-custom-icon-identifier');
+            }
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/BeforeModuleCreationEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/BeforeModuleCreationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
@@ -1,65 +1,67 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; BeforePagePreviewUriGeneratedEvent
-.. _BeforePagePreviewUriGeneratedEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; BeforePagePreviewUriGeneratedEvent
+..  _BeforePagePreviewUriGeneratedEvent:
 
 
 ==================================
 BeforePagePreviewUriGeneratedEvent
 ==================================
 
-.. versionadded:: 12.0
-   This PSR-14 event replaces the
-   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']`
-   preProcess hook.
+..  versionadded:: 12.0
+    This PSR-14 event replaces the
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']`
+    preProcess hook.
 
 The :php:`\TYPO3\CMS\Backend\Routing\Event\BeforePagePreviewUriGeneratedEvent`
 is executed in :php:`\TYPO3\CMS\Backend\Routing->buildUri()`, before the preview
 URI is actually built. It allows to either adjust the parameters, such as the
 page id or the language id, or to set a custom preview URI, which will then stop
-the event propagation and also prevents :php:`PreviewUriBuilder` from building
-the URI based on the parameters.
+the event propagation and also prevents
+:php:`\TYPO3\CMS\Backend\Routing\PreviewUriBuilder` from building the URI based
+on the parameters.
 
-.. note::
-   The overwritten parameters are used for building the URI and are also passed
-   to the :ref:`AfterPagePreviewUriGeneratedEvent`. They however do not
-   overwrite the related class properties in :php:`PreviewUriBuilder`.
+..  note::
+    The overwritten parameters are used for building the URI and are also passed
+    to the :ref:`AfterPagePreviewUriGeneratedEvent`. They however do not
+    overwrite the related class properties in :php:`PreviewUriBuilder`.
 
 Example
 =======
 
-Registration of the event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/backend/modify-parameters'
-         method: 'modifyParameters'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-parameters'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Routing\Event\BeforePagePreviewUriGeneratedEvent;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener
-   {
-       public function modifyParameters(BeforePagePreviewUriGeneratedEvent $event): void
-       {
-           // Add custom query parameter before URI generation
-           $event->setAdditionalQueryParameters(
-               array_replace_recursive(
-                   $event->getAdditionalQueryParameters(),
-                   ['myParam' => 'paramValue']
-               )
-           );
-       }
-   }
+    use TYPO3\CMS\Backend\Routing\Event\BeforePagePreviewUriGeneratedEvent;
+
+    final class MyEventListener
+    {
+        public function __invoke(BeforePagePreviewUriGeneratedEvent $event): void
+        {
+            // Add custom query parameter before URI generation
+            $event->setAdditionalQueryParameters(
+                array_replace_recursive(
+                    $event->getAdditionalQueryParameters(),
+                    ['myParam' => 'paramValue']
+                )
+            );
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
@@ -1,20 +1,21 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; BeforeSearchInDatabaseRecordProviderEvent
-.. _BeforeSearchInDatabaseRecordProviderEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; BeforeSearchInDatabaseRecordProviderEvent
+..  _BeforeSearchInDatabaseRecordProviderEvent:
 
 =========================================
 BeforeSearchInDatabaseRecordProviderEvent
 =========================================
 
-.. versionadded:: 12.1
+..  versionadded:: 12.1
 
 The TYPO3 backend search (also known as "Live Search") uses the
 :php:`\TYPO3\CMS\Backend\Search\LiveSearch\DatabaseRecordProvider` to search
 for records in database tables, having :php:`searchFields` configured in TCA.
 
 In some individual cases it may not be desirable to search in a specific table.
-Therefore, the :php:`\TYPO3\CMS\Backend\Search\Event\BeforeSearchInDatabaseRecordProviderEvent`
-event is available, which allows to exclude / ignore such tables by adding them
+Therefore, the PSR-14 event
+:php:`\TYPO3\CMS\Backend\Search\Event\BeforeSearchInDatabaseRecordProviderEvent`
+is available, which allows to exclude / ignore such tables by adding them
 to a deny list. Additionally, the PSR-14 event can be used to restrict the
 search result on certain page IDs or to modify the search query altogether.
 
@@ -27,7 +28,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyExtension\EventListener\BeforeSearchInDatabaseRecordProviderEventListener:
+    MyVendor\MyExtension\EventListener\MyEventListener:
       tags:
         - name: event.listener
           identifier: 'my-extension/before-search-in-database-record-provider-event-listener'
@@ -35,11 +36,13 @@ Registration of the event in your extension's :file:`Services.yaml`:
 The corresponding event listener class:
 
 ..  code-block:: php
-    :caption: EXT:my_extension/Classes/EventListener/BeforeSearchInDatabaseRecordProviderEventListener.php
+    :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
+
+    namespace MyVendor\MyExtension\EventListener;
 
     use TYPO3\CMS\Backend\Search\Event\BeforeSearchInDatabaseRecordProviderEvent;
 
-    final class ModifyEditFileFormDataEventListener
+    final class MyEventListener
     {
         public function __invoke(BeforeSearchInDatabaseRecordProviderEvent $event): void
         {
@@ -51,4 +54,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/CustomFileControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/CustomFileControlsEvent.rst
@@ -8,10 +8,13 @@ CustomFileControlsEvent
 
 ..  versionadded:: 12.0
     This event replaces the :php:`customControls`
-    hook option, which is only available for TCA type :php:`inline`.
+    hook option, which is only available for TCA type
+    :ref:`inline <t3tca:columns-inline>`.
 
-Listeners to this event are able to add custom controls to a TCA type
-:php:`file` field in :ref:`FormEngine <FormEngine>`.
+Listeners to the PSR-14 event
+:php:`\TYPO3\CMS\Backend\Form\Event\CustomFileControlsEvent`
+are able to add custom controls to a TCA type
+:php:`file` field in :ref:`form engine <FormEngine>`.
 
 Custom controls are always displayed below the file references. In contrast
 to the selectors, e.g. :guilabel:`Select & upload files` are custom controls

--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -7,15 +7,15 @@ IsContentUsedOnPageLayoutEvent
 ==============================
 
 ..  versionadded:: 12.0
-    The PSR-14 event :php:`TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent`
-    has been introduced which serves as a drop-in replacement for the removed
+    This event :php:`TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent`
+    serves as a drop-in replacement for the removed
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['record_is_used']`
     hook.
 
-Use this event to identify if content has been used in a column that is not in
-a backend layout.
+Use the PSR-14 event :php:`\TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent`
+to identify if content has been used in a column that is not in a backend layout.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/IsContentUsedOnPageLayoutEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/IsContentUsedOnPageLayoutEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
@@ -20,15 +20,19 @@ Example
 Registration of the event in your extension's :file:`Services.yaml`:
 
 ..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyPackage\Backend\MyEventListener:
+    MyVendor\MyExtension\Backend\MyEventListener:
       tags:
         - name: event.listener
-          identifier: 'my-package/backend/modify-file-is-selectable'
+          identifier: 'my-extension/backend/modify-file-is-selectable'
 
 The corresponding event listener class:
 
 ..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+
+    namespace MyVendor\MyExtension\Backend;
 
     use TYPO3\CMS\Backend\ElementBrowser\Event\IsFileSelectableEvent;
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
@@ -10,13 +10,13 @@ ModifyAllowedItemsEvent
 ..  versionadded:: 12.0
     This event has been introduced together with
     :ref:`ModifyLinkHandlersEvent` to
-    serve as a direct replacement for the following removed hook:
-
-    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['LinkBrowser']['hooks']`
-
+    serve as a direct replacement for the following removed hook
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['LinkBrowser']['hooks']`.
     It replaces the method :php:`modifyAllowedItems()` in this hook.
 
-The event allows extensions to add or remove from the list of allowed link
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\ModifyAllowedItemsEvent`
+allows extension authors to add or remove from the list of allowed link
 types.
 
 ..  seealso::
@@ -32,7 +32,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    Vendor\MyExtension\Backend\MyEventListener:
+    MyVendor\MyExtension\Backend\MyEventListener:
         tags:
             - name: event.listener
               identifier: 'my-extension/backend/allowed-items'
@@ -42,7 +42,9 @@ The corresponding event listener class:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-    TYPO3\CMS\Backend\Controller\Event\ModifyAllowedItemsEvent;
+    namespace MyVendor\MyExtension\Backend;
+
+    use TYPO3\CMS\Backend\Controller\Event\ModifyAllowedItemsEvent;
 
     final class MyEventListener
     {
@@ -56,4 +58,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyAllowedItemsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyAllowedItemsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -1,22 +1,23 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyClearCacheActionsEvent
-.. _ModifyClearCacheActionsEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyClearCacheActionsEvent
+..  _ModifyClearCacheActionsEvent:
 
 
-====================================
+============================
 ModifyClearCacheActionsEvent
-====================================
+============================
 
-.. versionadded:: 11.4
+..  versionadded:: 11.4
 
-The :php:`ModifyClearCacheActionsEvent` is fired in the :php:`ClearCacheToolbarItem`
-class and allows extensions to modify the clear cache actions, shown
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
+is fired in the :php:`\TYPO3\CMS\Backend\Backend\ToolbarItems\ClearCacheToolbarItem`
+class and allows extension authors to modify the clear cache actions, shown
 in the TYPO3 backend top toolbar.
 
 The event can be used to change or remove existing clear cache
-actions, as well as to add new actions. Therefore the event also
+actions, as well as to add new actions. Therefore, the event also
 contains, next to the usual "getter" and "setter" methods, the convenience
-method :php:`add` for the :php:`cacheActions` and
+method :php:`add()` for the :php:`cacheActions` and
 :php:`cacheActionIdentifiers` arrays.
 
 Example
@@ -24,45 +25,45 @@ Example
 
 Registration of the event in the :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:some_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:some_extension/Configuration/Services.yaml
 
-   Vendor\SomeExtension\Toolbar\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/toolbar/my-event-listener'
+    MyVendor\MyExtension\Toolbar\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/toolbar/my-event-listener'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/EventListener/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
+
+    namespace MyVendor\MyExtension\Toolbar;
 
     use TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent;
 
     final class MyEventListener {
-
         public function __invoke(ModifyClearCacheActionsEvent $event): void
         {
             // do magic here
         }
-
     }
 
 The cache action array element consists of the following keys and values:
 
-.. code-block:: php
-   :caption: Example cache action array
+..  code-block:: php
+    :caption: Example cache action array
 
-   [
-       'id' => 'pages',
-       'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesTitle',
-       'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
-       'href' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
-       'iconIdentifier' => 'actions-system-cache-clear-impact-low'
-   ]
+    [
+        'id' => 'pages',
+        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesTitle',
+        'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
+        'href' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
+        'iconIdentifier' => 'actions-system-cache-clear-impact-low'
+    ]
 
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyClearCacheActionsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyClearCacheActionsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
@@ -7,15 +7,15 @@ ModifyDatabaseQueryForContentEvent
 ==================================
 
 ..  versionadded:: 12.0
-    The PSR-14 event :php:`TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent`
-    has been introduced which serves as a drop-in replacement for the removed
+    This event has been introduced which serves as a drop-in replacement for the removed
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][PageLayoutView::class]['modifyQuery']`
     hook.
 
-Use this event to filter out certain content elements from being shown in the
+Use the PSR-14 event :php:`TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent`
+to filter out certain content elements from being shown in the
 :guilabel:`Page` module.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyDatabaseQueryForContentEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyDatabaseQueryForContentEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
@@ -14,8 +14,10 @@ ModifyDatabaseQueryForRecordListingEvent
     *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList']['makeSearchStringConstraints']`
 
 
-This event allows to alter the :ref:`QueryBuilder <database-query-builder>` SQL
-statement before a list of records is rendered in record lists such as
+The PSR-14 event
+:php:`TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForRecordListingEvent`
+allows to alter the :ref:`query builder <database-query-builder>` SQL
+statement before a list of records is rendered in record lists, such as
 the :guilabel:`List` module or an element browser.
 
 Example
@@ -26,7 +28,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyExtension\Backend\View\ModifyDatabaseQueryForRecordListingEvent:
+    MyVendor\MyExtension\Backend\View\MyEventListener:
         tags:
             - name: event.listener
               identifier: 'my-extension/backend/modify-database-query-for-record-list'
@@ -34,11 +36,11 @@ Registration of the event in your extension's :file:`Services.yaml`:
 The corresponding event listener class:
 
 ..  code-block:: php
-    :caption: EXT:my_extension/Classes/Backend/View/ModifyDatabaseQueryForRecordListingEventListener.php
+    :caption: EXT:my_extension/Classes/Backend/View/MyEventListener.php
 
     use TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForRecordListingEvent;
 
-    final class ModifyDatabaseQueryForRecordListingEventListener
+    final class MyEventListener
     {
         public function __invoke(ModifyDatabaseQueryForRecordListingEvent $event): void
         {

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
@@ -7,13 +7,13 @@ ModifyEditFormUserAccessEvent
 =============================
 
 ..  versionadded:: 12.0
-    The PSR-14 event
-    :php:`TYPO3\CMS\Backend\Form\Event\ModifyEditFormUserAccessEvent\ModifyEditFormUserAccessEvent`
-    serves as a more powerful and flexible alternative for the removed
+    This event serves as a more powerful and flexible alternative for the removed
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/alt_doc.php']['makeEditForm_accessCheck']`
     hook.
 
-The event provides the full database row of the record in question next to the
+The PSR-14 event
+:php:`TYPO3\CMS\Backend\Form\Event\ModifyEditFormUserAccessEvent\ModifyEditFormUserAccessEvent`
+provides the full database row of the record in question next to the
 exception, which might have been set by the Core. Additionally, the event allows
 to modify the user access decision in an object-oriented way, using
 convenience methods.
@@ -30,7 +30,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyExtension\Backend\Form\ModifyEditFormUserAccessEventListener:
+    MyVendor\MyExtension\Backend\Form\MyEventListener:
         tags:
             - name: event.listener
               identifier: 'my-extension/backend/modify-edit-form-user-access'
@@ -38,11 +38,13 @@ Registration of the event in your extension's :file:`Services.yaml`:
 The corresponding event listener class:
 
 ..  code-block:: php
-    :caption: EXT:my_extension/Classes/Backend/Form/ModifyEditFormUserAccessEventListener.php
+    :caption: EXT:my_extension/Classes/Backend/Form/MyEventListener.php
+
+    namespace MyVendor\MyExtension\Backend\Form;
 
     use TYPO3\CMS\Backend\Form\Event\ModifyEditFormUserAccessEvent;
 
-    final class ModifyEditFormUserAccessEventListener
+    final class MyEventListener
     {
         public function __invoke(ModifyEditFormUserAccessEvent $event): void
         {
@@ -57,4 +59,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyEditFormUserAccessEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyEditFormUserAccessEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceControlsEvent.rst
@@ -8,10 +8,12 @@ ModifyFileReferenceControlsEvent
 
 ..  versionadded:: 12.0
 
-Listeners to this event are able to modify the controls of a single
-file reference of a TCA type :php:`file` field. This event is similar to the
+Listeners to the PSR-14 event
+:php:`\TYPO3\CMS\Backend\Form\Event\ModifyFileReferenceControlsEvent`
+are able to modify the controls of a single file reference of a TCA type
+:ref:`file <columns-file>` field. This event is similar to the
 :ref:`ModifyInlineElementControlsEvent`, which is only available for TCA
-type :php:`inline`.
+type :ref:`inline <columns-inline>`.
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceEnabledControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceEnabledControlsEvent.rst
@@ -8,10 +8,12 @@ ModifyFileReferenceEnabledControlsEvent
 
 ..  versionadded:: 12.0
 
-Listeners to this event are able to modify the state (enabled or disabled)
-for the controls of a single file reference of a TCA type :php:`file` field. This
+Listeners to the PSR-14 event
+:php:`\TYPO3\CMS\Backend\Form\Event\ModifyFileReferenceEnabledControlsEvent`
+are able to modify the state (enabled or disabled) for the controls of a single
+file reference of a TCA type :ref:`file <columns-file>` field. This
 event is similar to the :ref:`ModifyInlineElementEnabledControlsEvent`, which
-is only available for TCA type `inline`.
+is only available for TCA type :ref:`inline <columns-inline>`.
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
@@ -1,54 +1,57 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyGenericBackendMessagesEvent
-.. _ModifyGenericBackendMessagesEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyGenericBackendMessagesEvent
+..  _ModifyGenericBackendMessagesEvent:
 
-====================================
+=================================
 ModifyGenericBackendMessagesEvent
-====================================
+=================================
 
-.. versionadded:: 12.0
-   This event serves as direct replacement for the now removed hook
-   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['displayWarningMessages']`.
+..  versionadded:: 12.0
+    This event serves as direct replacement for the now removed hook
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['displayWarningMessages']`.
 
-This event allows to add or alter messages that are displayed
-in the "About" module (default start module of the TYPO3 Backend).
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\ModifyGenericBackendMessagesEvent`
+allows to add or alter messages that are displayed in the :guilabel:`About`
+module (default start module of the TYPO3 backend).
 
-Extensions such as the system extension EXT:reports use this event to display
-custom messages based on the status of the system:
+Extensions such as the :doc:`EXT:reports <ext_reports:Index>` system extension
+use this event to display custom messages based on the system status:
 
-.. include:: /Images/ManualScreenshots/Backend/GenericBackendMessage.rst.txt
+..  include:: /Images/ManualScreenshots/Backend/GenericBackendMessage.rst.txt
 
 Example
 =======
 
-Registration of an event listener in your extensions' :file:`Services.yaml`:
+Registration of an event listener in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/backend/add-message'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/add-message'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: my_extension/Classes/Backend/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Controller\Event\ModifyGenericBackendMessagesEvent;
-   use TYPO3\CMS\Core\Messaging\FlashMessage;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener {
+    use TYPO3\CMS\Backend\Controller\Event\ModifyGenericBackendMessagesEvent;
+    use TYPO3\CMS\Core\Messaging\FlashMessage;
 
-       public function __invoke(ModifyGenericBackendMessagesEvent $event): void
-       {
-           // Add a custom message
-           $event->addMessage(new FlashMessage('My custom message'));
-       }
-   }
+    final class MyEventListener {
+        public function __invoke(ModifyGenericBackendMessagesEvent $event): void
+        {
+            // Add a custom message
+            $event->addMessage(new FlashMessage('My custom message'));
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyGenericBackendMessagesEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyGenericBackendMessagesEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
@@ -1,60 +1,63 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Events; ModifyImageManipulationPreviewUrlEvent
-.. _ModifyImageManipulationPreviewUrlEvent:
+..  include:: /Includes.rst.txt
+..  index::
+    Events; ModifyImageManipulationPreviewUrlEvent
+..  _ModifyImageManipulationPreviewUrlEvent:
 
-============================================
+======================================
 ModifyImageManipulationPreviewUrlEvent
-============================================
+======================================
 
-.. versionadded:: 12.0
-   This event serves as a direct replacement for the now removed
-   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend/Form/Element/ImageManipulationElement']['previewUrl']`
-   hook.
+..  versionadded:: 12.0
+    This event serves as a direct replacement for the now removed
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend/Form/Element/ImageManipulationElement']['previewUrl']`
+    hook.
 
-This event can be used to modify the preview url within the image manipulation
-element, used for example for the :php:`crop` field of the
-:sql:`sys_file_reference` table.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Form\Event\ModifyImageManipulationPreviewUrlEvent`
+can be used to modify the preview URL within the
+:ref:`image manipulation <t3tca:columns-imageManipulation>` element, used
+for example for the :php:`crop` field of the :sql:`sys_file_reference` table.
 
-As soon as a preview url is set, the image manipulation element will display
+As soon as a preview URL is set, the image manipulation element will display
 a corresponding button in the footer of the modal window, next to the
 :guilabel:`Cancel` and :guilabel:`Accept` buttons. On click, the preview
-url will be opened in a new window.
+URL will be opened in a new window.
 
-.. note::
-
-    The elements crop variants will always be appended to the preview url
-    as json encoded string, using the `cropVariants` parameter.
+..  note::
+    The element's crop variants will always be appended to the preview URL
+    as JSON-encoded string, using the `cropVariants` parameter.
 
 Example
 =======
 
-Registration of the event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\ModifyLinkExplanationEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/backend/modify-imagemanipulation-previewurl'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-imagemanipulation-previewurl'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/ModifyLinkExplanationEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Form\Event\ModifyImageManipulationPreviewUrlEvent
+    namespace MyVendor\MyExtension\Backend;
 
-   final class ModifyLinkExplanationEventListener
-   {
-       public function __invoke(ModifyImageManipulationPreviewUrlEvent $event): void
-       {
-           $event->setPreviewUrl('https://example.com/some/preview/url');
-       }
-   }
+    use TYPO3\CMS\Backend\Form\Event\ModifyImageManipulationPreviewUrlEvent
+
+    final class MyEventListener
+    {
+        public function __invoke(ModifyImageManipulationPreviewUrlEvent $event): void
+        {
+            $event->setPreviewUrl('https://example.com/some/preview/url');
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
@@ -1,17 +1,17 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyInlineElementControlsEvent
-.. _ModifyInlineElementControlsEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyInlineElementControlsEvent
+..  _ModifyInlineElementControlsEvent:
 
-====================================
+================================
 ModifyInlineElementControlsEvent
-====================================
+================================
 
-.. versionadded:: 12.0
-   This event, together with :ref:`ModifyInlineElementEnabledControlsEvent`
-   serves as a more powerful and flexible replacement
-   for the removed hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tceforms_inline.php']['tceformsInlineHook']`
+..  versionadded:: 12.0
+    This event, together with :ref:`ModifyInlineElementEnabledControlsEvent`,
+    serves as a more powerful and flexible replacement
+    for the removed hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tceforms_inline.php']['tceformsInlineHook']`
 
-This event
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Form\Event\ModifyInlineElementControlsEvent`
 is called after the markup for all enabled controls has been generated. It
 can be used to either change the markup of a control, to add a new control
 or to completely remove a control.
@@ -23,53 +23,54 @@ Example
 
 Registration of the event in your extensions' :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyPackage\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/backend/modify-enabled-controls'
-         method: 'modifyEnabledControls'
-       - name: event.listener
-         identifier: 'my-package/backend/modify-controls'
-         method: 'modifyControls'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-enabled-controls'
+          method: 'modifyEnabledControls'
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-controls'
+          method: 'modifyControls'
 
 The corresponding event listener class:
 
-.. code-block:: php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementEnabledControlsEvent;
-   use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementControlsEvent;
-   use TYPO3\CMS\Core\Imaging\Icon;
-   use TYPO3\CMS\Core\Imaging\IconFactory;
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener {
+    use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementEnabledControlsEvent;
+    use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementControlsEvent;
+    use TYPO3\CMS\Core\Imaging\Icon;
+    use TYPO3\CMS\Core\Imaging\IconFactory;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-       public function modifyEnabledControls(ModifyInlineElementEnabledControlsEvent $event): void
-       {
-           // Enable a control depending on the foreign table
-           if ($event->getForeignTable() === 'sys_file_reference' && $event->isControlEnabled('sort')) {
-               $event->enableControl('sort');
-           }
-       }
+    final class MyEventListener {
+        public function modifyEnabledControls(ModifyInlineElementEnabledControlsEvent $event): void
+        {
+            // Enable a control depending on the foreign table
+            if ($event->getForeignTable() === 'sys_file_reference' && $event->isControlEnabled('sort')) {
+                $event->enableControl('sort');
+            }
+        }
 
-       public function modifyControls(ModifyInlineElementControlsEvent $event): void
-       {
-           // Add a custom control depending on the parent table
-           if ($event->getElementData()['inlineParentTableName'] === 'tt_content') {
-               $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
-               $event->setControl(
-                   'tx_my_control',
-                   '<a href="/some/url" class="btn btn-default t3js-modal-trigger">' . $iconFactory->getIcon('my-icon-identifier', Icon::SIZE_SMALL)->render() . '</a>'
-               );
-           }
-       }
-
-   }
+        public function modifyControls(ModifyInlineElementControlsEvent $event): void
+        {
+            // Add a custom control depending on the parent table
+            if ($event->getElementData()['inlineParentTableName'] === 'tt_content') {
+                $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+                $event->setControl(
+                    'tx_my_control',
+                    '<a href="/some/url" class="btn btn-default t3js-modal-trigger">' . $iconFactory->getIcon('my-icon-identifier', Icon::SIZE_SMALL)->render() . '</a>'
+                );
+            }
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyInlineElementControlsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyInlineElementControlsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst
@@ -7,19 +7,20 @@ ModifyInlineElementEnabledControlsEvent
 =======================================
 
 .. versionadded:: 12.0
-   This event, together with :ref:`ModifyInlineElementControlsEvent`
+   This event, together with :ref:`ModifyInlineElementControlsEvent`,
    serves as a more powerful and flexible replacement
    for the removed hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tceforms_inline.php']['tceformsInlineHook']`
 
-This event
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Form\Event\ModifyInlineElementEnabledControlsEvent`
 is called before any control markup is generated. It can be used to
 enable or disable each control. With this event it is therefore possible
 to enable a control, which is disabled in TCA, only for some use case.
 
-For an example see
-:ref:`ModifyInlineElementControlsEvent Example <ModifyInlineElementControlsEvent_example>`.
+See the
+:ref:`ModifyInlineElementControlsEvent example <ModifyInlineElementControlsEvent_example>`
+for details.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
@@ -1,19 +1,19 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyLinkExplanationEvent
-.. _ModifyLinkExplanationEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyLinkExplanationEvent
+..  _ModifyLinkExplanationEvent:
 
-=============================
+==========================
 ModifyLinkExplanationEvent
-=============================
+==========================
 
-.. versionadded:: 12.0
-   This event serves as a more powerful and flexible alternative
-   for the removed :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['linkHandler']`
-   hook.
+..  versionadded:: 12.0
+    This event serves as a more powerful and flexible alternative
+    for the removed :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['linkHandler']`
+    hook.
 
 While the removed hook effectively only allowed to modify the link explanation
 of TCA `link` fields in case the resolved link type did not already match
-one of those, implemented by TYPO3 itself, does the new event now allow to
+one of those, implemented by TYPO3 itself, the new event allows to
 always modify the link explanation of any type. Additionally, this also allows
 to modify the `additionalAttributes`, displayed below the actual link
 explanation field. This is especially useful for extended link handler setups.
@@ -40,41 +40,44 @@ The current context can be evaluated using the following methods:
 Example
 =======
 
-Registration of the event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyExtension\Backend\ModifyLinkExplanationEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/backend/modify-link-explanation'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-link-explanation'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/ModifyLinkExplanationEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Form\Event\ModifyLinkExplanationEvent;
-   use TYPO3\CMS\Core\Imaging\Icon;
-   use TYPO3\CMS\Core\Imaging\IconFactory;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class ModifyLinkExplanationEventListener
-   {
-       public function __construct(protected readonly IconFactory $iconFactory)
-       {
-       }
+    use TYPO3\CMS\Backend\Form\Event\ModifyLinkExplanationEvent;
+    use TYPO3\CMS\Core\Imaging\Icon;
+    use TYPO3\CMS\Core\Imaging\IconFactory;
 
-       public function __invoke(ModifyLinkExplanationEvent $event): void
-       {
-           // Use a custom icon for a custom link type
-           if ($event->getLinkData()['type'] === 'myCustomLinkType') {
-               $event->setLinkExplanationValue('icon', $this->iconFactory->getIcon('my-custom-link-icon', Icon::SIZE_SMALL)->render());
-           }
-       }
-   }
+    final class MyEventListener
+    {
+        public function __construct(
+            private readonly IconFactory $iconFactory
+        ) {
+        }
+
+        public function __invoke(ModifyLinkExplanationEvent $event): void
+        {
+            // Use a custom icon for a custom link type
+            if ($event->getLinkData()['type'] === 'myCustomLinkType') {
+                $event->setLinkExplanationValue('icon', $this->iconFactory->getIcon('my-custom-link-icon', Icon::SIZE_SMALL)->render());
+            }
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyLinkExplanationEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyLinkExplanationEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
@@ -10,13 +10,13 @@ ModifyLinkHandlersEvent
 ..  versionadded:: 12.0
     This event has been introduced together with
     :ref:`ModifyAllowedItemsEvent` to
-    serve as a direct replacement for the following removed hook:
-
-    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['LinkBrowser']['hooks']`
-
+    serve as a direct replacement for the following removed hook
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['LinkBrowser']['hooks']`.
     It replaces the method :php:`modifyLinkHandlers()` in this hook.
 
-The event is triggered before link handlers are executed, allowing listeners
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\ModifyLinkHandlersEvent`
+is triggered before link handlers are executed, allowing listeners
 to modify the set of handlers that will be used.
 
 ..  seealso::
@@ -31,7 +31,7 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    Vendor\MyExtension\Backend\MyEventListener:
+    MyVendor\MyExtension\Backend\MyEventListener:
         tags:
             - name: event.listener
               identifier: 'my-extension/backend/link-handlers'
@@ -40,6 +40,8 @@ The corresponding event listener class:
 
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+
+    namespace MyVendor\MyExtension\Backend;
 
     use TYPO3\CMS\Backend\Controller\Event\ModifyLinkHandlersEvent;
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
@@ -1,63 +1,67 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyNewContentElementWizardItemsEvent
-.. _ModifyNewContentElementWizardItemsEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyNewContentElementWizardItemsEvent
+..  _ModifyNewContentElementWizardItemsEvent:
 
-=============================================
+=======================================
 ModifyNewContentElementWizardItemsEvent
-=============================================
+=======================================
 
-.. versionadded:: 12.0
-   This event serves as a more powerful and flexible alternative
-   for the removed hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']`.
+..  versionadded:: 12.0
+    This event serves as a more powerful and flexible alternative
+    for the removed hook :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms']['db_new_content_el']['wizardItemsHook']`.
 
-The event is called after TYPO3 has already prepared the wizard items,
-defined in TSconfig (:typoscript:`mod.wizards.newContentElement.wizardItems`).
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\ModifyNewContentElementWizardItemsEvent`
+is called after TYPO3 has already prepared the wizard items,
+defined in page TSconfig (:ref:`mod.wizards.newContentElement.wizardItems
+<t3tsconfig:pagenewcontentelementwizard>`).
 
 The event allows listeners to modify any available wizard item as well
-as adding new ones. It's therefore possible for the listeners to e.g. change
-the configuration, the position or to remove existing items altogether.
+as adding new ones. It is therefore possible for the listeners to, for example,
+change the configuration, the position or to remove existing items altogether.
 
 Example
 =======
 
-Registration of the event in your extensions' :file:`Services.yaml`:
+Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   MyVendor\MyPackage\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/backend/modify-wizard-items'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-wizard-items'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
-   use TYPO3\CMS\Backend\Controller\Event\ModifyNewContentElementWizardItemsEvent;
+    namespace MyVendor\MyExtension\Backend;
 
-   final class MyEventListener {
+    use TYPO3\CMS\Backend\Controller\Event\ModifyNewContentElementWizardItemsEvent;
 
-       public function __invoke(ModifyNewContentElementWizardItemsEvent $event): void
-       {
-           // Add a new wizard item after "textpic"
-           $event->setWizardItem(
-               'my_element',
-               [
-                   'iconIdentifier' => 'icon-my-element',
-                   'title' => 'My element',
-                   'description' => 'My element description',
-                   'tt_content_defValues' => [
-                       'CType' => 'my_element'
-                   ],
-               ],
-               ['after' => 'common_textpic']
-           );
-       }
-   }
+    final class MyEventListener {
+        public function __invoke(ModifyNewContentElementWizardItemsEvent $event): void
+        {
+            // Add a new wizard item after "textpic"
+            $event->setWizardItem(
+                'my_element',
+                [
+                    'iconIdentifier' => 'icon-my-element',
+                    'title' => 'My element',
+                    'description' => 'My element description',
+                    'tt_content_defValues' => [
+                        'CType' => 'my_element'
+                    ],
+                ],
+                ['after' => 'common_textpic']
+            );
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -1,14 +1,15 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyPageLayoutContentEvent
-.. _ModifyPageLayoutContentEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyPageLayoutContentEvent
+..  _ModifyPageLayoutContentEvent:
 
 =============================
 ModifyPageLayoutContentEvent
 =============================
 
-.. versionadded:: 12.0
+..  versionadded:: 12.0
 
-Event for modifying page module content.
+The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent`
+allows to modify page module content.
 
 This event features the methods :php:`getRequest()`, :php:`getModuleTemplate()`
 and additional getters and setters for the header and footer
@@ -22,37 +23,36 @@ Example
 
 Registration of the event in your extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   Vendor\MyExtension\Backend\MyEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-package/backend/modify-page-module-content'
+    MyVendor\MyExtension\Backend\MyEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/backend/modify-page-module-content'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
-   namespace Vendor\MyExtension\Backend\MyEventListener;
+    namespace MyVendor\MyExtension\Backend\MyEventListener;
 
-   use TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent;
+    use TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent;
 
-   final class MyEventListener {
+    final class MyEventListener {
+        public function __invoke(ModifyPageLayoutContentEvent $event): void
+        {
+            $event->addHeaderContent('Additional header content');
 
-       public function __invoke(ModifyPageLayoutContentEvent $event): void
-       {
-           $event->addHeaderContent('Additional header content');
-
-           $event->setFooterContent('Overwrite footer content');
-       }
-   }
+            $event->setFooterContent('Overwrite footer content');
+        }
+    }
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyPageLayoutContentEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyPageLayoutContentEvent.rst.txt
 
 History / Migration
 ===================
@@ -69,7 +69,8 @@ has been the only public method, which is now directly included in the event.
 
 An example to get the current :php:`$id`:
 
-.. code-block:: php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
     public function __invoke(ModifyPageLayoutContentEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
@@ -1,15 +1,17 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyPageLayoutOnLoginProviderSelectionEvent
-.. _ModifyPageLayoutOnLoginProviderSelectionEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyPageLayoutOnLoginProviderSelectionEvent
+..  _ModifyPageLayoutOnLoginProviderSelectionEvent:
 
 =============================================
 ModifyPageLayoutOnLoginProviderSelectionEvent
 =============================================
 
-Allows to modify variables for the view depending
-on a special login provider set in the controller.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\LoginProvider\Event\ModifyPageLayoutOnLoginProviderSelectionEvent`
+allows to modify variables for the view depending on a special login provider
+set in the controller.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
@@ -1,64 +1,66 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; ModifyQueryForLiveSearchEvent
-.. _ModifyQueryForLiveSearchEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; ModifyQueryForLiveSearchEvent
+..  _ModifyQueryForLiveSearchEvent:
 
 =============================
 ModifyQueryForLiveSearchEvent
 =============================
 
-.. versionadded:: 12.0
+..  versionadded:: 12.0
 
-This event can be used to modify the live search queries in the backend.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Search\Event\ModifyQueryForLiveSearchEvent`
+can be used to modify the live search queries in the backend.
 
-This can be used to adjust the limit for a specific
-table or to change the result order.
+This can be used to adjust the limit for a specific table or to change the
+result order.
 
 This event is fired in the
 :php:`\TYPO3\CMS\Backend\Search\LiveSearch\LiveSearch` class
-and allows extensions to modify the :php:`QueryBuilder` instance
-before execution.
+and allows extensions to modify the :ref:`query builder <database-query-builder>`
+instance before execution.
 
 Example
 =======
 
 Registration of the event in your extensions' :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
+..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-   Vendor\MyExtension\HrefLang\EventListener\ModifyQueryForLiveSearchEventListener:
-     tags:
-       - name: event.listener
-         identifier: 'my-extension/modify-query-for-live-search-event-listener'
+    MyVendor\MyExtension\HrefLang\EventListener\ModifyQueryForLiveSearchEventListener:
+      tags:
+        - name: event.listener
+          identifier: 'my-extension/modify-query-for-live-search-event-listener'
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/HrefLang/EventListener/MyEventListener.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/HrefLang/EventListener/MyEventListener.php
 
-   namespace Vendor\MyExtension\HrefLang\EventListener;
+    namespace MyVendor\MyExtension\HrefLang\EventListener;
 
-   use TYPO3\CMS\Backend\Search\Event\ModifyQueryForLiveSearchEvent;
+    use TYPO3\CMS\Backend\Search\Event\ModifyQueryForLiveSearchEvent;
 
-   final class ModifyQueryForLiveSearchEventListener
-   {
-       public function __invoke(ModifyQueryForLiveSearchEvent $event): void
-       {
-           // Get the current instance
-           $queryBuilder = $event->getQueryBuilder();
+    final class ModifyQueryForLiveSearchEventListener
+    {
+        public function __invoke(ModifyQueryForLiveSearchEvent $event): void
+        {
+            // Get the current instance
+            $queryBuilder = $event->getQueryBuilder();
 
-           // Change limit depending on the table
-           if ($event->getTableName() === 'pages') {
-               $queryBuilder->setMaxResults(2);
-           }
+            // Change limit depending on the table
+            if ($event->getTableName() === 'pages') {
+                $queryBuilder->setMaxResults(2);
+            }
 
-           // Reset the orderBy part
-           $queryBuilder->resetQueryPart('orderBy');
-       }
-   }
+            // Reset the orderBy part
+            $queryBuilder->resetQueryPart('orderBy');
+        }
+    }
 
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyQueryForLiveSearchEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyQueryForLiveSearchEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListHeaderColumnsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListHeaderColumnsEvent.rst
@@ -12,14 +12,16 @@ ModifyRecordListHeaderColumnsEvent
 ..  versionchanged:: 12.0
     Due to the integration of EXT:recordlist into EXT:backend the namespace of
     the event changed from
-    :php:`TYPO3\CMS\Recordlist\Event\ModifyRecordListHeaderColumnsEvent`
+    :php:`\TYPO3\CMS\Recordlist\Event\ModifyRecordListHeaderColumnsEvent`
     to
-    :php:`TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListHeaderColumnsEvent`.
+    :php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListHeaderColumnsEvent`.
     For TYPO3 v12 the moved class is available as an alias under the old
     namespace to allow extensions to be compatible with TYPO3 v11 and v12.
 
 
-An event to modify the header columns for a table in the record list.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListHeaderColumnsEvent`
+allows to modify the header columns for a table in the record list.
 
 Usage
 =====
@@ -29,4 +31,4 @@ See :ref:`combined usage example <ModifyRecordListTableActionsEvent-usage>`.
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyRecordListHeaderColumnsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyRecordListHeaderColumnsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListRecordActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListRecordActionsEvent.rst
@@ -12,13 +12,15 @@ ModifyRecordListRecordActionsEvent
 ..  versionchanged:: 12.0
     Due to the integration of EXT:recordlist into EXT:backend the namespace of
     the event changed from
-    :php:`TYPO3\CMS\Recordlist\Event\ModifyRecordListRecordActionsEvent`
+    :php:`\TYPO3\CMS\Recordlist\Event\ModifyRecordListRecordActionsEvent`
     to
-    :php:`TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent`.
+    :php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent`.
     For TYPO3 v12 the moved class is available as an alias under the old
     namespace to allow extensions to be compatible with TYPO3 v11 and v12.
 
-An event to modify the displayed record actions (for example
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListRecordActionsEvent`
+allows to modify the displayed record actions (for example
 :guilabel:`edit`, :guilabel:`copy`, :guilabel:`delete`) for a table in
 the record list.
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
@@ -12,13 +12,15 @@ ModifyRecordListTableActionsEvent
 ..  versionchanged:: 12.0
     Due to the integration of EXT:recordlist into EXT:backend the namespace of
     the event changed from
-    :php:`TYPO3\CMS\Recordlist\Event\ModifyRecordListTableActionsEvent`
+    :php:`\TYPO3\CMS\Recordlist\Event\ModifyRecordListTableActionsEvent`
     to
-    :php:`TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent`.
+    :php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent`.
     For TYPO3 v12 the moved class is available as an alias under the old
     namespace to allow extensions to be compatible with TYPO3 v11 and v12.
 
-An event to modify the multi record selection actions (for example
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent`
+allows to modify the multi record selection actions (for example
 :guilabel:`edit`, :guilabel:`copy to clipboard`) for a table in the record list.
 
 ..  _ModifyRecordListTableActionsEvent-usage:
@@ -26,25 +28,29 @@ An event to modify the multi record selection actions (for example
 Usage
 =====
 
-An example registration of the events in your extensions' :file:`Services.yaml`:
+An example registration of the events in your extension's :file:`Services.yaml`:
 
 ..  code-block:: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyPackage\RecordList\MyEventListener:
+    MyVendor\MyExtension\RecordList\MyEventListener:
         tags:
             - name: event.listener
-              identifier: 'my-package/recordlist/my-event-listener'
+              identifier: 'my-extension/recordlist/my-event-listener'
               method: 'modifyRecordActions'
             - name: event.listener
-              identifier: 'my-package/recordlist/my-event-listener'
+              identifier: 'my-extension/recordlist/my-event-listener'
               method: 'modifyHeaderColumns'
             - name: event.listener
-              identifier: 'my-package/recordlist/my-event-listener'
+              identifier: 'my-extension/recordlist/my-event-listener'
               method: 'modifyTableActions'
 
 The corresponding event listener class:
 
 ..  code-block:: php
+    :caption: EXT:my_extension/Classes/RecordList/MyEventListener.php
+
+    namespace MyVendor\MyExtension\RecordList;
 
     use Psr\Log\LoggerInterface;
     use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListHeaderColumnsEvent;
@@ -52,8 +58,7 @@ The corresponding event listener class:
     use TYPO3\CMS\Backend\RecordList\Event\ModifyRecordListTableActionsEvent;
 
     final class MyEventListener {
-
-        protected LoggerInterface $logger;
+        private LoggerInterface $logger;
 
         public function __construct(LoggerInterface $logger)
         {
@@ -111,4 +116,4 @@ The corresponding event listener class:
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/ModifyRecordListTableActionsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/ModifyRecordListTableActionsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
@@ -24,15 +24,15 @@ Registration of the event in your extension's :file:`Services.yaml`:
 ..  code-block:: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
-    MyVendor\MyExtension\Search\EventListener\AddLiveSearchResultActionsListener:
+    MyVendor\MyExtension\Search\EventListener\MyEventListener:
       tags:
         - name: event.listener
-          identifier: 'my-vendor/my-extension/add-live-search-result-actions-listener'
+          identifier: 'my-extension/add-live-search-result-actions-listener'
 
 The corresponding event listener class:
 
 ..  code-block:: php
-    :caption: EXT:my_extension/Search/EventListener/AddLiveSearchResultActionsListener.php
+    :caption: EXT:my_extension/Search/EventListener/MyEventListener.php
 
     namespace MyVendor\MyExtension\Search\EventListener;
 
@@ -42,14 +42,14 @@ The corresponding event listener class:
     use TYPO3\CMS\Core\Imaging\Icon;
     use TYPO3\CMS\Core\Imaging\IconFactory;
 
-    final class AddLiveSearchResultActionsListener
+    final class MyEventListener
     {
-        protected LanguageService $languageService;
+        private readonly LanguageService $languageService;
 
         public function __construct(
-            protected readonly IconFactory $iconFactory,
-            protected readonly LanguageServiceFactory $languageServiceFactory,
-            protected readonly UriBuilder $uriBuilder
+            private readonly IconFactory $iconFactory,
+            LanguageServiceFactory $languageServiceFactory,
+            private readonly UriBuilder $uriBuilder
         ) {
             $this->languageService = $this->languageServiceFactory->createFromUserPreferences($GLOBALS['BE_USER']);
         }

--- a/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
@@ -7,15 +7,16 @@ PageContentPreviewRenderingEvent
 ================================
 
 ..  versionadded:: 12.0
-    The PSR-14 event :php:`TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent`
-    has been introduced which serves as a drop-in replacement for the removed
+    This event has been introduced which serves as a drop-in replacement for the removed
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/class.tx_cms_layout.php']['tt_content_drawItem']`
     hook.
 
-Use this event to ship an alternative rendering for a specific content type or
+Use the PSR-14 event
+:php:`\TYPO3\CMS\Backend\View\Event\PageContentPreviewRenderingEvent`
+to ship an alternative rendering for a specific content type or
 to manipulate the record data of a content element.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/PageContentPreviewRenderingEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/PageContentPreviewRenderingEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
@@ -18,13 +18,15 @@ RenderAdditionalContentToRecordListEvent
 ..  versionchanged:: 12.0
     Due to the integration of EXT:recordlist into EXT:backend the namespace of
     the event changed from
-    :php:`TYPO3\CMS\Recordlist\Event\RenderAdditionalContentToRecordListEvent`
+    :php:`\TYPO3\CMS\Recordlist\Event\RenderAdditionalContentToRecordListEvent`
     to
-    :php:`TYPO3\CMS\Backend\Controller\Event\RenderAdditionalContentToRecordListEvent`.
+    :php:`\TYPO3\CMS\Backend\Controller\Event\RenderAdditionalContentToRecordListEvent`.
     For TYPO3 v12 the moved class is available as an alias under the old
     namespace to allow extensions to be compatible with TYPO3 v11 and v12.
 
-Event to add content before or after the main content of the :guilabel:`List`
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Controller\Event\RenderAdditionalContentToRecordListEvent`
+allows to add content before or after the main content of the :guilabel:`List`
 module.
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
@@ -1,15 +1,17 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; SwitchUserEvent
-.. _SwitchUserEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; SwitchUserEvent
+..  _SwitchUserEvent:
 
 
 ===============
 SwitchUserEvent
 ===============
 
-This event is dispatched when a "SU" (switch user) action has been triggered.
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Authentication\Event\SwitchUserEvent`
+is dispatched when a "SU" (switch user) action has been triggered.
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Backend/SwitchUserEvent.rst.txt
+..  include:: /CodeSnippets/Events/Backend/SwitchUserEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
@@ -1,12 +1,14 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; SystemInformationToolbarCollectorEvent
-.. _SystemInformationToolbarCollectorEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; SystemInformationToolbarCollectorEvent
+..  _SystemInformationToolbarCollectorEvent:
 
 ======================================
 SystemInformationToolbarCollectorEvent
 ======================================
 
-An event to enrich the system information toolbar in the TYPO3 Backend top toolbar
+The PSR-14 event
+:php:`\TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent`
+allows to enrich the system information toolbar in the TYPO3 backend top toolbar
 with various information.
 
 API

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -60,6 +60,7 @@ ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
 ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
 ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
 ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+ext_reports        = https://docs.typo3.org/c/typo3/cms-reports/main/en-us/
 ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
 ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
 ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/


### PR DESCRIPTION
Mainly:
- Use "my-extension" instead of "my-package"
- Use "MyListenerClass" as event listener class
- Always add the FQCN of the event in the introduction paragraph
- Add "namespace" declaration to PHP snippets
- Add missing captions to snippets

This is a preparation for moving the code snippets into separate files for linting, code style adaption and easier migration to future PHP versions.

This is main branch only, as a backport would result in many conflicts and therefore may introduce errors.

Releases: main