### PR TITLE
[TASK] Add invitation to contribute to event examples

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/AfterFormEnginePageInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterFormEnginePageInitializedEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\AfterFormEnginePageIn
 is available to listen for after the :ref:`form engine <FormEngine>` has been
 initialized (all data has been persisted).
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterHistoryRollbackFinishedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterHistoryRollbackFinishedEvent.rst
@@ -9,6 +9,11 @@ AfterHistoryRollbackFinishedEvent
 The PSR-14 event :php:`\TYPO3\CMS\Backend\History\Event\AfterHistoryRollbackFinishedEvent`
 is fired after a history record rollback finished.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageColumnsSelectedForLocalizationEvent.rst
@@ -31,6 +31,10 @@ gets displayed in the translation modal when a user has clicked the
 :guilabel:`Translate` button in the page module, by implementing a listener for
 the event.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeFormEnginePageInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeFormEnginePageInitializedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 allows to listen for before the :ref:`form engine <FormEngine>` has been
 initialized (before all data will be persisted).
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeHistoryRollbackStartEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeHistoryRollbackStartEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Backend\History\Event\BeforeHistoryRollbackStartEvent`
 is fired before a history record rollback starts.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/CustomFileControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/CustomFileControlsEvent.rst
@@ -22,6 +22,11 @@ independent of the :php:`readonly` and :php:`showFileSelectors` options.
 This means, you have full control in which scenario your custom controls
 are being displayed.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -15,6 +15,11 @@ IsContentUsedOnPageLayoutEvent
 Use the PSR-14 event :php:`\TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent`
 to identify if content has been used in a column that is not in a backend layout.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
@@ -15,6 +15,11 @@ Use the PSR-14 event :php:`\TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForC
 to filter out certain content elements from being shown in the
 :guilabel:`Page` module.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceControlsEvent.rst
@@ -15,6 +15,11 @@ are able to modify the controls of a single file reference of a TCA type
 :ref:`ModifyInlineElementControlsEvent`, which is only available for TCA
 type :ref:`inline <columns-inline>`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceEnabledControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyFileReferenceEnabledControlsEvent.rst
@@ -15,6 +15,11 @@ file reference of a TCA type :ref:`file <columns-file>` field. This
 event is similar to the :ref:`ModifyInlineElementEnabledControlsEvent`, which
 is only available for TCA type :ref:`inline <columns-inline>`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementEnabledControlsEvent.rst
@@ -20,6 +20,11 @@ See the
 :ref:`ModifyInlineElementControlsEvent example <ModifyInlineElementControlsEvent_example>`
 for details.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutOnLoginProviderSelectionEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 allows to modify variables for the view depending on a special login provider
 set in the controller.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/RenderAdditionalContentToRecordListEvent.rst
@@ -29,6 +29,10 @@ The PSR-14 event
 allows to add content before or after the main content of the :guilabel:`List`
 module.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SwitchUserEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Backend\Authentication\Event\SwitchUserEvent`
 is dispatched when a "SU" (switch user) action has been triggered.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/SystemInformationToolbarCollectorEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 allows to enrich the system information toolbar in the TYPO3 backend top toolbar
 with various information.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterGroupsResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterGroupsResolvedEvent.rst
@@ -18,6 +18,10 @@ particular user logs in or is seated at a special location.
     This event acts as a substitution for the removed TYPO3 hook
     :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauthgroup.php']['fetchGroups_postProcessing']`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedOutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedOutEvent.rst
@@ -14,6 +14,11 @@ The purpose of the PSR-14 event
 :php:`\TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedOutEvent`
 is to trigger any kind of action when a user has been successfully logged out.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeUserLogoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeUserLogoutEvent.rst
@@ -18,6 +18,11 @@ The event has the possibility to bypass the regular logout process by TYPO3
 (removing the cookie and the user session) by calling
 :php:`$event->disableRegularLogoutProcess()` in an event listener.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureParsedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureParsedEvent.rst
