### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -368,7 +368,7 @@ The new field *tx_examples_separator* is added to the TCA definition of the tabl
    ];
    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_content', $temporaryColumn);
 
-You can read more about defining fields via TCA in the :doc:`t3tca:Index`.
+You can read more about defining fields via TCA in the :ref:`t3tca:start`.
 
 Now the new field can be used in your Fluid template just like any other
 tt_content field.

--- a/Documentation/ApiOverview/ContentElements/ContentElementsWizard.rst
+++ b/Documentation/ApiOverview/ContentElements/ContentElementsWizard.rst
@@ -7,7 +7,7 @@ Add content elements to the Content Element Wizard
 ==================================================
 
 The content element wizard opens when a new content element is
-created. It can be fully configured using :doc:`TSConfig <t3tsconfig:Index>`.
+created. It can be fully configured using :ref:`TSConfig <t3tsconfig:start>`.
 
 Our extension key is `example` and the name of the content element or
 plugin is `registration`.

--- a/Documentation/ApiOverview/ContentElements/Introduction.rst
+++ b/Documentation/ApiOverview/ContentElements/Introduction.rst
@@ -86,7 +86,7 @@ Indexed search plugin type, provided by the TYPO3 core.
 Editing
 =======
 
-The :doc:`Editors Tutorial <t3editors:Index>` describes how to work with
+The :ref:`Editors Tutorial <t3editors:start>` describes how to work with
 :ref:`page content <t3editors:content-working>` and
 lists the :ref:`basic TYPO3 content elements <t3editors:content-types>`
 and how to work with them.

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -34,7 +34,7 @@ Requirements
 
 There are certain requirements for such managed tables:
 
--   The table must be configured in the :doc:`global TCA array <t3tca:Index>`,
+-   The table must be configured in the :ref:`global TCA array <t3tca:start>`,
     for example:
 
     -   table name

--- a/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseUpgrade/Index.rst
@@ -49,7 +49,7 @@ installation.
 
 ..  seealso::
     For more information about the process of upgrading TYPO3, see the
-    :doc:`Upgrade Guide <t3install:Index>`.
+    :ref:`Upgrade Guide <t3install:start>`.
 
 
 ..  index::

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -14,7 +14,7 @@ Fluid is based on XML and you can use HTML markup in Fluid.
 
 Fluid ViewHelpers can be used for various purposes. Some transform data, some include
 Partials, some loop over data or even set variables. You can find a complete list of
-them in the :doc:`ViewHelper Reference <t3viewhelper:Index>`.
+them in the :ref:`ViewHelper Reference <t3viewhelper:start>`.
 
 You can :ref:`write your own custom ViewHelper <fluid-custom-viewhelper>`,
 which is a PHP component.
@@ -215,7 +215,7 @@ Example: Using Fluid to create a theme
 ======================================
 
 This example was taken from the `example extension <https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage-Code/>`__
-for :doc:`t3sitepackage:Index` and reduced to a very basic example.
+for :ref:`t3sitepackage:start` and reduced to a very basic example.
 
 The Sitepackage Tutorial walks you through the creation of a sitepackage
 (theme) using Fluid. In our simplified example, the overall structure of

--- a/Documentation/ApiOverview/Fluid/Syntax.rst
+++ b/Documentation/ApiOverview/Fluid/Syntax.rst
@@ -82,7 +82,7 @@ functionality such as loops or generating links.
 The functionality of the ViewHelper is implemented in PHP, every ViewHelper has
 its own PHP class.
 
-See the :doc:`Fluid Viewhelper Reference <t3viewhelper:Index>` for a complete
+See the :ref:`Fluid Viewhelper Reference <t3viewhelper:start>` for a complete
 list of all available ViewHelpers.
 
 Within Fluid, the ViewHelper is used as a special HTML element with a namespace

