### PR TITLE
Update testing extensions (12.4 branch)

### DIFF
--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -134,7 +134,7 @@ This is how the composer.json file looks before we add a test setup:
         "GPL-2.0-or-later"
       ],
       "require": {
-        "typo3/cms-core": "^11.5"
+        "typo3/cms-core": "^12.4"
       },
       "autoload": {
         "psr-4": {
@@ -149,7 +149,7 @@ This is how the composer.json file looks before we add a test setup:
     }
 
 This is a typical composer.json file without any complexity: It's a `typo3-cms-extension`, with an
-author and a license. We are stating that "I need at least 11.5.0 of cms-core" and we tell the autoloader
+author and a license. We are stating that "I need at least 12.4.0 of cms-core" and we tell the autoloader
 "find all class names starting with :php:`Lolli\Enetcache` in the Classes/ directory".
 
 The extension already contains some unit tests that extend `typo3/testing-framework`'s base
@@ -199,14 +199,14 @@ to add root :file:`composer.json` details, turning the extension into a project 
         "GPL-2.0-or-later"
       ],
       "require": {
-        "typo3/cms-core": "^11.5"
+        "typo3/cms-core": "^12.4"
       },
       "config": {
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin"
       },
       "require-dev": {
-        "typo3/testing-framework": "^7"
+        "typo3/testing-framework": "^8"
       },
       "autoload": {
         "psr-4": {
@@ -232,7 +232,7 @@ to add root :file:`composer.json` details, turning the extension into a project 
 Note all added properties are only used within our root :file:`composer.json` files, they are ignored if the
 extension is loaded as a dependency in our project. Note: We specify `.Build` as
 build directory. This is where our TYPO3 instance will be set up. We add `typo3/testing-framework`
-in a v11 compatible version as `require-dev` dependency. We add a `autoload-dev` to tell composer
+in a v12.4 compatible version as `require-dev` dependency. We add a `autoload-dev` to tell composer
 that test classes are found in the :file:`Tests/` directory.
 
 Now, before we start playing around with this setup, we instruct `git` to ignore runtime
@@ -415,7 +415,7 @@ In order to tell the CI what to do, create a new workflow file in `.github/workf
        runs-on: ubuntu-latest
        strategy:
          matrix:
-           php: [ '7.4', '8.0', '8.1' ]
+           php: [ '8.1', '8.2' ]
            minMax: [ 'composerInstallMin', 'composerInstallMax' ]
        steps:
          - name: Checkout
@@ -468,7 +468,7 @@ to composer's `packagist.org <https://packagist.org/packages/typo3/cms-styleguid
 dependency (or require-dev dependency) in any project.
 
 The styleguide extension follows the Core branching principle, too: At the time of this writing, its `main`
-branch is dedicated to be compatible with upcoming Core version 11. There are branches compatible with older Core versions, too.
+branch is dedicated to be compatible with Core version 12.4. There are branches compatible with older Core versions, too.
 
 In comparison to enetcache, styleguide comes with additional test suites: It has functional and
 acceptance tests! Our goal is to run the functional tests with different database platforms, and to
@@ -596,8 +596,8 @@ That's it. It executes fine using :file:`runTests.sh`:
     Creating local_mariadb10_1 ... done
     Waiting for database start...
     Database is up
-    PHP 7.2.11-3+ubuntu18.04.1+deb.sury.org+1 (cli) (built: Oct 25 2018 06:44:08) ( NTS )
-    PHPUnit 7.1.5 by Sebastian Bergmann and contributors.
+    PHP ...
+    PHPUnit ... by Sebastian Bergmann and contributors.
 
     ..                                                                  2 / 2 (100%)
 
@@ -745,8 +745,8 @@ have some database fixtures included to easily log in to the backend. Additional
     Creating local_mariadb10_1 ... done
     Waiting for database start...
     Database is up
-    Codeception PHP Testing Framework v2.5.1
-    Powered by PHPUnit 7.1.5 by Sebastian Bergmann and contributors.
+    Codeception PHP Testing Framework ...
+    Powered by PHPUnit ... by Sebastian Bergmann and contributors.
     Running with seed:
 
 
@@ -798,7 +798,7 @@ Now we want all of this automatically checked using Github Actions. As before, w
        runs-on: ubuntu-latest
        strategy:
          matrix:
-           php: [ '7.4', '8.0', '8.1' ]
+           php: [ '8.1', '8.2' ]
        steps:
          - name: Checkout
            uses: actions/checkout@v2

--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -8,19 +8,6 @@
 Extension testing
 =================
 
-.. attention::
-
-    This page has not been fully updated yet. Specifically the following:
-
-    *   Decide if multi-core-version testing should be documented or testing only
-        one core version. (Originally, this page was written for testing only one
-        core version since testing 2 core versions was not supported well at the
-        time. Also, when this page was originally written, enetcache tested only one core
-        version and supported only one core version per branch).
-
-    For now, we document testing only one core version here, even if 2 is possible
-    and enetcache supports it.
-
 Introduction
 ============
 

--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -326,25 +326,31 @@ through the files and adapt to your needs, for example.
    supported PHP version. (You can also specify the version on the command line
    using runTests.sh with -p.)
 
-Let's run the tests:
+Let's run the unit tests:
 
 .. code-block:: shell
+    :caption: command line
 
-    lolli@apoc /var/www/local/git/enetcache $ Build/Scripts/runTests.sh
+    Build/Scripts/runTests.sh
+
+You may now see something similar to this:
+
+.. code-block:: text
+
     Creating network "local_default" with the default driver
-    PHP ....
-    PHPUnit ... by Sebastian Bergmann and contributors.
+    PHP 8.2.6 (cli) (built: May 13 2023 01:04:28) (NTS)
+    PHPUnit 10.2.0 by Sebastian Bergmann and contributors.
 
-    .....SS                                                             7 / 7 (100%)
+    Runtime:       PHP 8.2.6
+    Configuration: /var/www/mysite/typo3conf/ext/styleguide/Build/UnitTests.xml
 
-    Time: 84 ms, Memory: 12.00MB
+    .                                                                   1 / 1 (100%)
 
-    OK, but incomplete, skipped, or risky tests!
-    Tests: 7, Assertions: 56, Skipped: 2.
-    Removing local_unit_run_1 ... done
+    Time: 00:00.007, Memory: 12.00 MB
+
+    OK (1 test, 5 assertions)
+    Removing local_unit_run_1f529b0fb49d ... done
     Removing network local_default
-
-Done. That's it. Execution of your extension`s unit tests.
 
 If there is no test output, try changing the verbosity when you run runTests.sh:
 


### PR DESCRIPTION
based on PR #2926

- No longer use ExtensionTestEnvironment in composer.json
- Remove replace / self.version in composer.json
- Remove cms-package-dir in composer.json
- Remove ignore-as-root in composer.json
- Update version numbers for TYPO3, PHP, testing-framework
- Clarify testing of one or more core versions (for
  now we stick to testing only one core version in the
  example)
- Change information that testing more than core version
  is not recommended (it is better supported now with
  testing-framework)
- Remove link to nimut/testing-framework (nimut is
  only supported until TYPO3 v11)
- Remove section about installing to .Build/Web/typo3conf/ext
  since that is no longer supported. Instead, the paths
  should be updated so this is no longer necessary.
- Use composerUpdate instead of composerInstall
- the list of features for runTests.sh is formatted
  as list as this makes the individual points better readable
  for skimming over the part
- Use generic phrase for several PHP versions

Related: #2921
Related: #2972

Co-authored-by: Lina Wolf <48202465+linawolf@users.noreply.github.com>
Co-authored-by: Chris Müller <2566282+brotkrueml@users.noreply.github.com>
