### PR TITLE
[BUGFIX] Fix PHPDoc using @var for method (branch 11.5)

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendModulesWithoutExtbase/BackendTemplateViewWithoutExtbase.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendModulesWithoutExtbase/BackendTemplateViewWithoutExtbase.rst
@@ -30,7 +30,7 @@ to return the rendered template:
        /**
         * Constructor Method
         *
-        * @var ModuleTemplate $moduleTemplate
+        * @param ModuleTemplate $moduleTemplate
         */
        public function __construct(ModuleTemplate $moduleTemplate = null)
        {


### PR DESCRIPTION
Is only in 11.5 branch (and possibly below), not in main. Can not be easily backported to 10 because the file structure changed (again).