--- a/Documentation/ApiOverview/Fluid/UsingFluidInTypo3.rst
+++ b/Documentation/ApiOverview/Fluid/UsingFluidInTypo3.rst
@@ -11,7 +11,7 @@ Here are some examples of how Fluid can be used in TYPO3:
 
 *  Create a template (theme) using a combination of TypoScript
    :ref:`FLUIDTEMPLATE <t3tsref:cobj-fluidtemplate>` and Fluid.
-   Check out the :doc:`t3sitepackage:Index` which walks you through the
+   Check out the :ref:`t3sitepackage:start` which walks you through the
    creation of a sitepackage extension.
 *  :ref:`adding-your-own-content-elements` in addition to the already existing
    content elements TYPO3 supplies.

--- a/Documentation/ApiOverview/Localization/TranslationServer/Pootle.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Pootle.rst
@@ -18,5 +18,5 @@ They can be fetched in the TYPO3 CMS backend, via the Install Tool and on the co
 
 It is not the point of this manual to go into the details of the translation
 process. More information can be found in the
-:doc:`Frontend Localization Guide <t3translate:Index>`.
+:ref:`Frontend Localization Guide <t3translate:start>`.
 

--- a/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
@@ -178,7 +178,7 @@ this will typically go through such important steps like:
 
 -  checking backend access: Is it locked? Does it have proper SSL setup?
 
--  loading the full :doc:`TCA <t3tca:Index>`
+-  loading the full :ref:`TCA <t3tca:start>`
 
 -  verifying and initializing the backend user
 

--- a/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
@@ -12,7 +12,7 @@ site object :php:`\TYPO3\CMS\core\Site\Entity\Site`.
 
 Additionally, these settings are available in both
 :ref:`page TSconfig <t3tsconfig:pagetsconfig>` and
-:doc:`TypoScript templates <t3tsref:Index>`. This allows us, for example, to
+:ref:`TypoScript templates <t3tsref:start>`. This allows us, for example, to
 configure site-wide storage page IDs which can be used in both frontend and
 backend.
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Introduction/Index.rst
@@ -35,7 +35,7 @@ to evaluate against. This means you cannot use DataHandler from the
 frontend scope. Thus writing to tables (such as a guestbook) will have
 to be done from the frontend *without* DataHandler.
 
