### PR TITLE
[TASK] Discourage usage of Extbase in middlewares

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Index.rst
@@ -14,12 +14,23 @@ have to be used.
 
 Extbase is included in the TYPO3 Core as system extension :php:`extbase`.
 
+**Please note:** Extbase relies on :ref:`frontend TypoScript <t3tsref:start>`
+being present; otherwise the configuration is not applied. This is usually no
+problem - Extbase plugins are typically either included as
+:ref:`USER content object <t3tsref:cobj-user>` (its content is cached and
+returned together with other content elements in fully-cached page context), or
+the Extbase plugin is registered as USER_INT. In this case, the
+:ref:`TSFE <tsfe>` takes care of calculating TypoScript before the plugin is
+rendered, while other USER content objects are fetched from page cache. This in
+mind you should not use Extbase in another context, like in
+:ref:`middlewares <request-handling-middlewares-extbase>`.
+
 There are also tutorials in the :ref:`Extension Development -
 Tutorials <extension-tutorials>` section.
 
 ..  toctree::
     :titlesonly:
-    
+
     Introduction/Index
     Reference/Index
     Examples/Index


### PR DESCRIPTION
Additionally, add a TOC in middlewares chapter.

Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/78007
Releases: main, 11.5