### PR TITLE
[TASK] Add more invitations to contribute to event examples

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Html/BrokenLinkAnalysisEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Html/BrokenLinkAnalysisEvent.rst
@@ -24,6 +24,11 @@ This functionality is implemented in the system extension
 :doc:`linkvalidator <ext_linkvalidator:Index>`. Other extensions can use the
 event to override the default behaviour.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
@@ -21,6 +21,10 @@ is triggered after a package has been deactivated.
     `installer events by Composer <https://getcomposer.org/doc/articles/scripts.md#installer-events>`__
     for Composer-based installations.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Package/BeforePackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/BeforePackageActivationEvent.rst
@@ -17,6 +17,10 @@ is triggered before a number of packages should become active.
     `installer events by Composer <https://getcomposer.org/doc/articles/scripts.md#installer-events>`__
     for Composer-based installations.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
@@ -22,6 +22,11 @@ package listings.
     `installer events by Composer <https://getcomposer.org/doc/articles/scripts.md#installer-events>`__
     for Composer-based installations.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Page/BeforeJavaScriptsRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Page/BeforeJavaScriptsRenderingEvent.rst
@@ -13,6 +13,11 @@ is fired once before
 :php:`\TYPO3\CMS\Core\Page\AssetRenderer::render[Inline]JavaScript`
 renders the output.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Page/BeforeStylesheetsRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Page/BeforeStylesheetsRenderingEvent.rst
@@ -13,6 +13,11 @@ is fired once before
 :php:`\TYPO3\CMS\Core\Page\AssetRenderer::render[Inline]Stylesheets`
 renders the output.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedEvent.rst
@@ -16,6 +16,11 @@ is fired after a file was added to the resource
 permissions or perform specific analysis of files like additional metadata
 analysis after adding them to TYPO3.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedToIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileAddedToIndexEvent.rst
@@ -13,6 +13,11 @@ is fired once an index was just added to the database (= indexed).
 *Example:* Using listeners for this event allows to additionally populate custom
 fields of the :sql:`sys_file` / :sql:`sys_file_metadata` database records.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
@@ -13,6 +13,11 @@ is fired after the contents of a file got set / replaced.
 *Example:* Listeners can analyze content for :abbr:`AI (Artifical Intelligence)`
 purposes within extensions.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCopiedEvent.rst
@@ -15,6 +15,11 @@ The folder represents the "target folder".
 
 *Example:* Listeners can sign up for listing duplicates using this event.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
@@ -16,6 +16,11 @@ The folder represents the "target folder".
 *Example:* This allows to modify a file or check for an appropriate signature
 after a file was created in TYPO3.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileDeletedEvent.rst
@@ -14,6 +14,11 @@ is fired after a file was deleted.
 variants), this event allows listeners to also clean up their custom handling.
 This can also be used for versioning of files.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMarkedAsMissingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMarkedAsMissingEvent.rst
@@ -14,6 +14,11 @@ is fired once a file was just marked as missing in the database
 *Example*: If a file is marked as missing, listeners can try to recover a file.
 This can happen on specific setups where editors also work via FTP.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataCreatedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired once metadata of a file was added to the database,
 so it can be enriched with more information.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataDeletedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired once all metadata of a file was removed, in order to manage custom
 metadata that was added previously.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataUpdatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMetaDataUpdatedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired once metadata of a file was updated, in order to update custom metadata
 fields accordingly.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileMovedEvent.rst
@@ -16,6 +16,11 @@ The folder represents the "target folder".
 *Example*: Use this to update custom third-party handlers that rely on specific
 paths.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileProcessingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileProcessingEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired after a file object has been processed.
 This allows to further customize a file object's processed file.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRemovedFromIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRemovedFromIndexEvent.rst
@@ -13,6 +13,11 @@ is fired once a file was just removed in the database (table :sql:`sys_file`).
 *Example*: A listener can further handle files and manage them separately
 outside of TYPO3's index.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileRenamedEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired after a file was renamed in order to further process a file or filename
 or update custom references to a file.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileReplacedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileReplacedEvent.rst
@@ -12,6 +12,11 @@ is fired after a file was replaced.
 *Example*: Further process a file or create variants, or index the
 contents of a file for :abbr:`AI (Artificial Intelligence)` analysis etc.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileUpdatedInIndexEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileUpdatedInIndexEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired once an index was just updated inside the database (= indexed).
 Custom listeners can update further index values when a file was updated.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderAddedEvent.rst
@@ -15,6 +15,11 @@ is fired after a folder was added to the resource
 This allows to customize permissions or set up editor permissions automatically
 via listeners.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderCopiedEvent.rst
