### PR TITLE
[FIX] Correct cache flush/warm up includes

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -219,7 +219,7 @@ Clear cache command
 In addition to the GUI options explained above, caches can also be cleared
 via a :ref:`CLI command <symfony-console-commands>`:
 
-..  include:: /_includes/CliCacheWarmup.rst.txt
+..  include:: /_includes/CliCacheFlush.rst.txt
 
 Specific cache groups can be defined via the group option.
 The usage is described as this:
@@ -244,7 +244,7 @@ It is possible to warmup TYPO3 caches using the command line.
 The administrator can use the following
 :ref:`CLI command <symfony-console-commands>`:
 
-..  include:: /_includes/CliCacheFlush.rst.txt
+..  include:: /_includes/CliCacheWarmup.rst.txt
 
 Specific cache groups can be defined via the group option.
 The usage is described as this:


### PR DESCRIPTION
Currently the warmup/flush are the wrong way round for the tabs, but correctly output in the params after

<img width="969" alt="image" src="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/354085/68d403ca-382c-488d-a102-25390d0bb0d2">
