### PR TITLE
[TASK] #100032 - Add HTTP security headers for backend by default

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -927,18 +927,34 @@ HTTP
 
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
 
-   :type: array
-   :Default:
-      .. code-block:: php
+    :type: array
 
-         [
+    Set HTTP headers to be sent with each backend request. Other keys than
+    :php:`['Response']['Headers']` are ignored.
+
+    The default configuration:
+
+    ..  code-block:: php
+
+        [
             'Response' => [
-               'Headers' => ['clickJackingProtection' => 'X-Frame-Options: SAMEORIGIN']
-            ]
-         ]
+                'Headers' => [
+                    'clickJackingProtection' => 'X-Frame-Options: SAMEORIGIN',
+                    'strictTransportSecurity' => 'Strict-Transport-Security: max-age=31536000',
+                    'avoidMimeTypeSniffing' => 'X-Content-Type-Options: nosniff',
+                    'referrerPolicy' => 'Referrer-Policy: strict-origin-when-cross-origin',
+                ],
+            ],
+        ]
+    ..  versionchanged:: 12.3
+        The options :php:`strictTransportSecurity`, :php:`avoidMimeTypeSniffing`
+        and :php:`referrerPolicy` were added.
 
-   Set HTTP headers to be sent with each backend request. Other keys than
-   :php:`['Response']['Headers']` are ignored.
+    ..  note::
+        The `Strict-Transport-Security` is only active, if the option
+        :ref:`$GLOBALS[TYPO3_CONF_VARS][BE][lockSSL] <typo3ConfVars_be_lockSSL>`
+        is enabled.
+
 
 .. index::
    TYPO3_CONF_VARS BE; passwordHashing className

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -946,6 +946,7 @@ HTTP
                 ],
             ],
         ]
+
     ..  versionchanged:: 12.3
         The options :php:`strictTransportSecurity`, :php:`avoidMimeTypeSniffing`
         and :php:`referrerPolicy` were added.


### PR DESCRIPTION
The default configuration is moved from a confval attribute to plain text as it affects the layout.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/379
Releases: main