### PR TITLE
[TASK] Remove deprecated site language properties from example

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/_language-example.yaml
+++ b/Documentation/ApiOverview/SiteHandling/_language-example.yaml
@@ -4,8 +4,4 @@ languages:
     navigationTitle: ''
     base: /
     locale: en_GB.UTF-8
-    iso-639-1: en
-    hreflang: en-US
-    direction: ltr
-    typo3Language: default
     flag: gb


### PR DESCRIPTION
These four properties are deprecated. They are not available in the GUI since v12.3 anymore and not written with a new site configuration.

Releases: main