### PR TITLE
[Backport 11.5] [TASK] Streamline "Site handling" > "Error handling" chapter (#2697)

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
@@ -1,92 +1,60 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Error handling; fluid
-.. _sitehandling-errorHandling_fluid:
+..  include:: /Includes.rst.txt
+..  index:: pair: Error handling; fluid
+..  _sitehandling-errorHandling_fluid:
 
 =========================
 Fluid-based error handler
 =========================
 
-The fluid-based error handler is defined in
+The Fluid-based error handler is defined in
 :t3src:`core/Classes/Error/PageErrorHandler/FluidPageErrorHandler.php`.
 
 Properties
 ==========
 
-The fluid-based error handler has the properties
+The Fluid-based error handler has the properties
 :ref:`sitehandling-errorHandling_errorCode` and
-:ref:`sitehandling-errorHandling_errorHandler` and the following:
+:ref:`sitehandling-errorHandling_errorHandler`, and the following:
 
-errorFluidTemplate
-------------------
+..  confval:: errorFluidTemplate
 
-:aspect:`Datatype`
-    string
+    :type: string
+    :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html`
 
-:aspect:`Description`
-    Path to fluid template file. Path may be
+    The path to the Fluid template file. Path may be
 
-    * absolute
-    * relative to site root
-    * starting with `EXT:` for files from an extension
+    *   absolute
+    *   relative to site root
+    *   starting with `EXT:` for files from an extension
 
-:aspect:`Example`
-    `EXT:sitepackage/Resources/Private/Templates/Error.html`
+..  confval:: errorFluidTemplatesRootPath
 
+    :type: string [optional]
+    :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/`
 
-errorFluidTemplatesRootPath
----------------------------
+    The paths to the Fluid templates in case more flexibility is needed.
 
-:aspect:`Datatype`
-    string [optional]
+..  confval:: errorFluidPartialsRootPath
 
-:aspect:`Description`
-    Paths to Fluid Templates, Partials and Layouts in
-    case more flexibility is needed.
+    :type: string [optional]
+    :Example: `EXT:my_sitepackage/Resources/Private/Partials/Sites/`
 
-:aspect:`Example`
-    `EXT:sitepackage/Resources/Private/Templates/`
+    The paths to the Fluid partials in case more flexibility is needed.
 
+..  confval:: errorFluidLayoutsRootPath
 
-errorFluidPartialsRootPath
---------------------------
+    :type: string [optional]
+    :Example: `EXT:my_sitepackage/Resources/Private/Layouts/Sites/`
 
-:aspect:`Datatype`
-    string [optional]
-
-:aspect:`Description`
-    Paths to Fluid Templates, Partials and Layouts in
-    case more flexibility is needed.
-
-:aspect:`Example`
-    `EXT:sitepackage/Resources/Private/Partials/`
+    The paths to Fluid layouts in case more flexibility is needed.
 
 
-errorFluidLayoutsRootPath
--------------------------
+Example
+=======
 
-:aspect:`Datatype`
-    string [optional]
+Show the content of a Fluid template in case of an error with HTTP status 404:
 
-:aspect:`Description`
-    Paths to Fluid Templates, Partials and Layouts in
-    case more flexibility is needed.
+..  literalinclude:: _fluid-error-handler.yaml
+    :language: yaml
+    :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
-:aspect:`Example`
-    `EXT:sitepackage/Resources/Private/Layouts/`
-
-
-Examples
-========
-
-Shows the content of a Fluid template on error with HTTP status 404.
-
-.. code-block:: yaml
-
-   errorHandling:
-     -
-       errorCode: 404
-       errorHandler: Fluid
-       errorFluidTemplate: 'EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html'
-       errorFluidTemplatesRootPath: ''
-       errorFluidLayoutsRootPath: ''
-       errorFluidPartialsRootPath: 'EXT:my_sitepackage/Resources/Private/Partials/Sites/'

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/Index.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/Index.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Site handling; Error handling
-.. _sitehandling-errorHandling:
+..  include:: /Includes.rst.txt
+..  index:: pair: Site handling; Error handling
+..  _sitehandling-errorHandling:
 
 ==============
 Error handling
@@ -9,73 +9,68 @@ Error handling
 Error handling can be configured on site level and is automatically dependent
 on the current site and language.
 
-There are currently two error handler implementations and the option to write
+Currently, there are two error handler implementations and the option to write
 a custom handler:
 
-.. toctree::
-   :titlesonly:
+..  toctree::
+    :titlesonly:
 
-   PageErrorHandler
-   FluidErrorHandler
-   WriteCustomErrorHandler
+    PageErrorHandler
+    FluidErrorHandler
+    WriteCustomErrorHandler
 
 
 The configuration consists of two parts:
 
-* The HTTP Error Status Code that should be handled
-* The Error Handler Configuration
+*   The HTTP error status code that should be handled
+*   The error handler configuration
 
 You can define one error handler per HTTP error code and add a generic one that
 serves all error pages.
 
-.. attention::
-   Exceptions must be handled via the :ref:`error and exception handling
-   <error-handling>` since they occur on a much lower level.
-   These are currently not covered by site error handling.
+..  attention::
+    Exceptions must be handled via :ref:`error and exception handling
+    <error-handling>`, since they occur on a much lower level.
+    These are currently not covered by site error handling.
 
-.. include:: /Images/AutomaticScreenshots/SiteHandling/SiteHandlingErrorHandling-1.rst.txt
+..  include:: /Images/AutomaticScreenshots/SiteHandling/SiteHandlingErrorHandling-1.rst.txt
 
 
-.. index:: pair: Site handling; Error handling properties
+..  index:: pair: Site handling; Error handling properties
 
 Properties
 ==========
 
 These properties apply to all error handlers.
 
-.. _sitehandling-errorHandling_errorCode:
+..  _sitehandling-errorHandling_errorCode:
 
-errorCode
----------
+..  confval:: errorCode
 
-:aspect:`Datatype`
-    int
+    :type: int
+    :Example: `404`
 
-:aspect:`Description`
-    The HTTP (Error) Status Code to handle. The predefined list contains the most common errors.
-    A free definition of other error codes is also possible. The special value `0` will take care of
-    all errors.
+    The `HTTP (error) status code`_ to handle. The predefined list contains the
+    most common errors. A free definition of other error codes is also possible.
+    The special value `0` will take care of all errors.
 
-:aspect:`Example`
-    `404`
+    ..  _HTTP (error) status code: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 
 
 .. _sitehandling-errorHandling_errorHandler:
 
-errorHandler
-------------
+..  confval:: errorHandler
 
-:aspect:`Datatype`
-    string / enum
+    :type: string / enum
+    :Example: `Fluid`
 
-:aspect:`Description`
-   Define how to handle these errors. May be
-   :ref:`Fluid<sitehandling-errorHandling_fluid>` for rendering a Fluid template,
-   :ref:`Page<sitehandling-errorHandling_page>` for fetching content from a page
-   or :ref:`PHP<sitehandling-customErrorHandler>` for a custom implementation.
+    Define how to handle these errors:
 
-:aspect:`Example`
-   `Fluid`
-
+    *   :ref:`Fluid <sitehandling-errorHandling_fluid>` for rendering a Fluid
+        template
+    *   :ref:`Page <sitehandling-errorHandling_page>` for fetching content from
+        a page
+    *   :ref:`PHP <sitehandling-customErrorHandler>` for a custom
+        implementation
 
 

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
@@ -17,13 +17,13 @@ FeatureFlag: `subrequestPageErrors`
 -----------------------------------
 
 In order to prevent possible denial-of-service attacks when the page-based error
-handler is used with the curl-based approach, the content of the error page is
+handler is used with the cURL-based approach, the content of the error page is
 cached in the TYPO3 page cache. Any dynamic content on the error page (for
-example content created by TypoScript or uncached plugins) will therefore also be
-cached.
+example, content created by TypoScript or uncached plugins) will therefore also
+be cached.
 
 If the error page contains dynamic content, TYPO3 administrators must
