### PR TITLE
[TASK] Remove references to ExtensionUtility::registerModule()

### DIFF
--- a/Documentation/ExtensionArchitecture/BestPractises/NamingConventions.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/NamingConventions.rst
@@ -52,8 +52,10 @@ ExtensionName
 
     Example: for an extkey `bootstrap_package` the ExtensionName would be `BootstrapPackage`.
 
-    The ExtensionName is used as first parameter in the Extbase methods
-    :php:`ExtensionUtility::configurePlugin()` or :php:`ExtensionUtility::registerModule()`.
+    The ExtensionName is used as first parameter in the Extbase method
+    :php:`ExtensionUtility::configurePlugin()` and as value for the
+    :php:`extensionName` key when
+    :ref:`registering a backend module <backend-modules-configuration>`.
 
 modkey
     The backend module key.

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendGUI.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendGUI.rst
@@ -29,13 +29,12 @@ Module menu
 
   The module menu can be opened or closed by using the icon on the top left.
 
-  New main or submodules are registered using the
-  :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule()`
-  API.
+  The chapter :ref:`backend-modules-configuration` describes how new
+  main or submodules are registered.
 
   .. note::
 
-     In the TYPO3 CMS world, "module" is typically used for
+     In the TYPO3 world, "module" is typically used for
      the backend. Extension components which add features in the frontend
      are referred to as "plugins".
 


### PR DESCRIPTION
This method was deprecated in v12 and since then the new backend module registration via Modules.php is in place.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/565
Releases: main, 12.4