### PR TITLE
Differentiate log paths for Composer-based and legacy installs (#2812)

### DIFF
--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -89,8 +89,19 @@ for warnings (:php:`LogLevel::WARNING`) and lower, so all matching log entries
 are written to a file.
 
 If the filename is not set, then the file will contain a hash like
-:file:`typo3temp/var/logs/typo3_<hash>.log`, for example
-:file:`typo3temp/var/logs/typo3_7ac500bce5.log`.
+
+..  tabs::
+
+    ..  group-tab:: Composer-based installation
+
+        :file:`var/log/typo3_<hash>.log`, for example
+        :file:`var/log/typo3_7ac500bce5.log`.
+
+    ..  group-tab:: Legacy installation
+
+        :file:`typo3temp/var/log/typo3_<hash>.log`, for example
+        :file:`typo3temp/var/log/typo3_7ac500bce5.log`.
+
 
 A sample output looks like this:
 


### PR DESCRIPTION
Forward-port from https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/commit/55d114622a7266d08a329fed983da09d6ea0b949