### PR TITLE
[TASK] Revise manual references

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -30,7 +30,6 @@ t3coreapi11      = https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/
 
 # Official TYPO3 manuals
 h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
-# t3cheatsheets  = https://docs.typo3.org/m/typo3/docs-cheatsheets/main/en-us/
 t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 t3coreapi12    = https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/
 # t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
@@ -38,7 +37,6 @@ t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
 # t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
 # t3home         = https://docs.typo3.org/
 t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
-# t3l10n         = https://docs.typo3.org/m/typo3/guide-frontendlocalization/main/en-us/
 t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
 t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
 t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
@@ -57,13 +55,17 @@ ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
 ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
 ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
 ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/main/en-us/
+ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
 ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/main/en-us/
 ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/main/en-us/
-ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+# ext_reactions      = https://docs.typo3.org/c/typo3/cms-reactions/main/en-us/
+# ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
+# ext_redirects      = https://docs.typo3.org/c/typo3/cms-redirects/main/en-us/
 ext_reports        = https://docs.typo3.org/c/typo3/cms-reports/main/en-us/
 ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
 ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
 ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/
+# ext_t3editor      = https://docs.typo3.org/c/typo3/cms-t3editor/main/en-us/
 ext_workspaces     = https://docs.typo3.org/c/typo3/cms-workspaces/main/en-us/
 
 # Third-party manuals


### PR DESCRIPTION
- t3cheatsheets is outdated and therefore removed
- t3l10n is superseded by t3translate
- ext_reactions, ext_recycler, ext_redirects, ext_t3editor are added
- Sort sysext manuals alphabetically

Releases: main