### PR TITLE
[TASK] Enhance service configuration examples in PSR-14 event

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -464,6 +464,8 @@ to instantiate services. This is useful for factory-like services where the exac
 Configuration
 =============
 
+..  _dependency-injection-in-extensions:
+
 Configure dependency injection in extensions
 --------------------------------------------
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
@@ -28,6 +28,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterBackendPageRenderEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterPagePreviewUriGeneratedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
@@ -30,6 +30,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterPageTreeItemsPreparedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
@@ -24,6 +24,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterRecordSummaryForLocalizationEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
@@ -20,6 +20,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforeModuleCreationEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
@@ -34,6 +34,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforePagePreviewUriGeneratedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforeSearchInDatabaseRecordProviderEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
@@ -23,6 +23,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _IsFileSelectableEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
@@ -33,6 +33,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyAllowedItemsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyClearCacheActionsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyDatabaseQueryForRecordListingEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
@@ -31,6 +31,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyEditFormUserAccessEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
@@ -29,6 +29,8 @@ Registration of an event listener in your extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyGenericBackendMessagesEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
@@ -36,6 +36,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyImageManipulationPreviewUrlEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
@@ -27,6 +27,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyInlineElementControlsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
@@ -46,6 +46,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyLinkExplanationEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
@@ -31,6 +31,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyLinkHandlersEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyNewContentElementWizardItemsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -27,6 +27,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyPageLayoutContentEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyQueryForLiveSearchEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
@@ -34,6 +34,8 @@ An example registration of the events in your extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyRecordListTableActionsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyResultItemInLiveSearchEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _PageContentPreviewRenderingEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterBackendPageRenderEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterBackendPageRenderEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/after-backend-page-render'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/after-backend-page-render'

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterPagePreviewUriGeneratedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterPagePreviewUriGeneratedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-preview-uri'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-preview-uri'

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-page-tree-items'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-page-tree-items'

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterRecordSummaryForLocalizationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterRecordSummaryForLocalizationEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/after-record-summary-for-localization'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/after-record-summary-for-localization'

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforeModuleCreationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforeModuleCreationEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-module-icon'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-module-icon'

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-parameters'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-parameters'

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforeSearchInDatabaseRecordProviderEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforeSearchInDatabaseRecordProviderEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/before-search-in-database-record-provider-event-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/before-search-in-database-record-provider-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Backend/_IsFileSelectableEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_IsFileSelectableEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-file-is-selectable'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-file-is-selectable'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyAllowedItemsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyAllowedItemsEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/allowed-items'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/allowed-items'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/toolbar/my-event-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/toolbar/my-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForRecordListingEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForRecordListingEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-database-query-for-record-list'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-database-query-for-record-list'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyEditFormUserAccessEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyEditFormUserAccessEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-edit-form-user-access'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-edit-form-user-access'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyGenericBackendMessagesEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyGenericBackendMessagesEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/add-message'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/add-message'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyImageManipulationPreviewUrlEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyImageManipulationPreviewUrlEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-imagemanipulation-previewurl'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-imagemanipulation-previewurl'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_Services.yaml
@@ -1,8 +1,11 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-enabled-controls'
-      method: 'modifyEnabledControls'
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-controls'
-      method: 'modifyControls'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-enabled-controls'
+        method: 'modifyEnabledControls'
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-controls'
+        method: 'modifyControls'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-link-explanation'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-link-explanation'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkHandlersEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkHandlersEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/link-handlers'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/link-handlers'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-wizard-items'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-wizard-items'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/backend/modify-page-module-content'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/backend/modify-page-module-content'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyQueryForLiveSearchEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyQueryForLiveSearchEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-query-for-live-search-event-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/modify-query-for-live-search-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_Services.yaml
@@ -1,11 +1,14 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/recordlist/my-event-listener'
-      method: 'modifyRecordActions'
-    - name: event.listener
-      identifier: 'my-extension/recordlist/my-event-listener'
-      method: 'modifyHeaderColumns'
-    - name: event.listener
-      identifier: 'my-extension/recordlist/my-event-listener'
-      method: 'modifyTableActions'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/recordlist/my-event-listener'
+        method: 'modifyRecordActions'
+      - name: event.listener
+        identifier: 'my-extension/recordlist/my-event-listener'
+        method: 'modifyHeaderColumns'
+      - name: event.listener
+        identifier: 'my-extension/recordlist/my-event-listener'
+        method: 'modifyTableActions'

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/add-live-search-result-actions-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/add-live-search-result-actions-listener'