-The features of the $TCA are described in the :doc:`TCA Reference <t3tca:Index>`.
+The features of the $TCA are described in the :ref:`TCA Reference <t3tca:start>`.
 
 
 .. index:: pair: TYPO3 Core engine; Files

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -29,7 +29,7 @@ The only way to do so is with a :file:`Configuration/TCA/Overrides/example_table
 
    $GLOBALS['TCA']['example_table']['ctrl']['versioningWS'] = false;
 
-See :doc:`t3sitepackage:Index` and :ref:`storing-changes-extension-overrides` .
+See :ref:`t3sitepackage:start` and :ref:`storing-changes-extension-overrides` .
 
 .. note::
 

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -28,7 +28,7 @@ or the dependency injection mechanisms do not work or do not exist.
 
 If you need a hook or event that does not exist, feel free to submit
 a feature request and - even better - a patch. Consult the
-:doc:`TYPO3 Contribution Guide <t3contribute:Index>`
+:ref:`TYPO3 Contribution Guide <t3contribute:start>`
 about how to do this.
 
 

--- a/Documentation/CodingGuidelines/CglTsConfig.rst
+++ b/Documentation/CodingGuidelines/CglTsConfig.rst
@@ -39,4 +39,4 @@ More Information
 
 * See :ref:`cgl-ide` in this manual for information about setting up your Editor / IDE to adhere to
   the coding guidelines.
-* :doc:`t3tsconfig:Index`
+* :ref:`t3tsconfig:start`

--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -41,7 +41,7 @@ be easily replayed locally: If the test setup votes negative on a
 Core patch in the review system due to CGL violations, the patch
 can be easily fixed locally by calling :file:`./Build/Scripts/cglFixMyCommit.sh`
 and pushed another time. For details on Core contributions, have a look at the
-:doc:`TYPO3 Contribution Guide <t3contribute:Index>`.
+:ref:`TYPO3 Contribution Guide <t3contribute:start>`.
 
 
 .. _cgl-general-recommendations:

--- a/Documentation/Configuration/ConfigurationModule/Index.rst
+++ b/Documentation/Configuration/ConfigurationModule/Index.rst
@@ -16,7 +16,7 @@ Configuration module
 The configuration module can be found at :guilabel:`System > Configuration`.
 It allows integrators to view and validate the global configuration of TYPO3.
 The module displays all relevant global variables such as
-:ref:`TYPO3_CONF_VARS <typo3ConfVars>`, :doc:`TCA <t3tca:Index>` and many more,
+:ref:`TYPO3_CONF_VARS <typo3ConfVars>`, :ref:`TCA <t3tca:start>` and many more,
 in a tree format which is easy to browse through. Over time this module got
 extended to also display the configuration of newly introduced features like the
 :ref:`middleware stack <request-handling>` or

--- a/Documentation/Configuration/ConfigurationOverview.rst
+++ b/Documentation/Configuration/ConfigurationOverview.rst
@@ -70,13 +70,13 @@ Extension files
    :ref:`Dependency injection <DependencyInjection>`.
 
 :file:`Configuration/TCA`
-   :doc:`TCA configuration <t3tca:Index>`.
+   :ref:`TCA configuration <t3tca:start>`.
 
 :file:`Configuration/TSconfig/`
-   :doc:`TSconfig configuration <t3tsconfig:Index>`.
+   :ref:`TSconfig configuration <t3tsconfig:start>`.
 
 :file:`Configuration/TypoScript/`
-   :doc:`TypoScript configuration <t3tsref:Index>`.
+   :ref:`TypoScript configuration <t3tsref:start>`.
 
 
 .. hint::
@@ -119,7 +119,7 @@ what they mean) are not.
 Configuration methods
 =====================
 
-:doc:`TSconfig <t3tsconfig:Index>`
+:ref:`TSconfig <t3tsconfig:start>`
 ----------------------------------
 
 While Frontend TypoScript is used to steer the rendering of the frontend, TSconfig is used
@@ -133,13 +133,13 @@ in :ref:`typoscript-syntax-start`. Other than that, TSconfig and Frontend TypoSc
 don't have much more in common - they consist of entirely different properties.
 
 A full reference of properties as well as an introduction to explain details configuration usage, API and
-load orders can be found in the :doc:`TSconfig Reference document <t3tsconfig:Index>`. While Developers
+load orders can be found in the :ref:`TSconfig Reference document <t3tsconfig:start>`. While Developers
 should have an eye on this document, it is mostly used as a reference for Integrators who make life as
 easy as possible for backend users.
 
 
 
-:doc:`TypoScript Templating <t3tsref:Index>`
+:ref:`TypoScript Templating <t3tsref:start>`
 --------------------------------------------
 
 TypoScript - or more precisely "TypoScript Templating" - is used in TYPO3 to steer
@@ -152,15 +152,15 @@ often used. Nowadays, TypoScript in real life projects is often not much more th
 set a series of options for plugins, to set some global config options, and to act as a simple
 pre processor between database data and Fluid templates.
 
-Still, the :doc:`TypoScript Reference <t3tsref:Index>` manual that goes deep into
+Still, the :ref:`TypoScript Reference <t3tsref:start>` manual that goes deep into
 the incredible power of TypoScript Templating is daily bread for Integrators.
 
 
 For an introduction, you may want to read one of the following tutorials:
 
 
-* :doc:`t3ts45:Index` - Introduction to TypoScript Templating.
-* :doc:`t3sitepackage:Index` - Start a Sitepackage Extension to create a theme
+* :ref:`t3ts45:start` - Introduction to TypoScript Templating.
+* :ref:`t3sitepackage:start` - Start a Sitepackage Extension to create a theme
   for your site using TypoScript and Fluid.
 
 .. note::
@@ -189,7 +189,7 @@ The :php:`$GLOBALS` PHP array consists of:
    TCA is the backbone of database tables displayed in the backend, it configures
    how data is stored if editing records in the backend, how fields are displayed,
    relations to other tables and much more. It is a huge array loaded in almost all
-   access contexts. TCA is documented in the :doc:`TCA Reference <t3tca:Index>`.
+   access contexts. TCA is documented in the :ref:`TCA Reference <t3tca:start>`.
    Next to a small introduction, the document forms a complete reference of all
    different TCA options, with bells and whistles. The document is a must-read for
    Developers, partially for Integrators, and is often used as a reference book

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -35,7 +35,7 @@ $GLOBALS
    :Defined: :php:`\TYPO3\CMS\Core\Core\Bootstrap::loadExtensionTables()`
    :Frontend: Yes, partly
 
-   See :doc:`TCA Reference <t3tca:Index>`
+   See :ref:`TCA Reference <t3tca:start>`
 
 
 .. confval:: T3_SERVICES

--- a/Documentation/Configuration/Tsconfig.rst
+++ b/Documentation/Configuration/Tsconfig.rst
@@ -9,7 +9,7 @@ TSconfig
 "User TSconfig" and "page TSconfig" are very flexible concepts for
 adding fine-grained configuration to the backend of TYPO3. It is a text-
 based configuration system where you assign values to keyword strings,
-using the TypoScript syntax. The :doc:`TSconfig Reference <t3tsconfig:Index>`
+using the TypoScript syntax. The :ref:`TSconfig Reference <t3tsconfig:start>`
 describes in detail how this works and what can be done with it.
 
 

--- a/Documentation/Configuration/TypoScriptSyntax/Index.rst
+++ b/Documentation/Configuration/TypoScriptSyntax/Index.rst
@@ -17,14 +17,14 @@ for backend users.
 While the underlying TypoScript syntax is described in this chapter, both usages
 and their details are found in standalone manuals:
 
--  The :doc:`TypoScript Reference <t3tsref:Index>` goes into details about the
+-  The :ref:`TypoScript Reference <t3tsref:start>` goes into details about the
    usage of TypoScript in the frontend.
 
--  The :doc:`TSconfig Reference <t3tsconfig:Index>` goes into details about
+-  The :ref:`TSconfig Reference <t3tsconfig:start>` goes into details about
    configuring the TYPO3 backend for backend users.
 
 In addition, you can find a quick reference guide to TypoScript templates in
-:doc:`t3ts45:Index`.
+:ref:`t3ts45:start`.
 
 **Table of Contents:**
 

--- a/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
@@ -146,7 +146,7 @@ The following example contains the complete code:
 
 
 Additionally, it is possible to extend TYPO3 in a lot of different ways (adding
-:doc:`TCA <t3tca:Index>`, :ref:`backend routes <backend-routing>`,
+:ref:`TCA <t3tca:start>`, :ref:`backend routes <backend-routing>`,
 :ref:`Symfony console commands <symfony-console-commands>`, etc), which do not
 need to touch these files.
 

--- a/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
@@ -36,7 +36,7 @@ We recommend the first approach for the following reasons:
 
 For more details on both approaches see the :ref:`File structure <h2document:file-structure>`
 page and for more information on writing TYPO3 documentation in general, see the
-:doc:`Writing documentation <h2document:Index>` guide.
+:ref:`Writing documentation <h2document:start>` guide.
 
 .. _extension-documentation-tools:
 

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Index.rst
@@ -8,7 +8,7 @@ Localization
 
 The configuration options for localization inside TYPO3 are versatile.
 You will find a comprehensive description of all concepts and options in the
-:doc:`Frontend Localization Guide <t3translate:Index>`.
+:ref:`Frontend Localization Guide <t3translate:start>`.
 
 For the following sections, we assume a correct configuration of the
 localization, which is normally done in the

--- a/Documentation/ExtensionArchitecture/HowTo/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/PublishExtension/PublishToTER/Index.rst
@@ -83,7 +83,7 @@ releasing an extension:
    which lets you register new extension keys and helps you maintain
    your extensions, update extension information and publish new extension
    versions. For complete instructions and examples, see the official
-   :doc:`Tailor documentation <tailor:Index>`.
+   :ref:`Tailor documentation <tailor:start>`.
 
    Besides manual publishing, *Tailor* is the perfect complement for
    automatic publishing via CI / CD pipelines. On the application's homepage

--- a/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/Index.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/Index.rst
@@ -10,7 +10,7 @@ Sitepackage Builder
 The main incentive of the `Sitepackage Builder <https://www.sitepackagebuilder.com/>`__
 is a quick and easy way to create a new sitepackage, what would be called
 "theme" in other CMS, for your project. See the
