### PR TITLE
[TASK] Clarify type of repository

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
@@ -7,9 +7,11 @@
 Repository
 ==========
 
-All repositories inherit from :php:`\TYPO3\CMS\Extbase\Persistence\Repository`.
+All :ref:`Extbase <extbase>` repositories inherit from
+:php:`\TYPO3\CMS\Extbase\Persistence\Repository`.
 
-A repository is always responsible for precisely one type of domain object.
+A repository is always responsible for precisely one type of
+:ref:`domain object <extbase-model>`.
 
 The naming of the repositories is important:
 If the domain object is, for example, *Blog* (with full name


### PR DESCRIPTION
When coming from a search you just see "All repositories inherit from ...". You might miss the context in the breadcrumb or navigation. As also other repositories are possible (like building upon the ConnectionPool), this sentence is now set into the right context.

Additionally, a link from "domain object" to the model page is added.

Releases: main, 11.5