### PR TITLE
[TASK] #101007 - Remove deprecated TBE_MODULES related functionality

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -24,27 +24,6 @@ The :php:`$GLOBALS['BE_USER']` object is mostly used to check user access right,
 but contains other helpful information. This is presented here by a few examples:
 
 
-.. _be-user-access-current:
-
-Checking access to current backend module
-=========================================
-
-..  deprecated:: 12.0
-    The method :php:`->modAccess()` of the backend user object is deprecated.
-    Use :php:`ModuleProvider->accessGranted()` from the
-    :ref:`backend-module-provider-api` instead.
-
-:php:`$MCONF` is module configuration and the key :php:`$MCONF['access']` determines
-the access scope for the module. This function call will check if the
-:php:`$GLOBALS['BE_USER']` is allowed to access the module and if not, the function
-will exit with an error message.
-
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/Controller/SomeModuleController.php
-
-   $GLOBALS['BE_USER']->modAccess($MCONF);
-
-
 .. _be-user-access-any:
 
 Checking access to any backend module

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -9,11 +9,6 @@
 $GLOBALS
 ========
 
-.. versionchanged:: 12.0
-   The global variable :php:`$GLOBALS['TBE_MODULES']` was removed. Setting it
-   has no effect anymore. Use the
-   :ref:`ModuleProvider <backend-modules-api>` instead.
-
 .. confval:: TYPO3_CONF_VARS
 
    :Path: $GLOBALS

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ThirdlevelModules.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ThirdlevelModules.rst
@@ -9,14 +9,6 @@
 Third-level modules / module functions
 ======================================
 
-.. versionchanged:: 12.0
-   Previously, module functions could be added to modules such as
-   :guilabel:`Web > Info` or :guilabel:`Web > Template` via the
-   now removed global :php:`TBE_MODULES_EXT` array.
-
-   These are now registered as third-level modules with the
-   backend module configuration API.
-
 Third-level modules are registered in the
 extension's :file:`Configuration/Backend/Modules.php` file, the
 same way as :ref:`top-level <backend-modules-toplevel-module>`


### PR DESCRIPTION
The section about checking access in current backend module was removed completely from the BackendUserObject chapter as the check is moved to the ModuleProvider API.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/499
Releases: main