### PR TITLE
[BUGFIX] Corrected IgnoreValidation attribute declaration

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 final class BlogController extends ActionController
 {
-    #[IgnoreValidation('newBlog')]
+    #[IgnoreValidation(['argumentName' => 'newBlog'])]
     public function newAction(?Blog $newBlog = null): ResponseInterface
     {
         // Do something


### PR DESCRIPTION
Fixed the declaration of the IgnoreValidation attribute in TYPO3 to ensure proper functionality. The previous implementation had an incorrect specification that caused validation errors. This bugfix commit addresses the issue by rectifying the attribute declaration.