### PR TITLE
[Backport 12.4] [TASK] Add webhooks chapter (#3357)

### DIFF
--- a/Documentation/ApiOverview/Webhooks/Index.rst
+++ b/Documentation/ApiOverview/Webhooks/Index.rst
@@ -1,0 +1,26 @@
+..  include:: /Includes.rst.txt
+..  index::
+    Webhooks
+    Reactions
+.. _webhooks:
+
+======================
+Webhooks and reactions
+======================
+
+..  versionadded:: 12.1/12.3
+
+A webhook is an automated message sent from one application to another via HTTP.
+It is defined as an authorized POST or GET request to a defined URL. For
+example, a webhook can be used to send a notification to a Slack channel when a
+new page is created in TYPO3.
+
+TYPO3 supports incoming and outgoing webhooks:
+
+*   The system extension :doc:`Reactions <ext_reactions:Index>` provides the
+    functionality to receive webhooks in TYPO3 from third-party system.
+*   The system extension :ref:`Webhooks <ext_core:feature-99629-1674550092>`
+    provides the possibility to send webhooks from TYPO3 to third-party
+    systems.
+
+Have a look at the linked documentation for more details.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -60,6 +60,7 @@ ext_impexp         = https://docs.typo3.org/c/typo3/cms-impexp/12.4/en-us/
 ext_linkvalidator  = https://docs.typo3.org/c/typo3/cms-linkvalidator/12.4/en-us/
 ext_lowlevel       = https://docs.typo3.org/c/typo3/cms-lowlevel/12.4/en-us/
 ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/12.4/en-us/
+ext_reactions      = https://docs.typo3.org/c/typo3/cms-reactions/12.4/en-us/
 ext_reports        = https://docs.typo3.org/c/typo3/cms-reports/12.4/en-us/
 ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/12.4/en-us/
 ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/12.4/en-us/


### PR DESCRIPTION
In "A-Z" a new chapter "Webhooks and reactions" is added to guide the user to the with v12 introduced features. This makes them a little bit more prominent.

As there is currently no dedicated manual for the Webhooks system extension available, the changelog is linked for the time being.

Releases: main, 12.4