### PR TITLE
Add additional information for removing processed files

### DIFF
--- a/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Maintenance.rst
@@ -60,3 +60,75 @@ Here you can choose to delete all files in :file:`fileadmin/_processed_/`
 
 This cleanup is also good if processed files have accumulated for a
 long time. Many of them may then be obsolete.
+
+.. attention::
+
+    If you delete processed files, you should flush the (page) cache immediately
+    afterwards. If pages are cached and the page uses processed images, these
+    will not be regenerated on the fly when a page is loaded. Ideally, make sure
+    the removal of the processed files and flushing of page cache is one atomic
+    operation which is performed as quickly as possible.
+
+Also, deleting processed files while editors are active is not ideal.
+Preferably, lock the TYPO3 Backend before you remove the processed files.
+
+See also the next section in case you have many processed files and removal
+would take long (e.g. several minutes).
+
+Bulk removal of processed files
+-------------------------------
+
+This entire section is a "use at your own risk" hint.
+
+In general remove processed files as one atomic operation together with flushing
+the page cache afterwards.
+
+Removing processed files may take long if there are many. As a shortcut, you may
+remove all at once, but always be sure to consider the database table
+(sys_file_processedfiles) **and** the files on the filesystem (e.g.
+file:`fileadmin/_processed_`).
+
+TYPO3 uses storage 0 as default storage if files are not found in one of
+the configured storages. You may want to check if you have any processed
+files with storage=0 and where they are located before you begin. It is
+recommended to use TYPO3 functionality only when handling processed files in
+storage 0.
+
+.. code-block:: mysql
+    :caption: MySQL (or compatible) command for checking for processed files in storage 0
+
+    SELECT storage,identifier FROM sys_file_processedfile WHERE storage=0;
+
+See the original paths of the files as well:
+
+.. code-block:: mysql
+    :caption: MySQL command for showing file identifier for processed files in storage 0
+
+    SELECT p.storage,p.identifier,p.original,f.identifier FROM sys_file_processedfile p LEFT OUTER JOIN sys_file f ON p.original=f.uid WHERE p.storage=0;
+
+In order to remove the files, do this for each storage (sys_file_storage):
+
+.. code-block:: shell
+    :caption: command line: Move away processed files
+
+    # moving the directory may be much faster than removing individual files
+    #   unless on different mount points
+    # do not move the processed files into any managed filesystem (e.g. in
+    #   fileadmin) because the would be scanned as well.
+    mv fileadmin/_processed_ /var/tmp/fileadmin_processed.bak
+
+For the SQL command, consider the storage here as well, in case you have several
+storages and want to perform the task individually for each storage.
+
+.. code-block:: mysql
+    :caption: MySQL (or compatible) command for removing processed files in storage 1
+
+    DELETE FROM sys_file_processedfile WHERE storage=1;
+
+Alternatively, use truncate to delete all processed files in all storages.
+
+.. code-block:: mysql
+    :caption: MySQL (or compatible) command for removing all processed files
+
+    TRUNCATE sys_file_processedfile;
+


### PR DESCRIPTION
There are some things to consider when removing processed files:

1. Page cache should be flushed afterwards
2. In case there are many processed files, it might make sense to remove them in bulk
3. Ideally, backend should be locked because processed files will suddenly disappear, disrupting the editors

------

Additional information (not in commit message):

I verified behaviour with latest TYPO3 v12 (dev-main):

1. created page with textmedia and processed image (Add image to assets and set width=100)
2. load page in Frontend (in browser window with not logged in status) to make sure page is cached. Confirm that image is displayed and is scaled.
3. Remove all temporary assets in "Maintenance"
4. Remove browser cache
5. Now load page again (in browser not logged in status)

The image is not displayed in the FE. After flushing the page cache, the image is displayed again.