-ensure that no sensitive data (for example username of logged in frontend user)
+ensure that no sensitive data (for example, username of logged-in frontend user)
 will be shown on the error page.
 
 If dynamic content is required on the error page, it is recommended
@@ -40,18 +40,14 @@ The page-based error handler has the properties
 :ref:`sitehandling-errorHandling_errorCode` and
 :ref:`sitehandling-errorHandling_errorHandler` and the following:
 
-errorContentSource
-------------------
+..  confval:: errorContentSource
 
-:aspect:`Datatype`
-    string
+    :type: string
+    :Example: `t3://page?uid=123`
 
-:aspect:`Description`
-   May be either an External URL or TYPO3 Page that will be fetched with
-   curl and displayed in case of an error.
+    May be either an external URL or TYPO3 page that will be fetched with
+    cURL and displayed in case of an error.
 
-:aspect:`Example`
-    `t3://page?uid=123`
 
 Examples
 ========
@@ -59,26 +55,19 @@ Examples
 Internal error page
 -------------------
 
-Show the internal page with uid 145 on errors with HTML status 404.
+Show the internal page with uid `145` on all errors with HTML status code `404`.
 The content of this page will be fetched via internal sub-request.
 
-.. code-block:: yaml
-
-   errorHandling:
-     -
-       errorCode: 404
-       errorHandler: Page
-       errorContentSource: 't3://page?uid=145'
+..  literalinclude:: _page-error-handler-internal.yaml
+    :language: yaml
+    :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 External error page
 -------------------
 
