### PR TITLE
[BUGFIX] #100744 - Use correct configuration example for message routing

### DIFF
--- a/Documentation/ApiOverview/MessageBus/Index.rst
+++ b/Documentation/ApiOverview/MessageBus/Index.rst
@@ -192,7 +192,7 @@ name used in the settings is resolved to a service that has been tagged with
 ..  code-block:: php
     :caption: config/settings.php | config/additional.php | EXT:my_extension/ext_localconf.php
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['queue'] = [
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['messenger'] = [
         'routing' => [
             // Use "messenger.transport.demo" as transport for DemoMessage
             \MyVendor\MyExtension\Queue\Message\DemoMessage::class => 'demo',

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -1062,24 +1062,3 @@ routing
 
     ..  seealso::
         :ref:`message-bus-routing`
-
-
-..  index::
-    TYPO3_CONF_VARS SYS; queue
-..  _typo3ConfVars_sys_queue:
-
-queue
-=====
-
-..  versionadded:: 12.2
-
-..  confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['queue']
-
-    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['queue']
-    :type: array
-
-    This settings allows to configure a transport for the
-    :ref:`messenger component <message-bus>`.
-
-    ..  seealso::
-        :ref:`message-bus-custom-transport`


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/475
Releases: main, 12.4