--- a/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Backend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/preview-rendering-example-ctype'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/preview-rendering-example-ctype'

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedInEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedInEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _AfterUserLoggedInEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeRequestTokenProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeRequestTokenProcessedEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _BeforeRequestTokenProcessedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/LoginAttemptFailedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/LoginAttemptFailedEvent.rst
@@ -24,6 +24,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _LoginAttemptFailedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_AfterUserLoggedInEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_AfterUserLoggedInEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/after-user-logged-in'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/after-user-logged-in'

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/process-request-token-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/process-request-token-listener'

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_LoginAttemptFailedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_LoginAttemptFailedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/login-attempt-failed'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Authentication\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/login-attempt-failed'

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -38,6 +38,8 @@ Registration of the events in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:examples/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  include:: /CodeSnippets/Events/Core/FlexFormParsingModifyEventListener/FlexFormParsingModifyEventListener.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
@@ -40,6 +40,8 @@ Registration of both events in the file :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:bolt/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 Handle the old event in TYPO3 v11 only, but skip old event with TYPO3 v12:
 
 ..  literalinclude:: _ModifyLoadedPageTsConfigEvent/_Loader.php

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationBeforeWriteEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationBeforeWriteEvent.rst
@@ -27,6 +27,8 @@ To register an event listener to the new event, use the following code in your
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
@@ -27,6 +27,8 @@ To register an event listener to the new event, use the following code in your
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_AfterFlexFormDataStructureIdentifierInitializedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_AfterFlexFormDataStructureIdentifierInitializedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   T3docs\Examples\EventListener\Core\Configuration\FlexFormParsingModifyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_ModifyLoadedPageTsConfigEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_ModifyLoadedPageTsConfigEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   B13\Bolt\TsConfig\Loader:
     public: true
     tags:

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationBeforeWriteEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationBeforeWriteEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Configuration\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Configuration\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
@@ -28,6 +28,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _BootCompletedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Core/_BootCompletedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/_BootCompletedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Bootstrap\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/RecordAccessGrantedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/RecordAccessGrantedEvent.rst
@@ -26,6 +26,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _RecordAccessGrantedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/_RecordAccessGrantedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/_RecordAccessGrantedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Domain\Access\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerInitializationEvent.rst
@@ -19,6 +19,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An example listener, which hooks into the Mailer API to modify mailer settings
 to not send any emails ("null mailer"), could look like this:
 

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerSentMessageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerSentMessageEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterMailerSentMessageEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/BeforeMailerSentMessageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/BeforeMailerSentMessageEvent.rst
@@ -28,6 +28,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforeMailerSentMessageEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerInitializationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerInitializationEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Mail\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Mail\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_BeforeMailerSentMessageEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_BeforeMailerSentMessageEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Mail\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
@@ -30,6 +30,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _AfterPackageActivationEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Package\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/EnrichPasswordValidationContextDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/EnrichPasswordValidationContextDataEvent.rst
@@ -38,6 +38,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _EnrichPasswordValidationContextDataEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/_EnrichPasswordValidationContextDataEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/_EnrichPasswordValidationContextDataEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\PasswordPolicy\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/enrich-context-data-event-listener'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\PasswordPolicy\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/enrich-context-data-event-listener'

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterDefaultUploadFolderWasResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterDefaultUploadFolderWasResolvedEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterDefaultUploadFolderWasResolvedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterFileCommandProcessedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterVideoPreviewFetchedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterVideoPreviewFetchedEvent.rst
@@ -23,6 +23,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterVideoPreviewFetchedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
@@ -29,6 +29,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterFileCommandProcessedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterDefaultUploadFolderWasResolvedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterDefaultUploadFolderWasResolvedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Resource\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterFileCommandProcessedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterFileCommandProcessedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Resource\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Resource\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_ModifyFileDumpEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_ModifyFileDumpEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Resource\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/AfterTemplatesHaveBeenDeterminedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/AfterTemplatesHaveBeenDeterminedEvent.rst
@@ -32,6 +32,8 @@ Example
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class could look like this:
 
 ..  literalinclude:: _AfterTemplatesHaveBeenDeterminedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/EvaluateModifierFunctionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/EvaluateModifierFunctionEvent.rst
