### PR TITLE
[TASK] #101096 - Remove deprecated code in PasswordChangeEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/PasswordChangeEvent.rst
@@ -14,19 +14,6 @@ stored in the database shortly.
     You can find a basic example implementation of a listener to this event
     in the chapter :ref:`extension-development-event-listener`.
 
-..  deprecated:: 12.4
-    The :php:`PasswordChangeEvent` should not be used to validate user passwords,
-    since it is not possible to visualize to the user why a password has been
-    rejected. Therefore the following methods of the event are deprecated:
-
-    *   :php:`->setAsInvalid()`
-    *   :php:`->getErrorMessage()`
-    *   :php:`->isPropagationStopped()`
-    *   :php:`->setHashedPassword()`
-
-    A :ref:`custom password policy validator<password-policies-custom-validator>`
-    should be used to validate user passwords.
-
 Example
 =======
 

--- a/Documentation/CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/FrontendLogin/PasswordChangeEvent.rst.txt
@@ -14,38 +14,6 @@
    
       :returntype: string
       
-   .. php:method:: setHashedPassword(string $passwordHash)
-   
-      **Deprecated:** will be removed in TYPO3 13
-      
-      
-      
-      :param string $passwordHash: the passwordHash
-      
    .. php:method:: getRawPassword()
    
       :returntype: string
-      
-   .. php:method:: setAsInvalid(string $message)
-   
-      **Deprecated:** will be removed in TYPO3 13
-      
-      
-      
-      :param string $message: the message
-      
-   .. php:method:: getErrorMessage()
-   
-      **Deprecated:** will be removed in TYPO3 13
-      
-      
-      
-      :returntype: string
-      
-   .. php:method:: isPropagationStopped()
-   
-      **Deprecated:** will be removed in TYPO3 13
-      
-      
-      
-      :returntype: bool

--- a/Documentation/ExtensionArchitecture/HowTo/Events/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Events/Index.rst
@@ -30,6 +30,13 @@ the name in the :file:`Configuration/Services.yaml` or it is not found.
 It is best practice to use a descriptive class name and to put it in the
 namespace :php:`MyVendor\MyExtension\EventListener`.
 
+..  note::
+    This example is outdated as the used event :ref:`PasswordChangeEvent`
+    does not provide the method :php:`setAsInvalid()` anymore. However, it
+    illustrates the basic principle of an event listener.
+
+..  todo: Adjust example, see also https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/3155
+
 .. literalinclude:: _Joh316PasswordInvalidator.php
    :language: php
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/571
Releases: main