### PR TITLE
[TASK] Use "option" instead "confval" to avoid warnings in site handling

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -46,7 +46,7 @@ Example of a language configuration (excerpt):
 Configuration properties
 ========================
 
-..  confval:: enabled
+..  option:: enabled
 
     :type: bool
     :Example: :yaml:`true`
@@ -54,7 +54,7 @@ Configuration properties
     Defines, if the language is visible on the frontend. Editors in the TYPO3
     backend will still be able to translate content for the language.
 
-..  confval:: languageId
+..  option:: languageId
 
     :type: integer
     :Example: :yaml:`1`
@@ -67,21 +67,21 @@ Configuration properties
         Once pages, content or records are created in a specific language, the
         :yaml:`languageId` must not be changed anymore.
 
-..  confval:: title
+..  option:: title
 
     :type: string
     :Example: :yaml:`English`
 
     The internal human-readable name for this language.
 
-..  confval:: websiteTitle
+..  option:: websiteTitle
 
     :type: string
     :Example: :yaml:`My custom very British title`
 
     Overrides the global website title for this language.
 
-..  confval:: navigationTitle
+..  option:: navigationTitle
 
     :type: string
     :Example: :yaml:`British`
@@ -89,14 +89,14 @@ Configuration properties
     Optional navigation title which is used in
     :typoscript:`HMENU.special = language`.
 
-..  confval:: base
+..  option:: base
 
     :type: string / URL
     :Example: :yaml:`/uk/`
 
     The language base accepts either a URL or a path segment like :yaml:`/en/`.
 
-..  confval:: baseVariants
+..  option:: baseVariants
 
     :type: array
 
@@ -121,7 +121,7 @@ Configuration properties
 
 ..  _sitehandling-addingLanguages-locale:
 
-..  confval:: locale
+..  option:: locale
 
     :type: string / locale
     :Example: :yaml:`en_GB` or :yaml:`de_DE.utf8,de_DE`
@@ -133,7 +133,7 @@ Configuration properties
     iterate through the locales from left to right until it finds a locale that
     is installed on the server.
 
-..  confval:: iso-639-1
+..  option:: iso-639-1
 
     :type: string
     :Example: :yaml:`en`
@@ -148,7 +148,7 @@ Configuration properties
     `ISO-639 <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>`__
     nomenclature.
 
-..  confval:: hreflang
+..  option:: hreflang
 
     :type: string
     :Example: :yaml:`en-GB`
@@ -161,7 +161,7 @@ Configuration properties
 
     The frontend language for :html:`hreflang` and :html:`lang` tags.
 
-..  confval:: direction
+..  option:: direction
 
     :type: string
     :Example: :yaml:`ltr`
@@ -175,7 +175,7 @@ Configuration properties
     The text direction for content in this language (left-to-right or
     right-to-left).
 
-..  confval:: typo3Language
+..  option:: typo3Language
 
     :type: string
     :Example: :yaml:`en`
@@ -188,7 +188,7 @@ Configuration properties
 
     Language identifier to use in TYPO3 :ref:`XLIFF files <xliff_api>`.
 
-..  confval:: flag
+..  option:: flag
 
     :type: string
     :Example: :yaml:`gb`
@@ -196,7 +196,7 @@ Configuration properties
     The flag identifier. For example, the flag is displayed in the backend page
     module.
 
-..  confval:: fallbackType
+..  option:: fallbackType
 
     :type: string
     :Example: :yaml:`strict`
@@ -226,7 +226,7 @@ Configuration properties
 
         It behaves like old :typoscript:`config.sys_language_overlay = 0`.
 
-..  confval:: fallbacks
+..  option:: fallbacks
 
     :type: comma-separated list of language IDs
     :Example: :yaml:`1,0`

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -63,21 +63,21 @@ Example
 Properties
 ==========
 
-..  confval:: typo3.version
+..  option:: typo3.version
 
     :type: string
     :Example: `12.4.0`
 
     The current TYPO3 version.
 
-..  confval:: typo3.branch
+..  option:: typo3.branch
 
     :type: string
     :Example: `12.4`
 
     The current TYPO3 branch.
 
-..  confval:: typo3.devIpMask
+..  option:: typo3.devIpMask
 
     :type: string
     :Example: `203.0.113.*`
