### PR TITLE
[TASK] Remove line numbers in code snippets

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Tutorial.rst
+++ b/Documentation/ApiOverview/CommandControllers/Tutorial.rst
@@ -33,7 +33,6 @@ definition for your class as tag :yaml:`console.command`:
 
 ..  code-block:: yaml
     :caption: EXT:examples/Configuration/Services.yaml
-    :linenos:
     :emphasize-lines: 11-15
 
     services:

--- a/Documentation/ApiOverview/Events/Hooks/Index.rst
+++ b/Documentation/ApiOverview/Events/Hooks/Index.rst
@@ -42,16 +42,15 @@ The class has to be declared with the TYPO3 autoloader.
 If we take a look inside of :code:`\TYPO3\CMS\Core\DataHandling\DataHandler` we
 find the hook to be activated like this:
 
-.. code-block:: php
-   :linenos:
+..  code-block:: php
 
-      // Call post processing function for clear-cache:
-   if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'])) {
-      $_params = array('cacheCmd' => $cacheCmd);
-      foreach($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'] as $_funcRef) {
-         \TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction($_funcRef, $_params, $this);
-      }
-   }
+    // Call post processing function for clear-cache:
+    if (is_array($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'])) {
+        $_params = array('cacheCmd' => $cacheCmd);
+        foreach($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'] as $_funcRef) {
+            \TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction($_funcRef, $_params, $this);
+        }
+    }
 
 This is how hooks are typically constructed. The main action happens in line 5
 where the function :code:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()`

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -294,7 +294,6 @@ Set the Fluid paths with TypoScript using :ref:`t3tsref:cobj-fluidtemplate`
 
 .. code-block:: html
    :caption: Resources/Private/Templates/Page/ThreeColumn.html
-   :linenos:
 
    <f:layout name="Default" />
 

--- a/Documentation/ApiOverview/Routing/Examples.rst
+++ b/Documentation/ApiOverview/Routing/Examples.rst
@@ -28,7 +28,6 @@ If you use the *category menu* or *tag list* plugins to filter news records, the
 * Tag filter: :samp:`https://example.org/news/my-tag`
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      News:
@@ -88,7 +87,6 @@ Archive
 ^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      BlogArchive:
@@ -184,7 +182,6 @@ Posts by Author
 ^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      AuthorPosts:
@@ -218,7 +215,6 @@ Category pages
 ^^^^^^^^^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      BlogCategory:
@@ -252,7 +248,6 @@ Blog Feeds
 ^^^^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      PageTypeSuffix:
@@ -269,7 +264,6 @@ Blog Posts
 ^^^^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      BlogPosts:
@@ -293,7 +287,6 @@ Posts by Tag
 ^^^^^^^^^^^^
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      BlogTag:
@@ -327,7 +320,6 @@ BlogStaticDatabaseMapper
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: php
-   :linenos:
 
    <?php
         declare(strict_types = 1);
@@ -487,7 +479,6 @@ Usage with imports
 On typo3.com we are using imports to make routing configurations easier to manage:
 
 .. code-block:: yaml
-   :linenos:
 
    imports:
      - { resource: "EXT:template/Configuration/Routes/Blog/BlogCategory.yaml" }
@@ -503,7 +494,6 @@ Full project example config
 Taken from an anonymous live project:
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      news:
@@ -663,7 +653,6 @@ EXT: DpnGlossary
 * Detail view: :samp:`https://example.org/<YOUR_PLUGINPAGE_SLUG>/term/the-term-title`
 
 .. code-block:: yaml
-   :linenos:
 
    routeEnhancers:
      DpnGlossary:

--- a/Documentation/ApiOverview/Routing/ExtendingRouting.rst
+++ b/Documentation/ApiOverview/Routing/ExtendingRouting.rst
@@ -34,8 +34,8 @@ All mappers need to implement the methods :php:`generate` and :php:`resolve`. Th
 
 After implementing the matching interface, your aspect needs to be registered in :file:`ext_localconf.php`:
 
-.. code-block:: php
-   :linenos:
+..  code-block:: php
+    :caption: EXT:my_extension/ext_localconf.php
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['MyCustomMapperNameAsUsedInYamlConfig'] =
         \MyVendor\MyExtension\Routing\Aspect\MyCustomMapper::class;
@@ -68,8 +68,8 @@ The interfaces contain methods you need to implement as well as a description of
 
 To register the enhancer, add the following to your `ext_localconf.php`:
 
-.. code-block:: php
-   :linenos:
+..  code-block:: php
+    :caption: EXT:my_extension/ext_localconf.php
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['enhancers']['MyCustomEnhancerAsUsedInYaml'] = \MyVendor\MyExtension\Routing\Enhancer\MyCustomEnhancer::class;
 

--- a/Documentation/ApiOverview/Rte/Transformations/Introduction.rst
+++ b/Documentation/ApiOverview/Rte/Transformations/Introduction.rst
@@ -59,7 +59,6 @@ This is how the content in the database could look for a hybrid mode
 (such as :code:`css_transform`):
 
 .. code-block:: html
-   :linenos:
 
    This is line number 1 with a <a href="t3://page?uid=123">link</a> inside
    This is line number 2 with a <b>bold part</b> in the text

--- a/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
@@ -66,7 +66,6 @@ database.
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $dataHandler = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
    $dataHandler->start($data, []);
@@ -87,7 +86,6 @@ The most basic way of executing commands:
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $dataHandler = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
    $dataHandler->start([], $cmd);
@@ -110,7 +108,6 @@ calling the :php:`start()` method (which will initialize internal state).
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $dataHandler = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
    $dataHandler->start([], []);
@@ -130,7 +127,6 @@ Imagine the :php:`$data` array something like this:
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $data = [
        'pages' => [
@@ -162,7 +158,6 @@ all pages is cleared.
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $dataHandler = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
    $dataHandler->reverseOrder = 1;
@@ -191,7 +186,6 @@ should not set this argument since you want TCE to use the global
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    $dataHandler = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\DataHandling\DataHandler::class);
    $dataHandler->start($data, $cmd, $alternative_BE_USER);
@@ -212,7 +206,6 @@ You can use these e.g to logging or another error handling.
 
 .. code-block:: php
    :caption: EXT:some_extension/Classes/SomeClass.php
-   :linenos:
 
    if ($dataHandler->errorLog !== []) {
        $this->logger->error('Error(s) while creating content element');

--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -48,7 +48,6 @@ Subsequently:
 * The package name will be *my-vendor/my-extension*
 
 .. code-block:: json
-   :linenos:
 
    {
       "name": "my-vendor/my-extension",
@@ -92,7 +91,6 @@ Extended composer.json
 ======================
 
 .. code-block:: json
-   :linenos:
 
    {
       "name": "my-vendor/my-extension",


### PR DESCRIPTION
The line numbers are removed when they are not really necessary (as the snippets are short or the surrounding text does not reference line numbers).

Related: https://github.com/TYPO3-Documentation/sphinx_typo3_theme/issues/184
Releases: main, 11.5