### PR TITLE
[TASK] Move site handling CLI commands into commands chapter

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Commands/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Commands/Index.rst
@@ -1,0 +1,13 @@
+.. include:: /Includes.rst.txt
+
+.. _symfony-console-commands-overview:
+
+====================
+Overview of commands
+====================
+
+..  toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/Documentation/ApiOverview/CommandControllers/Commands/SiteList.rst
+++ b/Documentation/ApiOverview/CommandControllers/Commands/SiteList.rst
@@ -1,0 +1,40 @@
+.. include:: /Includes.rst.txt
+
+.. _symfony-console-commands-site-list:
+
+=====================================
+site:list (List all configured sites)
+=====================================
+
+The command will list all configured :ref:`sites <sitehandling>` with their
+identifier, root page, base URL, languages, locales and a flag whether or not
+the site is enabled.
+
+..  tabs::
+
+    ..  group-tab:: Composer-based installation
+
+        ..  code-block:: bash
+
+            vendor/bin/typo3 site:list
+
+    ..  group-tab:: Legacy installation
+
+        ..  code-block:: bash
+
+            typo3/sysext/core/bin/typo3 site:list
+
+
+The command will output, for example:
+
+..  code-block:: none
+
+    All configured sites
+    ====================
+
+    +------------+----------+-------------------------+----------------+------------+---------+
+    | Identifier | Root PID | Base URL                | Language       | Locale     | Status  |
+    +------------+----------+-------------------------+----------------+------------+---------+
+    | main       | 1        | https://example.com/    | English (id:0) | en_GB.utf8 | enabled |
+    |            |          | https://example.com/de/ | German (id:1)  | de_DE.utf8 | enabled |
+    +------------+----------+-------------------------+----------------+------------+---------+

--- a/Documentation/ApiOverview/CommandControllers/Commands/SiteShow.rst
+++ b/Documentation/ApiOverview/CommandControllers/Commands/SiteShow.rst
@@ -1,0 +1,59 @@
+.. include:: /Includes.rst.txt
+
+.. _symfony-console-commands-site-show:
+
+===========================================
+site:show (Show configuration for one site)
+===========================================
+
+The command needs an :ref:`identifier of a configured site
+<sitehandling-basics-site-identifier>` which must be provided after the command
+name. The command will output the complete configuration for the site in YAML
+syntax.
+
+..  tabs::
+
+    ..  group-tab:: Composer-based installation
+
+        ..  code-block:: bash
+
+            vendor/bin/typo3 site:show <identifier>
+
+    ..  group-tab:: Legacy installation
+
+        ..  code-block:: bash
+
+            typo3/sysext/core/bin/typo3 site:show <identifier>
+
+
+The command will output, for example:
+
+..  code-block:: none
+
+    Site configuration for main
+    ===========================
+
+    base: /
+    languages:
+        -
+            title: English
+            enabled: true
+            languageId: 0
+            base: /
+            locale: en_GB.utf8
+            navigationTitle: English
+            flag: gb
+            websiteTitle: ''
+        -
+            title: Deutsch
+            enabled: true
+            languageId: 1
+            base: /de
+            locale: de_DE.utf8
+            navigationTitle: Deutsch
+            flag: de
+            websiteTitle: ''
+            fallbackType: free
+            fallbacks: ''
+    rootPageId: 1
+    websiteTitle: 'My site'

--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -98,3 +98,4 @@ Read more
     :glob:
 
     *
+    */Index

--- a/Documentation/ApiOverview/SiteHandling/CliTools.rst
+++ b/Documentation/ApiOverview/SiteHandling/CliTools.rst
@@ -8,50 +8,5 @@ CLI tools for site handling
 
 Two :ref:`CLI commands <symfony-console-commands>` are available:
 
-*   `site:list`
-*   `site:show`
-
-
-List all configured sites
-=========================
-
-The following command will list all configured sites with their identifier, root
-page, base URL, languages, locales and a flag whether or not the site is
-enabled.
-
-..  tabs::
-
-    ..  group-tab:: Composer-based installation
-
-        ..  code-block:: bash
-
-            vendor/bin/typo3 site:list
-
-    ..  group-tab:: Legacy installation
-
-        ..  code-block:: bash
-
-            typo3/sysext/core/bin/typo3 site:list
-
-
-Show configuration for one site
-===============================
-
-The show command needs an :ref:`identifier of a configured site
-<sitehandling-basics-site-identifier>` which must be provided after the command
-name. The command will output the complete configuration for the site in YAML
-syntax.
-
-..  tabs::
-
-    ..  group-tab:: Composer-based installation
-
-        ..  code-block:: bash
-
-            vendor/bin/typo3 site:show <identifier>
-
-    ..  group-tab:: Legacy installation
-
-        ..  code-block:: bash
-
-            typo3/sysext/core/bin/typo3 site:show <identifier>
+*   :ref:`symfony-console-commands-site-list`
+*   :ref:`symfony-console-commands-site-show`


### PR DESCRIPTION
This is the first adjustment to collect and describe the available commands in the commands chapter.

Additionally, the site command chapters are enriched with an example output of a command.

Related: #2750
Releases: main, 12.4