### PR TITLE
[TASK] Rename header "Logging Framework" to "Logging"

### DIFF
--- a/Documentation/ApiOverview/Logging/Index.rst
+++ b/Documentation/ApiOverview/Logging/Index.rst
@@ -2,9 +2,9 @@
 ..  index:: ! Logging
 ..  _logging:
 
-=================
-Logging Framework
-=================
+=======
+Logging
+=======
 
 The chapter :ref:`logging-quickstart` helps you get started.
 


### PR DESCRIPTION
The "framework" word is removed from the header as it is superfluous. It is now also inline with other chapters, like "Caching".

Releases: main, 12.4, 11.5