### PR TITLE
[TASK] Remove the reference to the SOAP interface for publishing extensions

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/PublishExtension/PublishToTER/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/PublishExtension/PublishToTER/Index.rst
@@ -91,11 +91,3 @@ releasing an extension:
    simplify the integration into common CI / CD pipelines:
 
    GitHub: https://github.com/tomasnorre/typo3-upload-ter
-
-#. Via the SOAP interface (shut down on July 30, 2022):
-
-   Use the PHP CLI application
-   `TYPO3 Repository Client <https://github.com/NamelessCoder/typo3-repository-client>`__
-   , or the `TER Client <https://github.com/helhum/ter-client>`__ based on the
-   TYPO3 Repository Client.
-


### PR DESCRIPTION
The SOAP interface is not working anymore, therefore it is removed.

Releases: main, 11.5