### PR TITLE
[TASK] Update typo3/coding-standards to 0.7.1

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Backend;
 
 use TYPO3\CMS\Core\Context\Context;

--- a/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Backend\Form;
 
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;

--- a/Documentation/ApiOverview/FormEngine/Rendering/_SomeContainerJavaScript.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_SomeContainerJavaScript.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Backend;
 
 use TYPO3\CMS\Backend\Form\Container\AbstractContainer;

--- a/Documentation/ApiOverview/FormEngine/Rendering/_SomeController.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_SomeController.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Backend\Controller;
 
 use Psr\Http\Message\ResponseInterface;

--- a/Documentation/Configuration/Yaml/_ExamplePlaceholderProcessor.php
+++ b/Documentation/Configuration/Yaml/_ExamplePlaceholderProcessor.php
@@ -10,7 +10,7 @@ final class ExamplePlaceholderProcessor implements PlaceholderProcessorInterface
 {
     public function canProcess(string $placeholder, array $referenceArray): bool
     {
-        return strpos($placeholder, '%example(') !== false;
+        return str_contains($placeholder, '%example(');
     }
 
     public function process(string $value, array $referenceArray)

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Cascade.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Cascade.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Controller;
 
 use Psr\Http\Message\ResponseInterface;

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Lazy.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Lazy.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation\ORM\Lazy;

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Multiple.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Multiple.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation\ORM\Cascade;

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Transient.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Transient.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation\ORM\Transient;

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Validate.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Validate.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 namespace T3docs\BlogExample\Domain\Model;
 
 use TYPO3\CMS\Extbase\Annotation\Validate;

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "typo3/cms-tstemplate": "dev-main as 12.1",
         "typo3/cms-viewpage": "dev-main as 12.1",
         "typo3/cms-workspaces": "dev-main as 12.1",
-        "typo3/coding-standards": "^0.5.5"
+        "typo3/coding-standards": "^0.7.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
This avoids deprecations when running the checker, such as:

- Rule "braces" is deprecated. Use "single_space_around_construct", "control_structure_braces", "curly_braces_position", "control_structure_continuation_position", "declare_parentheses", "statement_indentation", "no_multiple_statements_per_line" and "no_extra_blank_lines" instead.
- Rule "no_trailing_comma_in_singleline_array" is deprecated. Use "no_trailing_comma_in_singleline" instead.

Releases: main, 12.4