@@ -24,6 +24,11 @@ object-oriented approach.
     *   :ref:`BeforeFlexFormDataStructureParsedEvent`
     *   :ref:`combined example <AfterFlexFormDataStructureIdentifierInitializedEvent-Example>`
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterTcaCompilationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterTcaCompilationEvent.rst
@@ -15,6 +15,11 @@ the :ref:`TCA <t3tca:start>`.
     It is possible to check against the original TCA as this is stored within
     :php:`$GLOBALS['TCA']` before this event is fired.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -24,6 +24,10 @@ object-oriented approach.
     *   :ref:`BeforeFlexFormDataStructureParsedEvent`
     *   :ref:`combined Example <AfterFlexFormDataStructureIdentifierInitializedEvent-Example>`
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureParsedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureParsedEvent.rst
@@ -24,6 +24,11 @@ object-oriented approach.
     *   :ref:`BeforeFlexFormDataStructureIdentifierInitializedEvent`
     *   :ref:`combined Example <AfterFlexFormDataStructureIdentifierInitializedEvent-Example>`
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
@@ -17,6 +17,11 @@ entries that can be overridden or added, based on the root line.
     and the new event, and TYPO3 v13 will stop calling the old event.
     See also :ref:`ModifyLoadedPageTsConfigEventv11v12`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/DataHandling/AppendLinkHandlerElementsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/DataHandling/AppendLinkHandlerElementsEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired so listeners can intercept and add elements when checking
 links within the :ref:`soft reference <soft-references>` parser.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/DataHandling/IsTableExcludedFromReferenceIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/DataHandling/IsTableExcludedFromReferenceIndexEvent.rst
@@ -13,6 +13,11 @@ allows to intercept, if a certain table should be excluded from the
 There is no need to add tables without a definition in :php:`$GLOBALS['TCA']`
 since the reference index only handles those.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Database/AlterTableDefinitionStatementsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Database/AlterTableDefinitionStatementsEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 allows to intercept the :sql:`CREATE TABLE` statement from all loaded
 extensions.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/AfterRecordLanguageOverlayEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/AfterRecordLanguageOverlayEvent.rst
@@ -14,6 +14,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Core\Domain\Event\AfterRecordLanguageOverlayEv
 can be used to modify the actual translated record (if found) to add additional
 information or perform custom processing of the record.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/BeforePageLanguageOverlayEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/BeforePageLanguageOverlayEvent.rst
@@ -16,6 +16,11 @@ of one or multiple pages, which could be one full record or multiple page IDs.
 This event is fired only for pages and in-between the events
 :ref:`BeforeRecordLanguageOverlayEvent` and :ref:`AfterRecordLanguageOverlayEvent`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/BeforeRecordLanguageOverlayEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/BeforeRecordLanguageOverlayEvent.rst
