### PR TITLE
[TASK] Add note for security.backend.enforceContentSecurityPolicy

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -860,6 +860,9 @@ security.backend.enforceContentSecurityPolicy
     If enabled, the :ref:`Content Security Policy <content-security-policy>`
     is applied in backend scope.
 
+    ..  note::
+        With TYPO3 v13.0 this feature setting is always enabled.
+
 ..  index::
     TYPO3_CONF_VARS SYS; features security.frontend.enforceContentSecurityPolicy
 ..  _typo3ConfVars_sys_features_security.frontend.enforceContentSecurityPolicy:


### PR DESCRIPTION
This feature setting is always enabled with TYPO3 v13. To hint the integrator early a note is added.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/564
Releases: 12.4