### PR TITLE
[TASK] #101065 - Remove obsolete method QueryBuilder->execute()

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -948,20 +948,16 @@ Remarks:
 
 ..  _database-query-builder-execute:
 
-execute(), executeQuery() and executeStatement()
-================================================
+executeQuery() and executeStatement()
+=====================================
 
 ..  versionchanged:: 11.5
     The widely used :php:`->execute()` method has been split into
     :php:`executeQuery()` and :php:`executeStatement()`. :php:`executeQuery()`
     returns a :php:`\Doctrine\DBAL\Result` instead of a
     :php:`\Doctrine\DBAL\Statement`. :php:`executeStatement()` returns the
-    number of affected rows.
-
-    Although :php:`->execute()` still works for backwards compatibility, you
-    should prefer to use :php:`->executeQuery()` for :sql:`SELECT` and
-    :sql:`COUNT` statements and :php:`->executeStatement()` for :sql:`INSERT`,
-    :sql:`UPDATE` and :sql:`DELETE` queries.
+    number of affected rows. The :php:`->execute()` method has been removed with
+    TYPO3 v13.0.
 
 ..  _database-query-builder-execute-query:
 

--- a/Documentation/ApiOverview/Database/Statement/Index.rst
+++ b/Documentation/ApiOverview/Database/Statement/Index.rst
@@ -20,10 +20,6 @@ with :ref:`->fetchAssociative() <database-result-fetch-associative>` or to fetch
 all rows as an array with :ref:`->fetchAllAssociative()
 <database-result-fetch-all-associative>`.
 
-Unlike :php:`\Doctrine\DBAL\Statement` returned formerly by :ref:`->execute()
-<database-query-builder-execute>`, a single prepared statement with different
-values cannot be executed multiple times.
-
 ..  warning::
     The return type of single field values is **not** type safe! If you select a
     value from a field that is defined as :sql:`INT`, the :php:`Result` result


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/542
Releases: main