### PR TITLE
[DOCS] Update Backend controller actions Code Example

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -482,10 +482,9 @@ Add the Ajax controller class in
    {
       /**
       * @param ServerRequestInterface $request
-      * @param ResponseInterface $response
       * @return ResponseInterface
       */
-      public function importDataAction(ServerRequestInterface $request, ResponseInterface $response)
+      public function importDataAction(ServerRequestInterface $request): ResponseInterface
       {
          $queryParameters = $request->getParsedBody();
          $id = (int)$queryParameters['id'];
@@ -499,7 +498,6 @@ Add the Ajax controller class in
          // trigger data import (simplified as example)
          $output = shell_exec('.' . DIRECTORY_SEPARATOR . 'import.sh' . $param);
 
-         $response->getBody()->write(json_encode(['success' => true, 'output' => $output]));
-         return $response;
+         return new JsonResponse(['success' => true, 'output' => $output]);
       }
    }

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -477,6 +477,7 @@ Add the Ajax controller class in
 
    use Psr\Http\Message\ResponseInterface;
    use Psr\Http\Message\ServerRequestInterface;
+   use TYPO3\CMS\Core\Http\JsonResponse;
 
    class ImportDataController
    {
@@ -490,8 +491,7 @@ Add the Ajax controller class in
          $id = (int)$queryParameters['id'];
 
          if (empty($id)) {
-            $response->getBody()->write(json_encode(['success' => false]));
-            return $response;
+            return new JsonResponse(['success' => false]);
          }
          $param = ' -id=' . $id;
 


### PR DESCRIPTION
since this Change https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Deprecation-84196-BackendControllerActionsDoNotReceivePreparedResponse.html the Action doesn't get a prepared response Object The example would lead to an ArgumentCountError Too few arguments to function ...