### PR TITLE
Add section $GLOBALS['LANG'] and amend information

### DIFF
--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -28,7 +28,7 @@ $GLOBALS
 
    .. attention::
 
-        The global array :php:`$GLOBALS['LANG']` is not available in all context,
+        The global array :php:`$GLOBALS['LANG']` is not available in all contexts,
         in particular the contexts where a logged in backend user is not
         available.
 

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -18,7 +18,7 @@ $GLOBALS
 
    :Path: $GLOBALS
    :type: :php:`\TYPO3\CMS\Core\Localization\LanguageService`
-   :Defined: is initialized by LanguageServiceFactory
+   :Defined: is initialized via :php:`\TYPO3\CMS\Core\Localization\LanguageServiceFactory`
    :Frontend: no
 
    The global array :php:`$GLOBALS['LANG']` is initialized by the Core.

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -14,6 +14,28 @@ $GLOBALS
    has no effect anymore. Use the
    :ref:`ModuleProvider <backend-modules-api>` instead.
 
+.. confval:: LANG
+
+   :Path: $GLOBALS
+   :type: :php:`\TYPO3\CMS\Core\Localization\LanguageService`
+   :Defined: is initialized by languageServiceFactory
+   :Frontend: no
+
+   The global array $GLOBALS['LANG'] is initialized by the core.
+   It can be used to fetch translations.
+   It contains an instantiation of the
+   :php:`\TYPO3\CMS\Core\Localization\LanguageService`.
+
+   .. attention::
+
+        The global array :php:`$GLOBALS['LANG']` is not available in all context,
+        in particular the contexts where a logged in backend user is not
+        available.
+
+   More information about instantiating and using :php:`$GLOBALS['LANG']` is
+   available in :ref:`extension-localization-php`.
+
+
 .. confval:: TYPO3_CONF_VARS
 
    :Path: $GLOBALS

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -18,7 +18,7 @@ $GLOBALS
 
    :Path: $GLOBALS
    :type: :php:`\TYPO3\CMS\Core\Localization\LanguageService`
-   :Defined: is initialized by languageServiceFactory
+   :Defined: is initialized by LanguageServiceFactory
    :Frontend: no
 
    The global array :php:`$GLOBALS['LANG']` is initialized by the Core.

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -14,28 +14,6 @@ $GLOBALS
    has no effect anymore. Use the
    :ref:`ModuleProvider <backend-modules-api>` instead.
 
-.. confval:: LANG
-
-   :Path: $GLOBALS
-   :type: :php:`\TYPO3\CMS\Core\Localization\LanguageService`
-   :Defined: is initialized via :php:`\TYPO3\CMS\Core\Localization\LanguageServiceFactory`
-   :Frontend: no
-
-   The global array :php:`$GLOBALS['LANG']` is initialized by the Core.
-   It can be used to fetch translations.
-   It contains an instantiation of the
-   :php:`\TYPO3\CMS\Core\Localization\LanguageService`.
-
-   .. attention::
-
-        The global array :php:`$GLOBALS['LANG']` is not available in all contexts,
-        in particular the contexts where a logged in backend user is not
-        available.
-
-   More information about instantiating and using :php:`$GLOBALS['LANG']` is
-   available in :ref:`extension-localization-php`.
-
-
 .. confval:: TYPO3_CONF_VARS
 
    :Path: $GLOBALS

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -21,7 +21,7 @@ $GLOBALS
    :Defined: is initialized by languageServiceFactory
    :Frontend: no
 
-   The global array $GLOBALS['LANG'] is initialized by the core.
+   The global array :php:`$GLOBALS['LANG']` is initialized by the Core.
    It can be used to fetch translations.
    It contains an instantiation of the
    :php:`\TYPO3\CMS\Core\Localization\LanguageService`.

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -20,7 +20,7 @@ Localization in plain PHP
 
 The :php:`$GLOBALS['LANG']` can be used to access the language service as
 instantiated :php:`\TYPO3\CMS\Core\Localization\LanguageService` class.
