### PR TITLE
[FEATURE] #97390 - Use password policy for password reset in ext:felogin

### DIFF
--- a/Documentation/ApiOverview/PasswordPolicies/Index.rst
+++ b/Documentation/ApiOverview/PasswordPolicies/Index.rst
@@ -36,6 +36,8 @@ The password policy applies to:
 *   Creating a backend user during installation
 *   Setting a new password for a backend user in :guilabel:`User settings`
 *   Resetting a password for a backend user
+*   Resetting a password for a frontend user (see also the feature toggle
+    ":ref:`typo3ConfVars_sys_features_security.usePasswordPolicyForFrontendUsers`")
 *   Password fields in tables :sql:`be_users` and :sql:`fe_users`
 
 Optionally, a password policy can be configured for custom TCA fields of the

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -843,6 +843,33 @@ security.backend.enforceReferrer
    required referer header. As this is a potential security risk, it is recommended to enable this option.
 
 
+..  index::
+    TYPO3_CONF_VARS SYS; features security.usePasswordPolicyForFrontendUsers
+..  _typo3ConfVars_sys_features_security.usePasswordPolicyForFrontendUsers:
+
+security.usePasswordPolicyForFrontendUsers
+------------------------------------------
+
+..  versionadded:: 12.3
+
+..  confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.usePasswordPolicyForFrontendUsers']
+
+    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']
+    :type: bool
+    :Default: false for existing installations, true for new installations
+
+    Password validation configured through
+    :typoscript:`plugin.tx_felogin_login.settings.passwordValidators` has been
+    marked as deprecated, but will still be used for password validation when
+    a user resets the password, if this feature toggle is set to :php:`false`.
+
+    If the feature toggle is set to :php:`true`, the globally configured
+    :ref:`password policy <password-policies>` is applied when a TYPO3 frontend
+    user resets the password.
+
+    ..  seealso::
+        :ref:`$GLOBALS['TYPO3_CONF_VARS']['FE']['passwordPolicy'] <typo3ConfVars_fe_passwordPolicy>`
+
 .. index::
    TYPO3_CONF_VARS SYS; availablePasswordHashAlgorithms
 .. _typo3ConfVars_sys_availablePasswordHashAlgorithms:


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/417
Releases: main, 12.4