### PR TITLE
[TASK] List configuration files for site and system-wide

### DIFF
--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -42,8 +42,12 @@ contains installation-wide configuration.
 :file:`config/sites/`
 ~~~~~~~~~~~~~~~~~~~~~
 
-The folder :file:`config/sites/` contains
-subfolders for each :ref:`site configuration <sitehandling>`.
+The folder :file:`config/sites/` contains subfolders for each site.
+
+The following files are processed:
+
+*   :file:`config.yaml` for the :ref:`site configuration <sitehandling>`
+*   :file:`settings.yaml` for the :ref:`site settings <sitehandling-settings>`
 
 
 .. _directory-config-system:
@@ -51,9 +55,16 @@ subfolders for each :ref:`site configuration <sitehandling>`.
 :file:`config/system/`
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The folder :file:`config/system/` contains the
-:ref:`Configuration files <configuration-files>` :file:`config/system/settings.php`
-and :file:`config/system/additional.php`.
+The folder :file:`config/system/` contains the installation-wide
+:ref:`configuration files <configuration-files>`:
+
+*   :file:`settings.php`: :ref:`Configuration <typo3ConfVars-settings>` written
+    by the :guilabel:`Admin Tools > Settings` backend module
+*   :file:`additional.php`: :ref:`Manually created file <typo3ConfVars-additional>`
+    which can override settings from :file:`settings.php` file
+
+These files define a set of global settings stored in a global array called
+:ref:`$GLOBALS['TYPO3_CONF_VARS'] <typo3ConfVars>`.
 
 This path can be retrieved from the Environment API, see
 :ref:`Environment-config-path`.

--- a/Documentation/ApiOverview/DirectoryStructure/LegacyInstallations.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/LegacyInstallations.rst
@@ -24,7 +24,7 @@ It might contain a file for server configuration like  :file:`.htaccess`.
 .. note::
 
    Further files might be useful depending on the server or the purpose.
-   It's for example common to place an authentication file in the web root for a search engine.
+   It is for example common to place an authentication file in the web root for a search engine.
    Also different files for server configuration might be possible.
 
    Note that TYPO3 has the possibility to provide one or more virtual file(s) :file:`robots.txt`.

--- a/Documentation/ApiOverview/DirectoryStructure/LegacyInstallations.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/LegacyInstallations.rst
@@ -23,10 +23,10 @@ It might contain a file for server configuration like  :file:`.htaccess`.
 
 .. note::
 
-   Further files might be useful depending on the server or the purpose.  
-   It's for example common to place an authentication file in the web root for a search engine.  
-   Also different files for server configuration might be possible.  
-   
+   Further files might be useful depending on the server or the purpose.
+   It's for example common to place an authentication file in the web root for a search engine.
+   Also different files for server configuration might be possible.
+
    Note that TYPO3 has the possibility to provide one or more virtual file(s) :file:`robots.txt`.
    This option can be found in the backend module 'Sites' in 'Site Management' and
    is especially advised when different domains shall be hosted in one TYPO3 installation.
@@ -143,16 +143,28 @@ This path can be retrieved from the Environment API, see
 :file:`typo3conf/sites/`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Contains subfolders for each :ref:`site configuration <sitehandling>`.
+The folder :file:`typo3conf/sites/` contains subfolders for each site.
+
+The following files are processed:
+
+*   :file:`config.yaml` for the :ref:`site configuration <sitehandling>`
+*   :file:`settings.yaml` for the :ref:`site settings <sitehandling-settings>`
 
 .. _legacy-directory-typo3conf-system:
 
 :file:`typo3conf/system/`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The folder :file:`typo3conf/system/` contains the
-:ref:`Configuration files <configuration-files>` :file:`typo3conf/system/settings.php`
-and :file:`typo3conf/system/additional.php`.
+The folder :file:`typo3conf/system/` contains the installation-wide
+:ref:`configuration files <configuration-files>`:
+
+*   :file:`settings.php`: :ref:`Configuration <typo3ConfVars-settings>` written
+    by the :guilabel:`Admin Tools > Settings` backend module
+*   :file:`additional.php`: :ref:`Manually created file <typo3ConfVars-additional>`
+    which can override settings from :file:`settings.php` file
+
+These files define a set of global settings stored in a global array called
+:ref:`$GLOBALS['TYPO3_CONF_VARS'] <typo3ConfVars>`.
 
 This path can be retrieved from the Environment API, see
 :ref:`Environment-config-path`.


### PR DESCRIPTION
List the possible configuration files for a site (`config/sites/`) and system-wide (`config/system/`). This gives an integrator a better overview at this place which files are processed and what is their purpose.

This is a preparation for the new Content Security Policy which introduces a `config/sites/<my_site>/csp.yaml` file.

Releases: main