### PR TITLE
[TASK] #101032 - Remove deprecated constant TYPO3_mainDir

### DIFF
--- a/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
+++ b/Documentation/ApiOverview/GlobalValues/Constants/Index.rst
@@ -23,32 +23,6 @@ for more constants.
 Paths
 =====
 
-
-.. index::
-   Paths; TYPO3_mainDir
-   Constants; TYPO3_mainDir
-
-TYPO3_mainDir
--------------
-
-..  deprecated:: 12.0
-    Accessing the constant will stop working in TYPO3 v13.
-
-    It is recommended to use the
-    :php:`TYPO3\CMS\Core\Routing\BackendEntryPointResolver`
-    class when needing to direct to the TYPO3 Backend.
-
-This is the directory of the backend administration for the sites of
-this TYPO3 installation. Hardcoded to :code:`typo3/`. Must be a subdirectory
-to the website.
-
-Defined in:
-   :php:`SystemEnvironmentBuilder::defineBaseConstants()`
-
-Available in Frontend:
-   Yes
-
-
 .. index:: pair: Constants; Security
 
 Security related constant


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/519
Releases: main