### PR TITLE
Fix typo in snippet of TypoScriptFrontendController->rootLine (#2880)

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
@@ -16,7 +16,7 @@ Example:
 ..  code-block:: php
 
     $frontendController = $request->getAttribute('frontend.controller');
-    $rootline = $frontendController->rootline;
+    $rootline = $frontendController->rootLine;  // Mind the capital "L"
 
 ..  attention::
     In former TYPO3 versions you have to retrieve the


### PR DESCRIPTION
Forward-port of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/2880.

Releases: main, 12.4