-:doc:`Sitepackage Tutorial <t3sitepackage:Index>` for details on sitepackages.
+:ref:`Sitepackage Tutorial <t3sitepackage:start>` for details on sitepackages.
 
 Kickstart a TYPO3 Extension with the "Sitepackage Builder"
 ==========================================================

--- a/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/MinimalExtension.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/MinimalExtension.rst
@@ -230,7 +230,7 @@ Next steps
 ==========
 
 You don't have a sitepackage yet? Have a look at the
-:doc:`Sitepackage Tutorial <t3sitepackage:Index>`.
+:ref:`Sitepackage Tutorial <t3sitepackage:start>`.
 
 If you want to display lists and single views of data, or maybe even manipulate
 the data in the frontend, have a look at :ref:`Extbase <extbase>`.

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/DirectoryStructure.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/DirectoryStructure.rst
@@ -115,7 +115,7 @@ The folder :file:`Configuration` contains several subfolders:
     by direct array manipulation or (preferred if possible) by calls to
     API functions.
 :file:`Configuration/TsConfig`
-    Contains :doc:`TSconfig <t3tsconfig:Index>` configurations for the TYPO3
+    Contains :ref:`TSconfig <t3tsconfig:start>` configurations for the TYPO3
     backend on page or user level in the syntax of TypoScript. This extension
     does not feature TSconfig, therefore the folder is only a placeholder here.
 :file:`Configuration/TypoScript`

