### PR TITLE
[TASK] Remove Wincache cache backend

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/FrontendsBackends/Index.rst
@@ -734,13 +734,6 @@ allkeys-lru, allkeys-lfu, allkeys-random
    *  `Redis eviction policies <https://redis.io/docs/manual/eviction/>`__
    *  `Redis configuration <https://redis.io/docs/manual/config/>`__
 
-.. _caching-backend-wincache:
-
-Wincache Backend
-================
-
-`Wincache <https://www.iis.net/downloads/microsoft/wincache-extension>`_ is a PHP opcode cache similar to APC, but
-dedicated to the Windows OS platform. Similar to APC, the cache can also be used as in-memory key/value cache.
 
 .. _caching-backend-file:
 


### PR DESCRIPTION
It was deprecated in TYPO3 v11.4:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94665-WincacheCacheBackend.html

In v12 the WincacheBackend class is not available anymore. Therefore, it is removed from the docs.

Releases: main, 12.4