### PR TITLE
Add note to composer.json

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -90,6 +90,11 @@ Subsequently:
 Extended composer.json
 ======================
 
+.. note::
+
+    Please see the chapter on :ref:`section on testing <testing-extensions>` for
+    further changes to composer.json for testing extensions.
+
 .. code-block:: json
 
    {


### PR DESCRIPTION
The basic composer.json does not contain information about testing. It should be referred to the testing chapter.