### PR TITLE
Remove nimut framework from composer.json

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -128,9 +128,6 @@ Extended composer.json
             "MyVendor\\MyExtension\\": "Classes/"
          }
       },
-      "require-dev": {
-         "nimut/testing-framework": "^6.0"
-      },
       "extra": {
          "typo3/cms": {
             "extension-key": "my_extension"

--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -102,6 +102,9 @@ Extended composer.json
          "typo3/cms-backend": "^11.5 || ^12.0",
          "typo3/cms-core": "^11.5 || ^12.0"
       },
+      "require-dev": {
+         "typo3/coding-standards": "^0.7.1"
+      },
       "authors": [
          {
             "name": "John Doe",


### PR DESCRIPTION
The nimut/testing-framework is only supported for v11, so it should not be referred to for v12 and above.

Also, we explain the testing setup in depth on the Extension Testing page, so it is best to refer there.

Resolves: #2972
Related: #2975