### PR TITLE
[BUGFIX] Update backend controller actions code example (#3070)

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Rendering/_ImportDataController.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_ImportDataController.php
@@ -6,29 +6,23 @@ namespace MyVendor\MyExtension\Controller\Ajax;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\JsonResponse;
 
 final class ImportDataController
 {
-    /**
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface $response
-     * @return ResponseInterface
-     */
-    public function importDataAction(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    public function importDataAction(ServerRequestInterface $request): ResponseInterface
     {
         $queryParameters = $request->getParsedBody();
         $id = (int)($queryParameters['id'] ?? 0);
 
         if ($id === 0) {
-            $response->getBody()->write(json_encode(['success' => false]));
-            return $response;
+            return new JsonResponse(['success' => false]);
         }
         $param = ' -id=' . $id;
 
         // trigger data import (simplified as example)
         $output = shell_exec('.' . DIRECTORY_SEPARATOR . 'import.sh' . $param);
 
-        $response->getBody()->write(json_encode(['success' => true, 'output' => $output]));
-        return $response;
+        return new JsonResponse(['success' => true, 'output' => $output]);
     }
 }


### PR DESCRIPTION
Since this Change https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.5/Deprecation-84196-BackendControllerActionsDoNotReceivePreparedResponse.html the Action doesn't get a prepared response Object The example would lead to an "ArgumentCountError Too few arguments to function ..."

Releases: main, 12.4