-Shows an external page on all errors with a HTML status not otherwise defined.
+Shows an external page on all errors with a HTTP status code not defined
+otherwise.
 
-.. code-block:: yaml
-
-   errorHandling:
-     -
-       errorCode: 0
-       errorHandler: Page
-       errorContentSource: 'https://typo3.org/404'
+..  literalinclude:: _page-error-handler-external.yaml
+    :language: yaml
+    :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
@@ -1,41 +1,48 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Site handling; Custom error handler
-.. _sitehandling-customErrorHandler:
+..  include:: /Includes.rst.txt
+..  index:: pair: Site handling; Custom error handler
+..  _sitehandling-customErrorHandler:
 
 ===================================
 Writing a custom page error handler
 ===================================
 
-The error handling configuration for sites allows implementing a custom error handler if the existing
-options of rendering a Fluid template or page are not enough. An example would be an error page
-that uses the requested page or its parameters to search for relevant content on the web site.
+The error handling configuration for sites allows implementing a custom error
+handler, if the existing options of rendering a
+:ref:`Fluid template <sitehandling-errorHandling_fluid>` or
+:ref:`page <sitehandling-errorHandling_page>` are not enough. An example would
+be an error page that uses the requested page or its parameters to search for
+relevant content on the website.
 
-A custom error handler needs to have a constructor that takes exactly two arguments:
+A custom error handler needs to have a constructor that takes exactly two
+arguments:
 
-* :php:`$statusCode`: an integer holding the status code TYPO3 expects the handler to use
-* :php:`$configuration`: an array holding the configuration of the handler
+*   :php:`$statusCode`: an integer holding the status code TYPO3 expects the
+    handler to use
+*   :php:`$configuration`: an array holding the configuration of the handler
 
 Furthermore it needs to implement the :php:`PageErrorHandlerInterface`
-(:php:`\TYPO3\CMS\Core\Error\PageErrorHandler\PageErrorHandlerInterface`). The interface specifies only one method:
+(:t3src:`core/Classes/Error/PageErrorHandler/PageErrorHandlerInterface.php`).
+The interface specifies only one method:
 :php:`handlePageError(ServerRequestInterface $request, string $message, array $reasons = []): ResponseInterface`
 
-Let's take a closer look:
+Let us take a closer look:
 
-The method :php:`handlePageError` get's three parameters:
+The method :php:`handlePageError()` gets three parameters:
 
-* :php:`$request`: the current HTTP request - we can for example access query parameters and
-  the request path via this object
-* :php:`$message`: an error message string - for example `Cannot connect to the configured database.`
-  or `Page not found`
-* :php:`$reasons`: an arbitrary array of failure reasons - see for
-  example :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::getPageAccessFailureReasons`
+*   :php:`$request`: the current HTTP request - for example, we can access
+    query parameters and the request path via this :ref:`object <typo3-request>`
+*   :php:`$message`: an error message string - for example, "Cannot connect to
+    the configured database." or "Page not found"
+*   :php:`$reasons`: an arbitrary array of failure reasons - see, for example,
+    :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::getPageAccessFailureReasons`
 
-What you do with these variables is left to you, but you need to return a valid :php:`ResponseInterface`
-response - most usually an :php:`HtmlResponse`.
+What you do with these variables is left to you, but you need to return a
+valid :php:`\Psr\Http\Message\ResponseInterface` response - most usually an
+:php:`\TYPO3\CMS\Core\Http\HtmlResponse`.
 
-For an example implementation of the :php:`PageErrorHandlerInterface` take a look
-at :php:`\TYPO3\CMS\Core\Error\PageErrorHandler\PageContentErrorHandler` or
-:php:`\TYPO3\CMS\Core\Error\PageErrorHandler\FluidPageErrorHandler`.
+For an example implementation of the :php:`PageErrorHandlerInterface`, take a
+look at :t3src:`core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php`
+or :t3src:`core/Classes/Error/PageErrorHandler/FluidPageErrorHandler.php`.
 
 Properties
 ==========
@@ -44,81 +51,25 @@ The custom error handlers have the properties
 :ref:`sitehandling-errorHandling_errorCode` and
 :ref:`sitehandling-errorHandling_errorHandler` and the following:
 
-errorPhpClassFQCN
------------------
+..  confval:: errorPhpClassFQCN
 
-:aspect:`Datatype`
-   string
+    :type: string
+    :Example: `MyVendor\MySitePackage\Error\MyErrorHandler`
 
