### PR TITLE
[TASK] #100355 - Deprecate methods in PasswordChangeEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
@@ -1,19 +1,33 @@
-.. include:: /Includes.rst.txt
-.. index:: Events; PasswordChangeEvent
-.. _PasswordChangeEvent:
+..  include:: /Includes.rst.txt
+..  index:: Events; PasswordChangeEvent
+..  _PasswordChangeEvent:
 
 ===================
 PasswordChangeEvent
 ===================
 
-The event contains information about the password that has been set and will be
-stored in the database shortly. It allows to mark the password as invalid.
+The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\PasswordChangeEvent`
+contains information about the password that has been set and will be
+stored in the database shortly.
 
 ..  note::
     You can find a basic example implementation of a listener to this event
     in the chapter :ref:`extension-development-event-listener`.
 
-API
----
+..  deprecated:: 12.4
+    The :php:`PasswordChangeEvent` should not be used to validate user passwords,
+    since it is not possible to visualize to the user why a password has been
+    rejected. Therefore the following methods of the event are deprecated:
 
-.. include:: /CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt
+    *   :php:`->setAsInvalid()`
+    *   :php:`->getErrorMessage()`
+    *   :php:`->isPropagationStopped()`
+    *   :php:`->setHashedPassword()`
+
+    A :ref:`custom password policy validator<password-policies-custom-validator>`
+    should be used to validate user passwords.
+
+API
+===
+
+..  include:: /CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt

--- a/Documentation/ApiOverview/PasswordPolicies/Index.rst
+++ b/Documentation/ApiOverview/PasswordPolicies/Index.rst
@@ -178,6 +178,8 @@ string has to be supplied as password policy for frontend and backend context:
     in development context.
 
 
+..  _password-policies-custom-validator:
+
 Custom password validator
 =========================
 

--- a/Documentation/CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt
@@ -3,9 +3,7 @@
 
 .. php:class:: PasswordChangeEvent
 
-   Event that contains information about the password which was set, and is about to be stored in the database.
-   
-   Additional validation can happen here.
+   Informal event that contains information about the password which was set, and is about to be stored in the database.
 
    
    .. php:method:: getUser()
@@ -18,6 +16,10 @@
       
    .. php:method:: setHashedPassword(string $passwordHash)
    
+      **Deprecated:** will be removed in TYPO3 13
+      
+      
+      
       :param string $passwordHash: the passwordHash
       
    .. php:method:: getRawPassword()
@@ -26,12 +28,24 @@
       
    .. php:method:: setAsInvalid(string $message)
    
+      **Deprecated:** will be removed in TYPO3 13
+      
+      
+      
       :param string $message: the message
       
    .. php:method:: getErrorMessage()
    
+      **Deprecated:** will be removed in TYPO3 13
+      
+      
+      
       :returntype: string
       
    .. php:method:: isPropagationStopped()
    
+      **Deprecated:** will be removed in TYPO3 13
+      
+      
+      
       :returntype: bool


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/436
Releases: main