### PR TITLE
Updates the numeric indices of the Select example (#3038)

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -186,16 +186,16 @@ Select field
             <renderType>selectSingle</renderType>
             <items>
                 <numIndex index="0">
-                    <numIndex index="0">
+                    <numIndex index="label">
                         LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.crdate
                     </numIndex>
-                    <numIndex index="1">crdate</numIndex>
+                    <numIndex index="value">crdate</numIndex>
                 </numIndex>
                 <numIndex index="1">
-                    <numIndex index="0">
+                    <numIndex index="label">
                         LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.title
                     </numIndex>
-                    <numIndex index="1">title</numIndex>
+                    <numIndex index="value">title</numIndex>
                 </numIndex>
             </items>
         </config>


### PR DESCRIPTION
When using the event listener, numeric indices are ignored and the select list is not rendered correctly. Since the numerical indices have also been deprecated in the TCA since 12.3, I have also adjusted this at this point.