@@ -15,6 +15,11 @@ can be used to modify information (such as the
 :ref:`LanguageAspect <context_api_aspects_language>` or the actual incoming
 record from the database) before the database is queried.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Mvc/AfterRequestDispatchedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Mvc/AfterRequestDispatchedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Extbase\Event\Mvc\AfterRequestDispatchedEvent`
 is fired after the dispatcher has successfully dispatched a request to a
 controller action.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Mvc/BeforeActionCallEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Mvc/BeforeActionCallEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Extbase\Event\Mvc\BeforeActionCallEvent` is
 triggered before any Extbase action is called within the :php:`ActionController`
 or one of its subclasses.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/AfterObjectThawedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/AfterObjectThawedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 allows to modify values when
 :ref:`creating domain objects <extbase-model-hydrating>`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityAddedToPersistenceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityAddedToPersistenceEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is dispatched after persisting the object, but before updating the reference
 index and adding the object to the persistence session.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityPersistedEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Extbase\Event\Persistence\EntityPersistedEvent`
 is fired after an object was pushed to the storage backend.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityRemovedFromPersistenceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityRemovedFromPersistenceEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Extbase\Event\Persistence\EntityRemovedFromPersistenceEvent`
 is fired after an object/entity was sent to the persistence layer to be removed.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityUpdatedInPersistenceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/EntityUpdatedInPersistenceEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Extbase\Event\Persistence\EntityUpdatedInPersistenceEvent`
 is fired after an object/entity was persisted on update.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyQueryBeforeFetchingObjectDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyQueryBeforeFetchingObjectDataEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Extbase\Event\Persistence\ModifyQueryBeforeFetchingObjectDataEvent`
 is fired before the storage backend is asked for results from a given query.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyResultAfterFetchingObjectDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyResultAfterFetchingObjectDataEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Extbase\Event\Persistence\ModifyResultAfterFetchingObjectDataEvent`
 is fired after the storage backend has pulled results from a given query.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionDatabaseContentHasImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionDatabaseContentHasImportedEvent.rst
@@ -14,6 +14,11 @@ AfterExtensionDatabaseContentHasBeenImportedEvent
 Event that is triggered after a package has imported the database file shipped
 within a t3d/xml import file.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionFilesHaveBeenImportedEvent.rst
@@ -14,6 +14,11 @@ AfterExtensionFilesHaveBeenImportedEvent
 Event that is triggered after a package has imported all extension files
 (from :file:`Initialisation/Files/`).
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionStaticDatabaseContentHasBeenImportedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AfterExtensionStaticDatabaseContentHasBeenImportedEvent.rst
@@ -14,6 +14,11 @@ AfterExtensionStaticDatabaseContentHasBeenImportedEvent
 Event that is triggered after a package has imported the database file shipped
 within :file:`ext_tables_static+adt.sql`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
@@ -13,6 +13,11 @@ AvailableActionsForExtensionEvent
 Event that is triggered when rendering an additional action (currently within
 a Fluid ViewHelper) in the extension manager.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterPageAndLanguageIsResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterPageAndLanguageIsResolvedEvent.rst
@@ -28,6 +28,11 @@ listeners (e.g. a custom 403 response).
     *   :ref:`AfterPageWithRootLineIsResolvedEvent`
     *   AfterPageAndLanguageIsResolvedEvent
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterPageWithRootLineIsResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterPageWithRootLineIsResolvedEvent.rst
@@ -28,6 +28,11 @@ page response if additional permissions should be checked.
     *   AfterPageWithRootLineIsResolvedEvent
     *   :ref:`AfterPageAndLanguageIsResolvedEvent`
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/BeforePageIsResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/BeforePageIsResolvedEvent.rst
@@ -28,6 +28,11 @@ parameters (such as :php:`$controller->id`) or the context for resolving a page.
     *   :ref:`AfterPageWithRootLineIsResolvedEvent`
     *   :ref:`AfterPageAndLanguageIsResolvedEvent`
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/FilterMenuItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/FilterMenuItemsEvent.rst
@@ -27,6 +27,10 @@ order is possible.
 Additionally, more information about the currently rendered menu, such as
 the menu items which were filtered out, is available.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyResolvedFrontendGroupsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyResolvedFrontendGroupsEvent.rst
@@ -14,6 +14,10 @@ The PSR-14 event :php:`\TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontend
 event allows frontend groups to be added to a (frontend) request, regardless of
 whether a user is logged in or not.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/BeforeRedirectEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/BeforeRedirectEvent.rst
@@ -13,6 +13,11 @@ triggered before a redirect is made.
 ..  versionadded:: 11.5.26/12.3
     The methods :php:`setRedirectUrl()` and :php:`getRequest()` are available.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/LoginConfirmedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/LoginConfirmedEvent.rst