-The global LANG array is available, if a backend user has been initialized,
+The global :php:`LANG` array is available, if a backend user has been initialized,
 in particular in the following contexts:
 
 *   frontend: only if there is a logged-in backend user

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -18,20 +18,24 @@ Which method of localization to use depends on the current context:
 Localization in plain PHP
 =========================
 
-The :php:`$GLOBALS['LANG']` can be used to access the language service as
-instantiated :php:`\TYPO3\CMS\Core\Localization\LanguageService` class.
-The global :php:`LANG` array is available, if a backend user has been initialized,
-in particular in the following contexts:
+.. note::
+
+    The :php:`\TYPO3\CMS\Core\Localization\LanguageService` could formerly be
+    accessed via the global variable :php:`$GLOBALS['LANG']`. This is now
+    discouraged. Use :php:`LanguageServiceFactory` instead.
+
+The :php:`\TYPO3\CMS\Core\Localization\LanguageService` is available if a
+backend user has been initialized, in particular in the following contexts:
 
 *   frontend: only if there is a logged-in backend user
-*   backend: always, except in :guilabel:`Admin Tools` modules (e.g. within :guilabel:`Upgrade Wizard`
+*   backend: always, except in :guilabel:`Admin Tools` modules (e.g. within
+    :guilabel:`Upgrade Wizard`
     in the backend)
 *   install tool / install tool modules in backend (e.g. Upgrade Wizard): no
 *   in cli: only if a backend user was initialized, e.g. by
     `TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`
 
-If it is not instantiated, the :php:`LanguageServiceFactory` can be used
-to instantiate. Please see the examples below.
+The :php:`LanguageServiceFactory` can be used to instantiate. Please see the examples below.
 
 :ref:`The methods provided by the instantiated LanguageService <LanguageService-api>`
 class then be used to translate texts using the language keys of XLIFF language

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -18,6 +18,25 @@ Which method of localization to use depends on the current context:
 Localization in plain PHP
 =========================
 
+The :php:`$GLOBALS['LANG']` can be used to access the language service as
+instantiated :php:`\TYPO3\CMS\Core\Localization\LanguageService` class.
+The global LANG array is available, if a backend user has been initialized,
+in particular in the following contexts:
+
+*   frontend: only if there is a logged-in backend user
+*   backend: always, except in Admin Tools modules (e.g. within Upgrade Wizard
+    in the backend)
+*   install tool / install tool modules in backend (e.g. Upgrade Wizard): no
+*   in cli: only if a backend user was initialized, e.g. by
+    `TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`
+
+If it is not instantiated, the :php:`LanguageServiceFactory` can be used
+to instantiate. Please see the examples below.
+
+:ref:`The methods provided by the instantiated LanguageService <LanguageService-api>`
+class then be used to translate texts using the language keys of XLIFF language
+files.
+
 Localization in frontend context
 --------------------------------
 

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -24,7 +24,7 @@ The global :php:`LANG` array is available, if a backend user has been initialize
 in particular in the following contexts:
 
 *   frontend: only if there is a logged-in backend user
-*   backend: always, except in Admin Tools modules (e.g. within Upgrade Wizard
+*   backend: always, except in :guilabel:`Admin Tools` modules (e.g. within :guilabel:`Upgrade Wizard`
     in the backend)
 *   install tool / install tool modules in backend (e.g. Upgrade Wizard): no
 *   in cli: only if a backend user was initialized, e.g. by


### PR DESCRIPTION
A new section is added to the page on GLOBALS for
$GLOBALS['LANG'].

This section provides a very short introduction and then links to the already existing page "Localization in PHP".

In the existing page "Localization in PHP" an introductory text is added, which summarizes what the array does and provides overview when it is inialized.

Resolves: #2737
Resolves: #2462