### PR TITLE
[TASK] Update JavaScript example to use ES6 modules

### DIFF
--- a/Documentation/ApiOverview/Backend/Ajax.rst
+++ b/Documentation/ApiOverview/Backend/Ajax.rst
@@ -157,16 +157,16 @@ compute our input and write the result into the console.
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Ajax/AjaxRequest'], function (AjaxRequest) {
-     // Generate a random number between 1 and 32
-     const randomNumber = Math.ceil(Math.random() * 32);
-     new AjaxRequest(TYPO3.settings.ajaxUrls.example_dosomething)
-       .withQueryArguments({input: randomNumber})
-       .get()
-       .then(async function (response) {
-       const resolved = await response.resolve();
-       console.log(resolved.result);
-     });
+   import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+
+   // Generate a random number between 1 and 32
+   const randomNumber = Math.ceil(Math.random() * 32);
+   new AjaxRequest(TYPO3.settings.ajaxUrls.example_dosomething)
+     .withQueryArguments({input: randomNumber})
+     .get()
+     .then(async function (response) {
+     const resolved = await response.resolve();
+     console.log(resolved.result);
    });
 
 

--- a/Documentation/ApiOverview/Backend/JavaScript/EventApi/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/EventApi/Index.rst
@@ -27,11 +27,11 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/RegularEvent'], function (RegularEvent) {
-     new RegularEvent('click', function (e) {
-       // Do something
-     }).bindTo(document.querySelector('#my-element'));
-   });
+   import RegularEvent from '@typo3/cms/core/event/regular-event.js';
+
+   new RegularEvent('click', function (e) {
+     // Do something
+   }).bindTo(document.querySelector('#my-element'));
 
 
 Event Delegation
@@ -44,11 +44,11 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/RegularEvent'], function (RegularEvent) {
-     new RegularEvent('click', function (e) {
-       // Do something
-     }).delegateTo(document, 'a[data-action="toggle"]');
-   });
+   import RegularEvent from '@typo3/cms/core/event/regular-event.js';
+
+   new RegularEvent('click', function (e) {
+     // Do something
+   }).delegateTo(document, 'a[data-action="toggle"]');
 
 The event listener is now called every time the element matching the selector
 :js:`a[data-action="toggle"]` within :js:`document` is clicked.
@@ -64,15 +64,15 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/RegularEvent'], function (RegularEvent) {
-     const clickEvent = new RegularEvent('click', function (e) {
-       // Do something
-     }).delegateTo(document, 'a[data-action="toggle"]');
+   import RegularEvent from '@typo3/cms/core/event/regular-event.js';
 
-     // Do more stuff
+   const clickEvent = new RegularEvent('click', function (e) {
+     // Do something
+   }).delegateTo(document, 'a[data-action="toggle"]');
 
-     clickEvent.release();
-   });
+   // Do more stuff
+
+   clickEvent.release();
 
 
 Event Strategies
@@ -95,12 +95,12 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/RegularEvent'], function (RegularEvent) {
-     new RegularEvent('click', function (e) {
-       e.preventDefault();
-       window.location.reload();
-     }).bindTo(document.querySelector('#my-element'));
-   });
+   import RegularEvent from '@typo3/cms/core/event/regular-event.js';
+
+   new RegularEvent('click', function (e) {
+     e.preventDefault();
+     window.location.reload();
+   }).bindTo(document.querySelector('#my-element'));
 
 
 DebounceEvent
@@ -120,11 +120,11 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/DebounceEvent'], function (DebounceEvent) {
-     new DebounceEvent('mousewheel', function (e) {
-       console.log('Triggered once after 250ms!');
-     }, 250).bindTo(document);
-   });
+   import DebounceEvent from '@typo3/cms/core/event/debounce-event.js';
+
+   new DebounceEvent('mousewheel', function (e) {
+     console.log('Triggered once after 250ms!');
+   }, 250).bindTo(document);
 
 
 ThrottleEvent
@@ -147,11 +147,11 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/ThrottleEvent'], function (ThrottleEvent) {
-     new ThrottleEvent('mousewheel', function (e) {
-       console.log('Triggered every 100ms!');
-     }, 100).bindTo(document);
-   });
+   import ThrottleEvent from '@typo3/cms/core/event/throttle-event.js';
+
+   new ThrottleEvent('mousewheel', function (e) {
+     console.log('Triggered every 100ms!');
+   }, 100).bindTo(document);
 
 
 RequestAnimationFrameEvent
@@ -170,8 +170,8 @@ Example:
 
 .. code-block:: js
 
-   require(['TYPO3/CMS/Core/Event/RequestAnimationFrameEvent'], function (RequestAnimationFrameEvent) {
-     new RequestAnimationFrameEvent('mousewheel', function (e) {
-       console.log('Triggered every 16ms (= 60 FPS)!');
-     });
+   import RequestAnimationFrameEvent from '@typo3/cms/core/event/request-animation-frame-event.js';
+
+   new RequestAnimationFrameEvent('mousewheel', function (e) {
+     console.log('Triggered every 16ms (= 60 FPS)!');
    });

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/DocumentService.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/DocumentService.rst
@@ -17,6 +17,8 @@ waiting for stylesheets, images, and sub-frames to finish loading.
 
 .. code-block:: javascript
 
+   import $ from 'jquery';
+
    $(document).ready(() => {
      // your application code
    });
@@ -25,10 +27,10 @@ Above jQuery code can be transformed into the following using :js:`DocumentServi
 
 .. code-block:: javascript
 
-   require(['TYPO3/CMS/Core/DocumentService'], function (DocumentService) {
-     DocumentService.ready().then(() => {
-       // your application code
-     });
+   import DocumentService from '@typo3/core/document-service.js';
+
+   DocumentService.ready().then(() => {
+     // your application code
    });
 
 


### PR DESCRIPTION
RequireJS modules have been deprecated in TYPO3 v12 with https://docs.typo3.org/c/typo3/cms-core/12.4/en-us/Changelog/12.0/Deprecation-97057-DeprecateRequireJSSupport.html They are replaced by ECMAScript 6 (ES6) modules: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96510-InfrastructureForJavaScriptModulesAndImportmaps.html

With the deprecation and refactorings to use ES6 modules throughout the core, the global `require()` method became "optional" and is only loaded, if at least one RequireJS module is loaded. That means `require()` works only from within a deprecated RequireJS module or when at least one RequireJS module has been loaded – it does not work when it's placed as inline JavaScript within backend modules.