### PR TITLE
[TASK] Update TYPO3 versions in Security > General information

### DIFF
--- a/Documentation/Security/GeneralInformation/Index.rst
+++ b/Documentation/Security/GeneralInformation/Index.rst
@@ -19,27 +19,27 @@ TYPO3 versions and lifecycle
 TYPO3 is offered in Long Term Support (LTS) and Sprint Release versions.
 
 The first versions of each branch are Sprint Release versions. A Sprint Release
-version only receives support until the next Sprint Release got published. E.g.
-TYPO3 `11.0.0` was the first Sprint Release of the `11` branch and its support
-ended when TYPO3 `11.1.0` got released.
+version only receives support until the next Sprint Release got published. For
+example, TYPO3 v12.0.0 was the first Sprint Release of the v12 branch and its
+support ended when TYPO3 v12.1.0 got released.
 
 An LTS version is planned to be created every 18 months. LTS versions are created
 from a branch in order to finalize it: Prior to reaching LTS status, a number of
 Sprint Releases has been created from that branch and the release of an LTS version
 marks the point after which no new features will be added to this branch. LTS
 versions get full support (bug fixes and security fixes) for at least three years.
-TYPO3 version 10 (`v10`) and v11 are such LTS versions.
+TYPO3 version 11 (v11) and v12 are such LTS versions.
 
 The minor-versions are skipped in the official
-naming. 11 LTS is version`11.5` internally and 10 LTS is `10.4`. Versions inside a
-major-version have minor-versions as usual (`11.0`, `11.1`, ...) until at some
-point the branch receives LTS-status.
+naming. 12 LTS is version v12.4 internally and 11 LTS is v11.5. Versions inside
+a major-version have minor-versions as usual (v12.0, v12.1, ...) until at some
+point the branch receives LTS status.
 
 Support and security fixes are provided for the current as well as the
-preceding LTS release. For example, when TYPO3 v11 is the current LTS release,
-TYPO3 v10 is still actively supported, including security updates.
+preceding LTS release. For example, when TYPO3 v12 is the current LTS release,
+TYPO3 v11 is still actively supported, including security updates.
 
-For users of v10 an update to v11 is recommended. All versions below TYPO3 v10 are
+For users of v11 an update to v12 is recommended. All versions below TYPO3 v11 are
 outdated and the regular support of these versions has ended, including security updates.
 Users of these versions are strongly encouraged to update their systems
 as soon as possible.
@@ -54,22 +54,24 @@ LTS and Sprint Releases offer new features and often a modified
 database structure. Also the visual appearance and handling of the
 backend may be changed and appropriate training for editors may be
 required. The content rendering may change, so that updates in
-`TypoScript`, templates or `CSS` code may be necessary. With LTS and
+TypoScript, templates or CSS code may be necessary. With LTS and
 Sprint Releases also the system requirements (for example PHP or MySQL
 version) may change. For a patch level release (i.e.
-changing from release `11.5.0` to `11.5.1`) the database structure and
+changing from release v12.4.0 to v12.4.1) the database structure and
 backend will usually not change and an update will only require the
 new version of the source code.
 
 List of TYPO3 LTS releases:
 
-*   v8 (8.7 ELTS): No free bugfix/security update. Extended long term support
+*   v8 (8.7 ELTS): No free bugfix/security update. Extended long-term support
     can be ordered at https://typo3.com/services/extended-support-elts
-*   v9 (9.5 ELTS): No free bugfix/security update. Extended long term support
+*   v9 (9.5 ELTS): No free bugfix/security update. Extended long-term support
     can be ordered at https://typo3.com/services/extended-support-elts
-*   v10 (10.4 LTS): Versions 10.0 through 10.3 do not receive security
-    updates any longer
+*   v10 (10.4 ELTS): No free bugfix/security update. Extended long-term support
+    can be ordered at https://typo3.com/services/extended-support-elts
 *   v11 (11.5 LTS): Versions 11.0 through 11.4 do not receive security
+    updates any longer
+*   v12 (12.4 LTS): Versions 12.0 through 12.3 do not receive security
     updates any longer
 
 


### PR DESCRIPTION
Support for v8 ELTS was extended to March 31, 2024, so it is left in the list of releases.

Releases: main