### PR TITLE
Update README for target-language usage

### DIFF
--- a/Documentation/ApiOverview/Localization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Localization/XliffFormat.rst
@@ -91,7 +91,9 @@ Before TYPO v12.2, one has to define a
 
 In the file itself, a :xml:`target-language` attribute is added to the
 :xml:`<file>` tag to indicate the translation language ("de" in our example).
-TYPO3 does not consider the :xml:`target-language` attribute for its own processing of translations, but the filename prefix instead.
+TYPO3 does not consider the :xml:`target-language` attribute for its own processing
+of translations, but the filename prefix instead. The attribute might be useful
+though for human translators or tools.
 Then, for each :xml:`<source>` tag there is a sibling :xml:`<target>` tag
 that contains the translated string.
 

--- a/Documentation/ApiOverview/Localization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Localization/XliffFormat.rst
@@ -91,6 +91,7 @@ Before TYPO v12.2, one has to define a
 
 In the file itself, a :xml:`target-language` attribute is added to the
 :xml:`<file>` tag to indicate the translation language ("de" in our example).
+TYPO3 does not consider the :xml:`target-language` attribute for its own processing of translations, but the filename prefix instead.
 Then, for each :xml:`<source>` tag there is a sibling :xml:`<target>` tag
 that contains the translated string.
 


### PR DESCRIPTION
Today we tried to understand if TYPO3 is using the `target-language` attribute inside the XLIFF-file and it seems that TYPO3 is only considering the filename prefix. So I thought this information would be helpful to find in the documentation of TYPO3 CMS :)
