### PR TITLE
[TASK] Adjust nonce request attribute chapter

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Nonce.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Nonce.rst
@@ -15,11 +15,9 @@ The :php:`nonce` request attribute is related to :ref:`content-security-policy`.
 ..  seealso::
     https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
 
-It is available in backend and frontend context, if the according feature is
-enabled:
-
-*   :ref:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.backend.enforceContentSecurityPolicy'] <typo3ConfVars_sys_features_security.backend.enforceContentSecurityPolicy>`
-*   :ref:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.frontend.enforceContentSecurityPolicy'] <typo3ConfVars_sys_features_security.frontend.enforceContentSecurityPolicy>`
+It is always available in backend context and only in frontend context, if the
+according :ref:`feature <typo3ConfVars_sys_features_security.frontend.enforceContentSecurityPolicy>`
+is enabled.
 
 One can retrieve the nonce like this:
 


### PR DESCRIPTION
Content Security Policy is always enabled in backend since v13.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/564
Releases: main