### PR TITLE
Update Repository.rst

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
@@ -79,6 +79,11 @@ they should be set in the method :php:`initializeObject()` method.
     Depending on the query settings, hidden or even deleted objects can become
     visible. This might cause sensitive information to be disclosed. Use with care.
 
+..  attention::
+    Since introduction of Services.yaml with TYPO3 10 you may have to flush
+    cache in maintenance module of TYPO3 to register that method to be loaded
+    while instanciating that object.
+
 If you only want to change the query settings for a specific method, they can be
 set in the method itself:
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
@@ -80,7 +80,8 @@ they should be set in the method :php:`initializeObject()` method.
     visible. This might cause sensitive information to be disclosed. Use with care.
 
 ..  attention::
-    Since introduction of Services.yaml with TYPO3 10 you may have to flush
+    Since introduction of :ref:`dependency injection via Services.yaml <dependency-injection-in-extensions>` 
+    with TYPO3 v10 you may have to flush
     cache in maintenance module of TYPO3 to register that method to be loaded
     while instanciating that object.
 


### PR DESCRIPTION
Just adding initializeObject to an object is not enough anymore. To load such methods while instanciation you have to create a Service.yaml and you have to use flush cache in maintenance module of TYPO3.