### PR TITLE
[TASK] Replaces default values for navigationComponent

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -187,10 +187,10 @@ Module configuration options
 
    The module navigation component. The following are provided by the Core:
 
-   `TYPO3/CMS/Backend/PageTree/PageTreeElement`
+   `@typo3/backend/page-tree/page-tree-element`
       The page tree as used in the :guilabel:`Web` module.
 
-   `TYPO3/CMS/Backend/Tree/FileStorageTreeContainer`
+   `@typo3/backend/tree/file-storage-tree-container`
       The file tree as used in the :guilabel:`Filelist` module.
 
 


### PR DESCRIPTION
The default values for the navigationComponent is misleading. I have replaced them with the values that are necessary for the configuration @see https://github.com/TYPO3/typo3/blob/2f2d3eae081b7a299c35f9225cd94da21b3172b7/typo3/sysext/core/Configuration/Backend/Modules.php#L10