-:aspect:`Description`
-   Fully qualified class name of a custom error handler implementing
-   `PageErrorHandlerInterface`.
-
-:aspect:`Example`
-   `My\Site\Error\Handler`
+    Fully-qualified class name of a custom error handler implementing
+    :php:`PageErrorHandlerInterface`.
 
 
-Examples
-========
+Example for a simple 404 error handler
+======================================
 
-Example for a simple 404 ErrorHandler
--------------------------------------
+The configuration:
 
-The configuration in *config.yaml*:
+..  literalinclude:: _custom-error-handler.yaml
+    :language: yaml
+    :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
-.. code-block:: yaml
+The error handler class:
 
-   errorHandling:
-      -
-         errorCode: '404'
-         errorHandler: PHP
-         errorPhpClassFQCN: My\ExtensionName\Error\ErrorHandler
-
-The ErrorHandler class:
-
-.. code-block:: php
-
-   <?php
-
-   namespace My\ExtensionName\Error;
-
-   use Psr\Http\Message\ResponseInterface;
-   use Psr\Http\Message\ServerRequestInterface;
-   use TYPO3\CMS\Core\Error\PageErrorHandler\PageErrorHandlerInterface;
-   use TYPO3\CMS\Core\Http\HtmlResponse;
-
-   final class ErrorHandler implements PageErrorHandlerInterface
-   {
-       /**
-        * @var int
-        */
-       protected $statusCode;
-
-       /**
-        * @var array
-        */
-       protected $errorHandlerConfiguration;
-
-       public function __construct(int $statusCode, array $configuration)
-       {
-           $this->statusCode = $statusCode;
-           // This contains the configuration of the error handler which is
-           // set in site configuration - this example does not use it.
-           $this->errorHandlerConfiguration = $configuration;
-       }
-
-       /**
-        * @param ServerRequestInterface $request
-        * @param string $message
-        * @param array $reasons
-        * @return ResponseInterface
-        */
-       public function handlePageError(
-           ServerRequestInterface $request,
-           string $message,
-           array $reasons = []
-       ): ResponseInterface {
-              return new HtmlResponse('<h1>Not found, sorry</h1>', $this->statusCode);
-       }
-
-   }
+..  literalinclude:: _MyErrorHandler.php
+    :caption: EXT:my_sitepackage/Classes/Error/MyErrorHandler.php

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_MyErrorHandler.php
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_MyErrorHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MySitePackage\Error;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Error\PageErrorHandler\PageErrorHandlerInterface;
+use TYPO3\CMS\Core\Http\HtmlResponse;
+
+final class ErrorHandler implements PageErrorHandlerInterface
+{
+    private int $statusCode;
+    private array $errorHandlerConfiguration;
+
+    public function __construct(int $statusCode, array $configuration)
+    {
+        $this->statusCode = $statusCode;
+        // This contains the configuration of the error handler which is
+        // set in site configuration - this example does not use it.
+        $this->errorHandlerConfiguration = $configuration;
+    }
+
+    public function handlePageError(
+        ServerRequestInterface $request,
+        string $message,
+        array $reasons = []
+    ): ResponseInterface {
+        return new HtmlResponse('<h1>Not found, sorry</h1>', $this->statusCode);
+    }
+}

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_custom-error-handler.yaml
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_custom-error-handler.yaml
@@ -1,0 +1,4 @@
+errorHandling:
+  - errorCode: '404'
+    errorHandler: PHP
+    errorPhpClassFQCN: MyVendor\MySitePackage\Error\MyErrorHandler

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_fluid-error-handler.yaml
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_fluid-error-handler.yaml
@@ -1,0 +1,7 @@
+errorHandling:
+  - errorCode: 404
+    errorHandler: Fluid
+    errorFluidTemplate: 'EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html'
+    errorFluidTemplatesRootPath: ''
+    errorFluidLayoutsRootPath: ''
+    errorFluidPartialsRootPath: 'EXT:my_sitepackage/Resources/Private/Partials/Sites/'

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_page-error-handler-external.yaml
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_page-error-handler-external.yaml
@@ -1,0 +1,4 @@
+errorHandling:
+  - errorCode: 0
+    errorHandler: Page
+    errorContentSource: 'https://example.org/page-not-found'

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_page-error-handler-internal.yaml
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_page-error-handler-internal.yaml
@@ -1,0 +1,4 @@
+errorHandling:
+  - errorCode: 404
+    errorHandler: Page
+    errorContentSource: 't3://page?uid=145'


### PR DESCRIPTION
Mainly:
- Move YAML/PHP snippets into separate files
- Use confval directive for properties
- Add links where appropriate

Releases: main, 11.5