@@ -85,7 +85,7 @@ Properties
     The configured devIpMask taken from
     :ref:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] <typo3ConfVars_sys_devIPmask>`.
 
-..  confval:: applicationContext
+..  option:: applicationContext
 
     :type: string
     :Example: `Development`
@@ -104,7 +104,7 @@ All functions from
 :t3src:`core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php`
 are available:
 
-..  confval:: ip
+..  option:: ip
 
     :type: string
     :Example: `ip("203.0.113.*")`
@@ -112,14 +112,14 @@ are available:
     Match an IP address, value or regex, wildcards possible.
     Special value: `devIp` for matching `devIpMask`.
 
-..  confval:: compatVersion
+..  option:: compatVersion
 
     :type: string
     :Example: `compatVersion("12.4.0")`, `compatVersion("11.5")`
 
     Match a TYPO3 version.
 
-..  confval:: like
+..  option:: like
 
     :type: string
     :Example: `like("foobarbaz", "*bar*")`
@@ -127,7 +127,7 @@ are available:
     A comparison function to compare two strings. The first parameter is the
     "haystack", the second the "needle". Wildcards are allowed.
 
-..  confval:: getenv
+..  option:: getenv
 
     :type: string
     :Example: `getenv("TYPO3_BASE_URL")`
@@ -137,14 +137,14 @@ are available:
 
     ..  _getenv(): https://www.php.net/manual/en/function.getenv.php
 
-..  confval:: date
+..  option:: date
 
     :type: string
     :Example: checking the current month: `date("j") == 7`
 
     Get the current date in given format.
 
-..  confval:: feature
+..  option:: feature
 
     :type: string
     :Example: `feature("redirects.hitCount")`
@@ -152,7 +152,7 @@ are available:
     Check whether a feature (":ref:`feature toggle <feature-toggles>`") is
     enabled in TYPO3.
 
-..  confval:: traverse
+..  option:: traverse
 
     :type: array|string
     :Example: `traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0`

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
@@ -16,7 +16,7 @@ The Fluid-based error handler has the properties
 :ref:`sitehandling-errorHandling_errorCode` and
 :ref:`sitehandling-errorHandling_errorHandler`, and the following:
 
-..  confval:: errorFluidTemplate
+..  option:: errorFluidTemplate
 
     :type: string
     :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html`
@@ -27,21 +27,21 @@ The Fluid-based error handler has the properties
     *   relative to site root
     *   starting with `EXT:` for files from an extension
 
-..  confval:: errorFluidTemplatesRootPath
+..  option:: errorFluidTemplatesRootPath
 
     :type: string [optional]
     :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/`
 
     The paths to the Fluid templates in case more flexibility is needed.
 
-..  confval:: errorFluidPartialsRootPath
+..  option:: errorFluidPartialsRootPath
 
     :type: string [optional]
     :Example: `EXT:my_sitepackage/Resources/Private/Partials/Sites/`
 
     The paths to the Fluid partials in case more flexibility is needed.
 
-..  confval:: errorFluidLayoutsRootPath
+..  option:: errorFluidLayoutsRootPath
 
     :type: string [optional]
     :Example: `EXT:my_sitepackage/Resources/Private/Layouts/Sites/`

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/Index.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/Index.rst
@@ -45,7 +45,7 @@ These properties apply to all error handlers.
 
 ..  _sitehandling-errorHandling_errorCode:
 
-..  confval:: errorCode
+..  option:: errorCode
 
     :type: int
     :Example: `404`
@@ -59,7 +59,7 @@ These properties apply to all error handlers.
 
 .. _sitehandling-errorHandling_errorHandler:
 
-..  confval:: errorHandler
+..  option:: errorHandler
 
     :type: string / enum
     :Example: `Fluid`

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
@@ -39,7 +39,7 @@ The page-based error handler has the properties
 :ref:`sitehandling-errorHandling_errorCode` and
 :ref:`sitehandling-errorHandling_errorHandler` and the following:
 
-..  confval:: errorContentSource
+..  option:: errorContentSource
 
     :type: string
     :Example: `t3://page?uid=123`

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
@@ -51,7 +51,7 @@ The custom error handlers have the properties
 :ref:`sitehandling-errorHandling_errorCode` and
 :ref:`sitehandling-errorHandling_errorHandler` and the following:
 
-..  confval:: errorPhpClassFQCN
+..  option:: errorPhpClassFQCN
 
     :type: string
     :Example: `MyVendor\MySitePackage\Error\MyErrorHandler`


### PR DESCRIPTION
To avoid warning when rendering the "confval" directive is changed to "option" (which looks the same):

./Documentation/ApiOverview/SiteHandling/AddLanguages.rst:70: WARNING: duplicate confval description of title, other instance in ApiOverview/Backend/JavaScript/Modules/Modals

Releases: main, 12.4