### PR TITLE
[TASK] Adjust ModifyVersionDifferencesEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
@@ -18,20 +18,6 @@ can be used to modify the version differences data, used for the display in the
 with the :php:`getVersionDifferences()` method and updated using the
 :php:`setVersionDifferences(array $versionDifferences)` method.
 
-The version differences :php:`array` contains the differences of each field,
-with the following keys:
-
-*   :php:`field`: The corresponding field name
-*   :php:`label`: The corresponding field label
-*   :php:`content`: The field values difference
-
-In addition, the event provides the following methods:
-
-*   :php:`getLiveRecordData()`: Returns the records live data (used to create
-    the version difference)
-*   :php:`getParameters()`: Returns meta information like current stage and
-    current workspace
-
 
 Example
 =======

--- a/Documentation/CodeSnippets/Events/Workspaces/ModifyVersionDifferencesEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/Workspaces/ModifyVersionDifferencesEvent.rst.txt
@@ -8,16 +8,32 @@
    
    .. php:method:: getVersionDifferences()
    
+      Get the version differences.
+      
+      This array contains the differences of each field with the following keys:
+      
+      - field: The corresponding field name
+      - label: The corresponding field label
+      - content: The field values difference
+      
       :returntype: array
+      :returns: string, label: string, content: string}>
       
    .. php:method:: setVersionDifferences(array $versionDifferences)
    
+      Modifies the version differences data
+      
       :param array $versionDifferences: the versionDifferences
       
    .. php:method:: getLiveRecordData()
    
+      Returns the records live data (used to create the version difference)
+      
       :returntype: array
+      :returns: string, label: string, content: string}>
       
    .. php:method:: getParameters()
    
+      Returns meta information like current stage and current workspace
+      
       :returntype: stdClass


### PR DESCRIPTION
With the change https://review.typo3.org/c/Packages/TYPO3.CMS/+/79163 the docblocks of the event class hold information of the different methods. Therefore, the given text in the event can be removed as duplicate.

Releases: main, 12.4