--- a/Documentation/Security/GeneralGuidelines/Index.rst
+++ b/Documentation/Security/GeneralGuidelines/Index.rst
@@ -142,7 +142,7 @@ version 11.x.x), a minor update (e.g. from version 11.4.x to version
 11.5.11 to 11.5.12).
 
 In most cases, a maintenance/bugfix/security update is a no-brainer,
-see :doc:`TYPO3 Installation and Upgrade Guide <t3install:Index>`
+see :ref:`TYPO3 Installation and Upgrade Guide <t3install:start>`
 for further details.
 
 When you extract the archive file of new TYPO3 sources into the

--- a/Documentation/Security/GuidelinesAdministrators/FileDirectoryPermissions.rst
+++ b/Documentation/Security/GuidelinesAdministrators/FileDirectoryPermissions.rst
@@ -14,7 +14,7 @@ permissions on files and directories are an important part of this
 strategy. However, too strict permissions may stop TYPO3 from working
 properly and/or restrict integrators or editors from using all
 features of the CMS. The official
-:doc:`TYPO3 Installation and Upgrade Guide <t3install:Index>`
+:ref:`TYPO3 Installation and Upgrade Guide <t3install:start>`
 provides further information about the install procedure.
 
 We do not need to mention that only privileged system users should


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198