### PR TITLE
[TASK] Add page about TYPO3_CONF_VARS|LOG in configuration chapter

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/LOG.rst
+++ b/Documentation/Configuration/Typo3ConfVars/LOG.rst
@@ -1,0 +1,16 @@
+..  include:: /Includes.rst.txt
+
+..  index::
+    TYPO3_CONF_VARS; LOG
+    Logging
+..  _typo3ConfVars_log:
+
+===========================
+LOG - Logging configuration
+===========================
+
+:php:`$GLOBALS['TYPO3_CONF_VARS']['LOG']` holds the logging configuration. Have
+a look into the :ref:`logging` chapter for more details.
+
+You can find the default logging configuration shipped with TYPO3 in the file
+:t3src:`core/Configuration/DefaultConfiguration.php`.


### PR DESCRIPTION
This way it can also be found in the left navigation menu of the TYPO3_CONF_VARS page for quick access.

Releases: main, 12.4, 11.5