### PR TITLE
[TASK] #100657 - Deprecate TYPO3_CONF_VARS['BE']['languageDebug']

### DIFF
--- a/Documentation/ApiOverview/Debugging/Index.rst
+++ b/Documentation/ApiOverview/Debugging/Index.rst
@@ -54,14 +54,3 @@ to the select options in the “Full Search” module.
 
 Additionally, in debug mode, the page renderer does not compress or concatenate JavaScript or CSS
 resources.
-
-.. index::
-   pair: Debugging; Backend language
-   TYPO3_CONF_VARS; BE languageDebug
-
-Backend language debug
-======================
-
-Setting :code:`$GLOBALS['TYPO3_CONF_VARS']['BE']['languageDebug']`
-in the :file:`config/system/settings.php` displays the language labels (with
-file and key) in the TYPO3 backend :code:`FormEngine`.

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -30,6 +30,12 @@ the TYPO3 backend:
 languageDebug
 =============
 
+..  deprecated:: 12.4
+    Judging from translators feedback, the option is not used in practice:
+    Setting the toggle to true leads to a massively convoluted backend
+    experience that breaks tons of CSS and renders the backend so unusable that
+    it is hardly a benefit at all. The setting will be removed with TYPO3 v13.
+
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['languageDebug']
 
    :type: bool


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/461
Releases: main