### PR TITLE
[TASK] Move PHP code snippets into separate files in ext_conf_template.txt chapter

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -136,7 +136,7 @@ You can also define nested options using the TypoScript notation:
 This will result in a multidimensional array:
 
 .. code-block:: plain
-   :caption: Example output of function `ExtensionConfiguration::get`
+   :caption: Example output of method `ExtensionConfiguration->get()`
 
    $extensionConfiguration['directories']['tmp']
    $extensionConfiguration['directories']['cache']

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -135,7 +135,8 @@ You can also define nested options using the TypoScript notation:
 
 This will result in a multidimensional array:
 
-.. code-block:: php
+.. code-block:: plain
+   :caption: Example output of function `ExtensionConfiguration::get`
 
    $extensionConfiguration['directories']['tmp']
    $extensionConfiguration['directories']['cache']

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -100,26 +100,20 @@ When saved in the Settings module, the configuration will be kept in the :file:`
 file and is available as array :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['my_extension_key']`.
 
 To retrieve the configuration use the API provided by the
-:php:`\TYPO3\CMS\Core\Configuration\ExtensionConfiguration` class:
+:php:`\TYPO3\CMS\Core\Configuration\ExtensionConfiguration` class via
+:ref:`constructor injection <Constructor-injection>`:
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
-
-   use TYPO3\CMS\Core\Utility\GeneralUtility;
-   use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-
-   $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)
-      ->get('my_extension_key');
+..  literalinclude:: _ExtConfTemplate/_MyClass.php
+    :language: php
+    :caption: EXT:my_extension/Classes/MyClass.php
 
 This will return the whole configuration as an array.
 
 To directly fetch specific values like :typoscript:`myVariable` from the example above:
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
-
-   $temporaryDirectory = GeneralUtility::makeInstance(ExtensionConfiguration::class)
-      ->get('my_extension_key', 'myVariable');
+..  literalinclude:: _ExtConfTemplate/_MyClass2.php
+    :language: php
+    :caption: EXT:my_extension/Classes/MyClass.php
 
 
 .. _extension-options-nested-structure:
@@ -142,7 +136,6 @@ You can also define nested options using the TypoScript notation:
 This will result in a multidimensional array:
 
 .. code-block:: php
-   :caption: EXT:some_extension/Classes/SomeClass.php
 
    $extensionConfiguration['directories']['tmp']
    $extensionConfiguration['directories']['cache']

--- a/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\MyClass;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+final class MyClass
+{
+    public function __construct(
+        private readonly ExtensionConfiguration $extensionConfiguration
+    ) {
+    }
+
+    public function doSomething()
+    {
+        // ...
+
+        $myConfiguration = $this->extensionConfiguration
+            ->get('my_extension_key');
+
+        // ...
+    }
+}

--- a/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass2.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass2.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\MyClass;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+final class MyClass
+{
+    public function __construct(
+        private readonly ExtensionConfiguration $extensionConfiguration
+    ) {
+    }
+
+    public function doSomething()
+    {
+        // ...
+
+        $myVariable = $this->extensionConfiguration
+            ->get('my_extension_key', 'myVariable');
+
+        // ...
+    }
+}


### PR DESCRIPTION
Constructor injection is used in the examples now.

Additionally, the caption of the last snippet in the chapter is removed as it is not bound to a class.

Releases: main, 12.4, 11.5