### PR TITLE
[TASK] Add video from dev days about Content Security Policy

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -27,6 +27,11 @@ web page context.
     *   https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
     *   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
+    At the TYPO3 Developer Days 2023 Oliver Hader talked about Content Security
+    Policy in general and in TYPO3:
+
+    *   https://www.youtube.com/watch?v=a_cS2XfCplI&t=28766s
+
 Content Security Policy declarations can be applied to a TYPO3 website in
 frontend and backend scope with a dedicated API.
 


### PR DESCRIPTION
As there is no dedicated video only for the CSP talk available, the video of the full day recording is linked with the start time. This seems not possible to do with an embedded YouTube video via the directive.

Releases: main, 12.4