### PR TITLE
[TASK] Remove outdated warning for ModifyResultItemInLiveSearchEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
@@ -9,15 +9,11 @@ ModifyResultItemInLiveSearchEvent
 ..  versionadded:: 12.2
 
 The PSR-14 event :php:`\TYPO3\CMS\Backend\Search\Event\ModifyResultItemInLiveSearchEvent`
-is available to allow extension developers to take control over search result
+allows extension developers to take control over search result
 items rendered in the backend search.
 
 Example
 =======
-
-..  warning::
-    Some code in this example is experimental API and may change until TYPO3
-    v12 LTS.
 
 Registration of the event listener in the extension's :file:`Services.yaml`:
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/617
Releases: main, 12.4