### PR TITLE
[BUGFIX] Use correct array key in redis example configuration

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
@@ -554,7 +554,7 @@ caches.
        ];
        if (isset($values['defaultLifetime'])) {
               $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['defaultLifetime']
-                  = $values['lifetime'];
+                  = $values['defaultLifetime'];
        }
        if (isset($values['compression'])) {
               $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][$name]['options']['compression']


### PR DESCRIPTION
The example configuration for redis uses a wrong array key for the lifetime. 

$values['defaultLifetime'] should be used instead of $values['lifetime']