### PR TITLE
[TASK] #100925 - Use dedicated cache for database schema information

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
@@ -215,6 +215,13 @@ The following caches exist in the TYPO3 Core:
   - Cache for TypoScript.
   - **group**: pages
 
+- `database_schema`
+
+  .. versionadded:: 12.4.2
+
+  - Cache for database schema information.
+  - **group**: system
+
 - `dashboard_rss`
 
   - Contains the contents of RSS feeds retrieved by RSS widgets on the dashboard.


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/486
Releases: main, 12.4