@@ -34,6 +34,8 @@ an event listener in an extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class could look like this:
 
 ..  literalinclude:: _EvaluateModifierFunctionEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_AfterTemplatesHaveBeenDeterminedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_AfterTemplatesHaveBeenDeterminedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\TypoScript\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_EvaluateModifierFunctionEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_EvaluateModifierFunctionEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\TypoScript\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Extbase/Configuration/BeforeFlexFormConfigurationOverrideEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Configuration/BeforeFlexFormConfigurationOverrideEvent.rst
@@ -24,6 +24,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforeFlexFormConfigurationOverrideEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Extbase/Configuration/_BeforeFlexFormConfigurationOverrideEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Configuration/_BeforeFlexFormConfigurationOverrideEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Extbase\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/before-flexform-configuration-override'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Extbase\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/before-flexform-configuration-override'

--- a/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
@@ -26,6 +26,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyEditFileFormDataEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -25,6 +25,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ProcessFileListActionsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\FileList\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-edit-file-form-data'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\FileList\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/modify-edit-file-form-data'

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\FileList\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/process-file-list'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\FileList\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/process-file-list'

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
@@ -41,6 +41,8 @@ extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterCacheableContentIsGeneratedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
@@ -27,6 +27,8 @@ extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterCachedPageIsPersistedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterLinkIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterLinkIsGeneratedEvent.rst
@@ -43,6 +43,7 @@ Registration of the `AfterLinkIsGeneratedEvent` in your extension's
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
 
 The corresponding event listener class:
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyCacheLifetimeForPageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyCacheLifetimeForPageEvent.rst
@@ -23,6 +23,8 @@ Register the listener:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The following listener limits the cache lifetime to 30 seconds in development
 context:
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
@@ -24,6 +24,8 @@ An example implementation could look like this:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 With :yaml:`after` and :yaml:`before`, you can make sure your own listener is
 executed after or before the given identifiers.
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
@@ -27,6 +27,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyPageLinkConfigurationEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
@@ -26,6 +26,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ShouldUseCachedPageDataIfAvailableEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/content-modifier'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/content-modifier'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterCachedPageIsPersistedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterCachedPageIsPersistedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/content-modifier'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/content-modifier'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/link-modifier'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/link-modifier'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyCacheLifetimeForPageEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyCacheLifetimeForPageEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/cache-timeout'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/cache-timeout'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyHrefLangTagsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyHrefLangTagsEvent/_Services.yaml
@@ -1,5 +1,8 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/cache-timeout'
-      after: 'typo3-seo/hreflangGenerator'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/cache-timeout'
+        after: 'typo3-seo/hreflangGenerator'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyPageLinkConfigurationEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyPageLinkConfigurationEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-page-link-configuration'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/modify-page-link-configuration'

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ShouldUseCachedPageDataIfAvailableEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ShouldUseCachedPageDataIfAvailableEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/avoid-cache-loading'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Frontend\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/avoid-cache-loading'

--- a/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
@@ -44,6 +44,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyInfoModuleContentEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Info\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/content-to-info-module'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Info\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/content-to-info-module'

--- a/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePacksEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePacksEvent.rst
@@ -26,6 +26,8 @@ Registration of the event:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _ModifyLanguagePacksEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePacksEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePacksEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Install\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
@@ -37,6 +37,8 @@ The listener must then be registered in the extensions :php:`Services.yaml`:
     :language: yaml
     :caption: EXT:examples/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 For the implementation we need the
 :php:`\TYPO3\CMS\Linkvalidator\Repository\BrokenLinkRepository` to register
 additional link errors and the

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/ModifyValidatorTaskEmailEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/ModifyValidatorTaskEmailEvent.rst
@@ -37,6 +37,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _ModifyValidatorTaskEmailEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/_BeforeRecordIsAnalyzedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/_BeforeRecordIsAnalyzedEvent/_Services.yaml
@@ -1,12 +1,5 @@
 services:
-  _defaults:
-    autowire: true
-    autoconfigure: true
-    public: false
-
-  T3docs\Examples\:
-    resource: '../Classes/*'
-    exclude: '../Classes/Domain/Model/*'
+  # Place here the default dependency injection configuration
 
   T3docs\Examples\EventListener\LinkValidator\CheckExternalLinksToLocalPagesEventListener:
     tags:

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Linkvalidator\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
@@ -34,6 +34,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 An implementation of the event listener:
 
 ..  literalinclude:: _ModifyBlindedConfigurationOptionsEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Lowlevel/_ModifyBlindedConfigurationOptionsEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Lowlevel/_ModifyBlindedConfigurationOptionsEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Lowlevel\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Redirects/AfterAutoCreateRedirectHasBeenPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/AfterAutoCreateRedirectHasBeenPersistedEvent.rst