@@ -10,6 +10,10 @@ LoginConfirmedEvent
 The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\LoginConfirmedEvent` is
 triggered when a login was successful.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/LoginErrorOccurredEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/LoginErrorOccurredEvent.rst
@@ -10,6 +10,10 @@ LoginErrorOccurredEvent
 The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\LoginErrorOccurredEvent`
 is triggered when an error occurs while trying to log in a user.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/LogoutConfirmedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/LogoutConfirmedEvent.rst
@@ -10,6 +10,10 @@ LogoutConfirmedEvent
 The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\LogoutConfirmedEvent` is
 triggered when a logout was successful.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/ModifyLoginFormViewEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/ModifyLoginFormViewEvent.rst
@@ -15,6 +15,10 @@ allows to inject custom variables into the login form.
     removed with v12. The :php:`getView()` method signature has been changed
     to :php:`TYPO3Fluid\Fluid\View\ViewInterface` with the v12 release.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
@@ -27,6 +27,11 @@ stored in the database shortly.
     A :ref:`custom password policy validator<password-policies-custom-validator>`
     should be used to validate user passwords.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/SendRecoveryEmailEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/SendRecoveryEmailEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\SendRecoveryEmailEvent`
 contains the email to be sent and additional information about the user who
 requested a new password.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Impexp/BeforeImportEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Impexp/BeforeImportEvent.rst
@@ -10,6 +10,11 @@ BeforeImportEvent
 The PSR-14 event :php:`\TYPO3\CMS\Impexp\Event\BeforeImportEvent` is triggered
 when an import file is about to be imported.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePackRemoteBaseUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePackRemoteBaseUrlEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent`
 allows to modify the main URL of a language pack.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/SEO/ModifyUrlForCanonicalTagEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/SEO/ModifyUrlForCanonicalTagEvent.rst
@@ -11,6 +11,11 @@ With the PSR-14 event `\TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent`
 the URL for the :html:`href` attribute of the canonical tag can be altered or
 emptied.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterCompiledCacheableDataForWorkspaceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterCompiledCacheableDataForWorkspaceEvent.rst
@@ -12,6 +12,11 @@ The PSR-14 event
 is used in the :guilabel:`Web > Workspaces` module to find all cacheable data of
 versions of a workspace.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterDataGeneratedForWorkspaceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterDataGeneratedForWorkspaceEvent.rst
@@ -12,6 +12,11 @@ The PSR-14 event
 is used in the :guilabel:`Web > Workspaces` module to find all data of versions
 of a workspace.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
@@ -15,6 +15,11 @@ fired after a record has been published in a workspace.
 Example
 =======
 
+..  include:: /_includes/EventsContributeNote.rst.txt
+
+Example
+=======
+
 Registration of the event listener in the extension's :file:`Services.yaml`:
 
 ..  literalinclude:: _AfterRecordPublishedEvent/_Services.yaml

--- a/Documentation/ApiOverview/Events/Events/Workspaces/GetVersionedDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/GetVersionedDataEvent.rst
@@ -13,6 +13,11 @@ of a workspace. In comparison to :ref:`AfterDataGeneratedForWorkspaceEvent`,
 this one contains the cleaned / prepared data with an optional limit applied
 depending on the view.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Workspaces/SortVersionedDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/SortVersionedDataEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Workspaces\Event\SortVersionedDataEvent` is
 used in the :guilabel:`Web > Workspaces` module after sorting all data for
 versions of a workspace.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/_includes/EventsContributeNote.rst.txt
+++ b/Documentation/_includes/EventsContributeNote.rst.txt
@@ -1,0 +1,6 @@
+..  note::
+    Currently, we do not have an example for this event. If you can provide a
+    useful one, please open `an issue`_ with your code snippets or
+    :ref:`a pull request <h2document:docs-contribute-git-docker>`.
+
+..  _an issue: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/new


### PR DESCRIPTION
We have some PSR-14 events that are missing a useful example. To fill these gaps, a call for participation will be added as a note to these events.

Releases: main, 12.4