### PR TITLE
Add LANG to globals

### DIFF
--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -153,7 +153,7 @@ $GLOBALS
 
         It is discouraged to use this variable directly. The
         :php:`LanguageServiceFactory` should be used instead to retrieve the
-        :php:`\TYPO3\CMS\Core\Localization\LanguageService`.
+        :php:`LanguageService`.
 
    The :php:`LanguageService` can be used to fetch
    translations.

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -142,6 +142,26 @@ $GLOBALS
       Should not be used anymore, rather use the
       :ref:`DateTime Aspect <context_api_aspects_datetime>`.
 
+.. confval:: LANG
+
+   :Path: $GLOBALS
+   :type: :php:`\TYPO3\CMS\Core\Localization\LanguageService`
+   :Defined: is initialized via :php:`\TYPO3\CMS\Core\Localization\LanguageServiceFactory`
+   :Frontend: no
+
+   .. attention::
+
+        It is discouraged to use this variable directly. The
+        :php:`LanguageServiceFactory` should be used instead to retrieve the
+        :php:`\TYPO3\CMS\Core\Localization\LanguageService`.
+
+   The :php:`\TYPO3\CMS\Core\Localization\LanguageService` can be used to fetch
+   translations.
+
+   More information about retrieving the
+   :php:`\TYPO3\CMS\Core\Localization\LanguageService` is available in
+   :ref:`extension-localization-php`.
+
 
 .. index:: $GLOBALS; Admin Tools
 .. _globals-exploring:

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -159,7 +159,7 @@ $GLOBALS
    translations.
 
    More information about retrieving the
-   :php:`\TYPO3\CMS\Core\Localization\LanguageService` is available in
+   :php:`LanguageService` is available in
    :ref:`extension-localization-php`.
 
 

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -155,7 +155,7 @@ $GLOBALS
         :php:`LanguageServiceFactory` should be used instead to retrieve the
         :php:`\TYPO3\CMS\Core\Localization\LanguageService`.
 
-   The :php:`\TYPO3\CMS\Core\Localization\LanguageService` can be used to fetch
+   The :php:`LanguageService` can be used to fetch
    translations.
 
    More information about retrieving the


### PR DESCRIPTION
Separated from PR https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/2739/

This adds LANG to the [Globals](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Configuration/GlobalVariables.html) page. Though $GLOBALS['LANG'] should no longer be used directly, it is good to have a section there and linking to up to date information about how to retrieve language labels (similar to $GLOBALS['TSFE'].

Have moved the section to the end of the page now.