### PR TITLE
[BUGFIX] Make JavaScript example for backdrop lint

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_static_backdrop.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_static_backdrop.js
@@ -1,4 +1,4 @@
-import {default as Modal} from './modal';
+import Modal from '@typo3/backend/modal';
 
 Modal.advanced({
   title: 'Hello',


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/485
Releases: main, 12.4