@@ -15,6 +15,11 @@ is fired after a folder was copied to the resource
 *Example*: Custom listeners can analyze contents of a file or add custom
 permissions to a folder automatically.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderDeletedEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Core\Resource\Event\AfterFolderDeletedEvent`
 is fired after a folder was deleted. Custom listeners can then further clean up
 permissions or third-party processed files with this event.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderMovedEvent.rst
@@ -13,6 +13,11 @@ is fired after a folder was moved within the resource
 :ref:`driver <fal-architecture-components-drivers>`.
 Custom references can be updated via listeners of this event.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFolderRenamedEvent.rst
@@ -15,6 +15,11 @@ This event is also used by TYPO3 itself to synchronize folder relations in
 records (for example in the table :sql:`sys_filemounts`) after renaming of
 folders.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterResourceStorageInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterResourceStorageInitializationEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is fired after a resource object was built/created. Custom handlers can be
 initialized at this moment for any kind of resource as well.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
@@ -13,6 +13,11 @@ is fired before a file is about to be added to the resource
 This allows to perform custom checks to a file or restrict access to a file
 before the file is added.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileContentsSetEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileContentsSetEvent.rst
@@ -12,6 +12,11 @@ is fired before the contents of a file gets set / replaced.
 This allows to further analyze or modify the content of a file before it is
 written by the :ref:`driver <fal-architecture-components-drivers>`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCopiedEvent.rst
@@ -15,6 +15,11 @@ The folder represents the "target folder".
 This allows to further analyze or modify the file or metadata before it is
 written by the driver.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileCreatedEvent.rst
@@ -15,6 +15,11 @@ The folder represents the "target folder".
 This allows to further analyze or modify the file or filename before it is
 written by the driver.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileDeletedEvent.rst
@@ -11,6 +11,11 @@ is fired before a file is about to be deleted.
 
 Event listeners can clean up third-party references with this event.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileMovedEvent.rst
@@ -12,6 +12,11 @@ is fired before a file is about to be moved within a resource
 :ref:`driver <fal-architecture-components-drivers>`.
 The folder represents the "target folder".
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileProcessingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileProcessingEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Core\Resource\Event\BeforeFileProcessingEvent`
 is fired before a file object is processed. This allows to add further
 information or enrich the file before the processing is kicking in.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileRenamedEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Core\Resource\Event\BeforeFileRenamedEvent`
 is fired before a file is about to be renamed. Custom listeners can further
 rename the file according to specific guidelines based on the project.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileReplacedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileReplacedEvent.rst
@@ -10,6 +10,11 @@ The PSR-14 event :php:`\TYPO3\CMS\Core\Resource\Event\BeforeFileReplacedEvent`
 is fired before a file is about to be replaced. Custom listeners can check for
 file integrity or analyze the content of the file before it gets added.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderAddedEvent.rst
@@ -13,6 +13,11 @@ fired before a folder is about to be added to the resource
 This allows to further specify folder names according to regulations for a
 specific project.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderCopiedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderCopiedEvent.rst
@@ -12,6 +12,11 @@ is fired before a folder is about to be copied to the resource
 :ref:`driver <fal-architecture-components-drivers>`.
 Listeners could add deferred processing / queuing of large folders.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderDeletedEvent.rst
@@ -12,6 +12,11 @@ is fired before a folder is about to be deleted.
 Listeners can use this event to clean up further external references
 to a folder / files in this folder.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderMovedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderMovedEvent.rst
@@ -13,6 +13,11 @@ fired before a folder is about to be moved to the resource
 Listeners can be used to modify a folder name before it is actually moved or to
 ensure consistency or specific rules when moving folders.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderRenamedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFolderRenamedEvent.rst
@@ -11,6 +11,11 @@ is fired before a folder is about to be renamed. Listeners can be used to modify
 a folder name before it is actually moved or to ensure consistency or specific
 rules when renaming folders.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeResourceStorageInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeResourceStorageInitializationEvent.rst
@@ -14,6 +14,11 @@ is fired before a resource object is actually built/created.
 resource (file/folder) before the creation of a
 :ref:`storage <fal-architecture-components-storage>`.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/EnrichFileMetaDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/EnrichFileMetaDataEvent.rst
@@ -11,6 +11,11 @@ is called after a record has been loaded from database. It allows other places
 to perform the extension of metadata at runtime or, for example, translation
 and workspace overlay.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/GeneratePublicUrlForResourceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/GeneratePublicUrlForResourceEvent.rst
@@ -13,6 +13,11 @@ is fired before TYPO3 FAL's native URL generation for a resource is instantiated
 This allows listeners to create custom links to certain files (for example
 restrictions) for creating authorized deep links.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyIconForResourcePropertiesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyIconForResourcePropertiesEvent.rst
@@ -11,6 +11,11 @@ The PSR-14 event
 is dispatched when an icon for a resource (file or folder) is fetched, allowing
 to modify the icon or overlay in an event listener.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/SanitizeFileNameEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/SanitizeFileNameEvent.rst
@@ -11,6 +11,11 @@ fired once an index was just added to the database (= indexed), so it is possibl
 to modify the file name, and name the files according to naming conventions of a
 specific project.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Security/PolicyMutatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/PolicyMutatedEvent.rst
@@ -16,6 +16,11 @@ will be dispatched once all mutations have been applied to the current
 corresponding HTTP header is added to the HTTP response object. This allows
 individual adjustments for custom implementations.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 

--- a/Documentation/ApiOverview/Events/Events/Core/Tree/ModifyTreeDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Tree/ModifyTreeDataEvent.rst
@@ -9,6 +9,11 @@ ModifyTreeDataEvent
 The PSR-14 event :php:`\TYPO3\CMS\Core\Tree\Event\ModifyTreeDataEvent` allows
 to modify tree data for any database tree.
 
+Example
+=======
+
+..  include:: /_includes/EventsContributeNote.rst.txt
+
 API
 ===
 


### PR DESCRIPTION
With #3046 event pages without examples have a contribution note added. However, some pages miss this note.

Releases: main, 12.4