### PR TITLE
Remove default value for sitemap url config

### DIFF
--- a/Documentation/ApiOverview/Seo/XmlSitemap.rst
+++ b/Documentation/ApiOverview/Seo/XmlSitemap.rst
@@ -68,8 +68,6 @@ sitemap types (`pages` and additional ones, for example, from the news extension
       Sitemap:
         type: Simple
         routePath: 'sitemap-type/{sitemap}'
-        defaults:
-          sitemap: ''
         aspects:
           sitemap:
             type: StaticValueMapper


### PR DESCRIPTION
Maybe someone else can validate this... I tried the example code with a real-world v12 project as well as v11 demo project. In sitemap-type/pages/sitemap.xml the urls weren't generated correctly:

```xml
<url>
    <loc>https://www.praetorius.me/sitemap-type</loc>
    <lastmod>2023-06-28T17:28:09+02:00</lastmod>
    <priority>0.5</priority>
</url>
<url>
    <loc>https://www.praetorius.me/erfahrung-fachwissen/sitemap-type</loc>
    <lastmod>2023-06-14T19:20:51+02:00</lastmod>
    <priority>0.5</priority>
</url>
```
When I removed the default value, the `sitemap-type` suffix disappeared.