### PR TITLE
[TASK] Move code snippets into separate files for info events

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
@@ -1,20 +1,20 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Events; ModifyInfoModuleContentEvent
-.. _ModifyInfoModuleContentEvent:
+..  include:: /Includes.rst.txt
+..  index::
+    Events; ModifyInfoModuleContentEvent
+..  _ModifyInfoModuleContentEvent:
 
 ============================
 ModifyInfoModuleContentEvent
 ============================
 
-.. versionadded:: 12.0
-   This event has been introduced as a more powerful and flexible alternative
-   to :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/web_info/class.tx_cms_webinfo.php']['drawFooterHook']`
-   which has now been removed.
+..  versionadded:: 12.0
+    This event has been introduced as a more powerful and flexible alternative
+    to :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/web_info/class.tx_cms_webinfo.php']['drawFooterHook']`
+    which has now been removed.
 
-This event allows the content above and below the
-info module to be modified. The content added in the event is
-displayed in each submodule of :guilabel:`Web > Info`.
+The PSR-14 event :php:`\TYPO3\CMS\Info\Controller\Event\ModifyInfoModuleContentEvent`
+allows the content above and below the info module to be modified. The content
+added in the event is displayed in each submodule of :guilabel:`Web > Info`.
 
 The event also provides the :php:`getCurrentModule()` method, which
 returns the current requested submodule. It is therefore possible to
@@ -40,33 +40,17 @@ Example
 
 Registration of the event listener in the extension's :file:`Services.yaml`:
 
-.. code-block:: yaml
-   :caption: EXT:my_extension/Configuration/Services.yaml
-
-   MyVendor\MyPackage\Backend\MyEventListener:
-    tags:
-      - name: event.listener
-        identifier: 'my-package/backend/content-to-info-module'
+..  literalinclude:: _ModifyInfoModuleContentEvent/_Services.yaml
+    :language: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
 The corresponding event listener class:
 
-.. code-block:: php
-   :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
-
-   use TYPO3\CMS\Info\Controller\Event\ModifyInfoModuleContentEvent;
-
-   final class MyEventListener {
-
-     public function __invoke(ModifyInfoModuleContentEvent $event): void
-     {
-         // Add header content for the "Page TSconfig" submodule if user has access to module content
-         if ($event->hasAccess() && $event->getCurrentModule()->getIdentifier() === 'web_info_pagets') {
-             $event->addHeaderContent('<h3>Additional header content</h3>');
-         }
-     }
-   }
+..  literalinclude:: _ModifyInfoModuleContentEvent/_MyEventListener.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Info/EventListener/MyEventListener.php
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Info/ModifyInfoModuleContentEvent.rst.txt
+..  include:: /CodeSnippets/Events/Info/ModifyInfoModuleContentEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_MyEventListener.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Info\EventListener;
+
+use TYPO3\CMS\Info\Controller\Event\ModifyInfoModuleContentEvent;
+
+final class MyEventListener
+{
+    public function __invoke(ModifyInfoModuleContentEvent $event): void
+    {
+        // Add header content for the "Localization overview" submodule,
+        // if user has access to module content
+        if (
+            $event->hasAccess() &&
+            $event->getCurrentModule()->getIdentifier() === 'web_info_translations'
+        ) {
+            $event->addHeaderContent('<h3>Additional header content</h3>');
+        }
+    }
+}

--- a/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_Services.yaml
@@ -1,0 +1,4 @@
+MyVendor\MyExtension\Info\EventListener\MyEventListener:
+  tags:
+    - name: event.listener
+      identifier: 'my-extension/content-to-info-module'


### PR DESCRIPTION
Additionally, adjust example as the previous page TSconfig submodule is now a main module and not under "Info" anymore.

Releases: main, 12.4