### PR TITLE
[TASK] Remove event tag from event listener registration

### DIFF
--- a/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
+++ b/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
@@ -201,11 +201,6 @@ If no attribute :yaml:`method` is given, the class is treated as invokable, thus
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
 
-.. versionchanged:: 11.3
-   The :yaml:`event` tag can be omitted if the listener implementation has a corresponding
-   event type in the method signature. In that case the event class is automatically derived
-   from the method signature of the listener implementation.
-
 
 .. index:: Event listener; Implementation
 .. _EventDispatcherEventListenerClass:

--- a/Documentation/ApiOverview/Events/EventDispatcher/_ServicesWithMethod.yaml
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_ServicesWithMethod.yaml
@@ -7,4 +7,3 @@ services:
         method: handleEvent
         identifier: 'myListener'
         before: 'redirects, anotherIdentifier'
-        event: TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent

--- a/Documentation/ApiOverview/Events/EventDispatcher/_ServicesWithoutMethod.yaml
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_ServicesWithoutMethod.yaml
@@ -6,4 +6,3 @@ services:
       - name: event.listener
         identifier: 'myListener'
         before: 'redirects, anotherIdentifier'
-        event: TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent


### PR DESCRIPTION
Since TYPO3 v11.3 it is not necessary anymore to set the tag attribute "event" anymore when registering event listeners. Therefore, it is removed now.

Releases: main, 12.4