### PR TITLE
[BUGFIX] Clarify the changes to the hreflang setting

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -154,13 +154,11 @@ Configuration properties
     :Example: :yaml:`en-GB`
 
     ..  versionchanged:: 12.4
-        This option is not relevant anymore for regular websites without
-        rendering hreflang tag, but is now customizable, and has a proper
-        fallback.
+        The information is now automatically derived from the 
+        :ref:`locale <sitehandling-addingLanguages-locale>` setting.
 
-    This property sets the hreflang tag for this language. It is empty by
-    default and will fallback to the
-    :ref:`locale <sitehandling-addingLanguages-locale>` setting.
+    Use this property to override the automatic hreflang tag value for this 
+    language.
 
     **Example setups:**
 


### PR DESCRIPTION
The new change description is based more closely on the description in the deprecation notice (https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99908-SiteLanguageHreflangSetting.html).

As the hreflang setting is automatically generated, the setting is also changed to describe the value as overriding this automatic functionality. This is better aligned with what the setting actually does since TYPO3 v12.3