### PR TITLE
[TASK] #100053 - Remove deprecated GeneralUtility::_GP() from examples

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -176,14 +176,17 @@ and "4" is "delete" permission. The result from the above query could be this st
 Saving module data
 ==================
 
-This stores the input variable :php:`$compareFlags` (an array!) with the key
-"tools\_beuser/index.php/compare"
+This stores the input variable :php:`$compareFlags` (an array!, retrieved from
+the :ref:`request object <typo3-request>`) with the key
+"tools\_beuser/index.php/compare":
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/Controller/SomeModuleController.php
+..  code-block:: php
+    :caption: EXT:some_extension/Classes/Controller/SomeModuleController.php
 
-   $compareFlags = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('compareFlags');
-   $GLOBALS['BE_USER']->pushModuleData('tools_beuser/index.php/compare', $compareFlags);
+    $compareFlags = $request->getParsedBody()['compareFlags'])
+        ?? $request->getQueryParams()['compareFlags'])
+        ?? null;
+    $GLOBALS['BE_USER']->pushModuleData('tools_beuser/index.php/compare', $compareFlags);
 
 
 .. index:: Backend user; pushModuleData

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -1049,7 +1049,7 @@ statement from SQL injections:
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
     // SELECT * FROM `tt_content` WHERE (`bodytext` = 'kl\'aus')
-    $searchWord = "kl'aus"; // $searchWord = GeneralUtility::_GP('searchword');
+    $searchWord = "kl'aus"; // $searchWord retrieved from the PSR-7 request
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder->getRestrictions()->removeAll();
     $queryBuilder
@@ -1078,7 +1078,7 @@ Not convinced? Suppose the code would look like this:
 
     // NEVER EVER DO THIS!
     $_POST['searchword'] = "'foo' UNION SELECT username FROM be_users";
-    $searchWord = GeneralUtility::_GP('searchword');
+    $searchWord = $request->getParsedBody()['searchword']);
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder->getRestrictions()->removeAll();
      this fails with syntax error to prevent copy and paste
@@ -1120,7 +1120,7 @@ Use integer, integer array:
     //     WHERE `bodytext` = 'kl\'aus'
     //     AND   sys_language_uid = 0
     //     AND   pid in (2, 42,13333)
-    $searchWord = "kl'aus"; // $searchWord = GeneralUtility::_GP('searchword');
+    $searchWord = "kl'aus"; // $searchWord retrieved from the PSR-7 request
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder->getRestrictions()->removeAll();
     $queryBuilder


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/377
Releases: main