### PR TITLE
[BUGFIX] Remove mail option transport_smtp_stream_options

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -233,41 +233,6 @@ transport_smtp_domain
        ];
 
 .. index::
-   TYPO3_CONF_VARS MAIL; transport_smtp_stream_options
-.. _typo3ConfVars_mail_transport_smtp_stream_options:
-
-transport_smtp_stream_options
-=============================
-
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_smtp_stream_options']
-
-   :type: bool
-   :Default: false
-
-   *only with transport=smtp* Sets additional stream options.
-
-   Configuration Example:
-
-   .. code-block:: php
-      :caption: typo3conf/AdditionalConfiguration.php
-
-       return [
-           //....
-           'MAIL' => [
-               'transport' => 'smtp',
-               'transport_sendmail_command' => ' -t -i ',
-               'transport_smtp_server' => 'localhost:1025',
-               'transport_smtp_stream_options' => [
-                   'ssl' => [
-                       'verify_peer' => false,
-                       'verify_peer_name' => false,
-                   ]
-               ],
-           ],
-           //....
-       ];
-
-.. index::
    TYPO3_CONF_VARS MAIL; transport_smtp_encrypt
 .. _typo3ConfVars_mail_transport_smtp_encrypt:
 


### PR DESCRIPTION
This option is only available since TYPO3 v12, therefore it is removed from the 11.5 docs.

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/2883
Releases: 11.5