### PR TITLE
[TASK] Remove paragraph about PHP 8 using log channels

### DIFF
--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -212,10 +212,6 @@ The :php:`\TYPO3\CMS\Core\Log\Channel` attribute is supported for
 parameter-specific attribute and for :php:`\Psr\Log\LoggerAwareInterface`
 dependency injection services as a class attribute.
 
-This feature is only available with PHP 8. The channel attribute will be
-gracefully ignored in PHP 7, and the classic component name will be used
-instead.
-
 Registration via class attribute for :php:`\Psr\Log\LoggerInterface` injection:
 
 ..  literalinclude:: _MyClassChannel.php


### PR DESCRIPTION
As PHP 8.1 is the minimum requirement for TYPO3 v12 the mentioned restriction when log channels can be used is removed.

Releases: main, 12.4