@@ -30,6 +30,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterAutoCreateRedirectHasBeenPersistedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/BeforeRedirectMatchDomainEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/BeforeRedirectMatchDomainEvent.rst
@@ -38,6 +38,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _BeforeRedirectMatchDomainEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/ModifyAutoCreateRedirectRecordBeforePersistingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/ModifyAutoCreateRedirectRecordBeforePersistingEvent.rst
@@ -32,6 +32,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/ModifyRedirectManagementControllerViewDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/ModifyRedirectManagementControllerViewDataEvent.rst
@@ -33,6 +33,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/RedirectWasHitEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/RedirectWasHitEvent.rst
@@ -33,6 +33,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _RedirectWasHitEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/SlugRedirectChangeItemCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/SlugRedirectChangeItemCreatedEvent.rst
@@ -51,6 +51,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Redirects/_AfterAutoCreateRedirectHasBeenPersistedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_AfterAutoCreateRedirectHasBeenPersistedEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/after-auto-create-redirect-has-been-persisted'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/after-auto-create-redirect-has-been-persisted'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_BeforeRedirectMatchDomainEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_BeforeRedirectMatchDomainEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/before-redirect-match-domain'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/before-redirect-match-domain'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-auto-create-redirect-record-before-persisting'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/modify-auto-create-redirect-record-before-persisting'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_Services.yaml
@@ -1,4 +1,7 @@
-MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/modify-redirect-management-controller-view-data'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/modify-redirect-management-controller-view-data'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_Services.yaml
@@ -1,5 +1,8 @@
-MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/redirects/validate-hit-count'
-      before: 'redirects-increment-hit-count'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Redirects\EventListener\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/redirects/validate-hit-count'
+        before: 'redirects-increment-hit-count'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_Services.yaml
@@ -1,7 +1,10 @@
-MyVendor\MyExtension\Backend\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/custom-page-type-redirect'
-      # Registering after Core listener is important, otherwise we would
-      # not know if there is a PageType source for page type 0
-      after: 'redirects-add-page-type-zero-source'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/custom-page-type-redirect'
+        # Registering after Core listener is important, otherwise we would
+        # not know if there is a PageType source for page type 0
+        after: 'redirects-add-page-type-zero-source'

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_Services.yaml
@@ -1,5 +1,8 @@
-MyVendor\MyExtension\Backend\MyEventListener:
-  tags:
-    - name: event.listener
-      identifier: 'my-extension/custom-page-type-redirect'
-      after: 'redirects-add-page-type-zero-source'
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\Backend\MyEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/custom-page-type-redirect'
+        after: 'redirects-add-page-type-zero-source'

--- a/Documentation/ApiOverview/Events/Events/Setup/AddJavaScriptModulesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Setup/AddJavaScriptModulesEvent.rst
@@ -21,6 +21,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AddJavaScriptModulesEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Setup/_AddJavaScriptModulesEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Setup/_AddJavaScriptModulesEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\UserSettings\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
@@ -21,6 +21,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _AfterRecordPublishedEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
@@ -42,6 +42,8 @@ Registration of the event listener in the extension's :file:`Services.yaml`:
     :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
 The corresponding event listener class:
 
 ..  literalinclude:: _ModifyVersionDifferencesEvent/_MyEventListener.php

--- a/Documentation/ApiOverview/Events/Events/Workspaces/_AfterRecordPublishedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/_AfterRecordPublishedEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Workspaces\EventListener\MyEventListener:
     tags:
       - name: event.listener

--- a/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_Services.yaml
@@ -1,4 +1,6 @@
 services:
+  # Place here the default dependency injection configuration
+
   MyVendor\MyExtension\Workspaces\EventListener\MyEventListener:
     tags:
       - name: event.listener


### PR DESCRIPTION
To avoid mistakes when not familiar with dependency injection and the configuration of a Services.yaml file, the Services.yaml examples now have a comment to hint the user that the example file is only an excerpt of a Services.yaml file. Furthermore, a link to the according DI section is added for more information.

Releases: main, 12.4