### PR TITLE
[TASK] Remove TYPO3CONF_VARS|FE|defaultUserTSconfig

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -429,24 +429,6 @@ cookieSameSite
    can be shared (first-party cookies vs. third-party cookies) in TYPO3 Frontend.
 
 .. index::
-   TYPO3_CONF_VARS FE; defaultUserTSconfig
-.. _typo3ConfVars_fe_defaultUserTSconfig:
-
-defaultUserTSconfig
-===================
-
-..  deprecated:: 12.1
-    This setting will be removed with TYPO3 v13. More information can be found
-    in the :ref:`changelog <ext_core:deprecation-99075-1668337874>`.
-
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultUserTSconfig']
-
-   :type: multiline
-   :Default: ''
-
-    Enter lines of default frontend user/group TSconfig.
-
-.. index::
    TYPO3_CONF_VARS FE; defaultTypoScript_constants
 .. _typo3ConfVars_fe_defaultTypoScript_constants:
 


### PR DESCRIPTION
This option has been deprecated in v12 and removed with v13.0.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/619
Releases: main