### PR TITLE
[TASK] Reference ext:container instead of ext:gridelements

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -238,7 +238,7 @@ Extensions for backend layouts
 
 In many cases besides defining fixed backend layouts a more modular approach with the possibility of combining different
 backend layouts and frontend layouts may be feasible. The extension
-:t3ext:`gridelements`
+:t3ext:`container`
 integrates the grid layout concept also to regular content elements.
 
 The extension :t3ext:`content_defender` offers advanced options to


### PR DESCRIPTION
gridelements still has not v11 compatible official release while
container is v12 ready already. We should reference container
over gridelements as additional grid extension.