### PR TITLE
[TASK] Streamline Events/FileList chapter

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Filelist/Index.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/Index.rst
@@ -1,19 +1,19 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Events; Filelist
-.. _eventlist-filelist:
+..  include:: /Includes.rst.txt
+..  index:: pair: Events; Filelist
+..  _eventlist-filelist:
 
 
-==========================
+========
 Filelist
-==========================
+========
 
 The following list contains :ref:`PSR-14 events <EventDispatcher>`
 in EXT:filelist.
 
 **Contents:**
 
-.. toctree::
-   :titlesonly:
-   :glob:
+..  toctree::
+    :titlesonly:
+    :glob:
 
-   *
+    *

--- a/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
@@ -22,15 +22,15 @@ Example
 
 Registration of the event listener in the extension's :file:`Services.yaml`:
 
-..  literalinclude:: _Snippets/_ModifyEditFileFormDataEvent.yaml
+..  literalinclude:: _ModifyEditFileFormDataEvent/_Services.yaml
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 The corresponding event listener class:
 
-..  literalinclude:: _Snippets/_ModifyEditFileFormDataEventListener.php
+..  literalinclude:: _ModifyEditFileFormDataEvent/_MyEventListener.php
     :language: php
-    :caption: EXT:my_extension/Classes/FileList/ModifyEditFileFormDataEventListener.php
+    :caption: EXT:my_extension/Classes/FileList/EventListener/MyEventListener.php
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -21,17 +21,17 @@ Example
 
 Registration of the event listener in the extension's :file:`Services.yaml`:
 
-..  literalinclude:: _Snippets/_ProcessFileListActionsEvent.yaml
+..  literalinclude:: _ProcessFileListActionsEvent/_Services.yaml
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 The corresponding event listener class:
 
-..  literalinclude:: _Snippets/_ProcessFileListActionsEventListener.php
+..  literalinclude:: _ProcessFileListActionsEvent/_MyEventListener.php
     :language: php
-    :caption: EXT:my_extension/Classes/FileList/ProcessFileListActionsEventListener.php
+    :caption: EXT:my_extension/Classes/FileList/EventListener/MyEventListener.php
 
 API
 ===
 
-.. include:: /CodeSnippets/Events/Filelist/ProcessFileListActionsEvent.rst.txt
+..  include:: /CodeSnippets/Events/Filelist/ProcessFileListActionsEvent.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_MyEventListener.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MyVendor\MyExtension\FileList;
+namespace MyVendor\MyExtension\FileList\EventListener;
 
 use TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent;
 
-final class ModifyEditFileFormDataEventListener
+final class MyEventListener
 {
     public function __invoke(ModifyEditFileFormDataEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_Services.yaml
@@ -1,0 +1,4 @@
+MyVendor\MyExtension\FileList\EventListener\MyEventListener:
+  tags:
+    - name: event.listener
+      identifier: 'my-extension/modify-edit-file-form-data'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_MyEventListener.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace MyVendor\MyExtension\FileList;
+namespace MyVendor\MyExtension\FileList\EventListener;
 
 use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
 
-final class ProcessFileListActionsEventListener
+final class MyEventListener
 {
     public function __invoke(ProcessFileListActionsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_Services.yaml
@@ -1,0 +1,4 @@
+MyVendor\MyExtension\FileList\EventListener\MyEventListener:
+  tags:
+    - name: event.listener
+      identifier: 'my-extension/process-file-list'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEvent.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ModifyEditFileFormDataEvent.yaml
@@ -1,4 +1,0 @@
-MyVendor\MyExtension\FileList\ModifyEditFileFormDataEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-edit-file-form-data-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEvent.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_Snippets/_ProcessFileListActionsEvent.yaml
@@ -1,4 +1,0 @@
-MyVendor\MyExtension\FileList\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/filelist/my-event-listener'


### PR DESCRIPTION
This section was one of the first where the snippets were moved to separate files. The structure is not in-line with the other sections, so this is streamlined now.

Releases: main, 12.4