### PR TITLE
[BUGFIX] Add hints what Extbase ForwardResponse needs to work properly

### DIFF
--- a/Documentation/CodeSnippets/Extbase/Controllers/ForwardAction.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Controllers/ForwardAction.rst.txt
@@ -23,7 +23,7 @@
        ): ResponseInterface {
            if ($blog == null) {
                return (new ForwardResponse('index'))
-                   ->withControllerName(('Blog'))
+                   ->withControllerName('Blog')
                    ->withExtensionName('blog_example')
                    ->withArguments(['currentPage' => $currentPage]);
            }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -121,7 +121,7 @@ displayed by the :php:`indexAction` of the :php:`BlogController`.
 .. include:: /CodeSnippets/Extbase/Controllers/ForwardAction.rst.txt
 
 Forwards only work when the target controller and action is properly registered
-as an allowed pair. This can be done via an extension's `ext_localconf.php` file
+as an allowed pair. This can be done via an extension's :file:`ext_localconf.php` file
 in the relevant :php:`ExtensionUtility::configurePlugin()` section, or by
 filling the :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']`
 array and :typoscript:`tt_content.list.20.(pluginSignature)` TypoScript.

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -120,13 +120,15 @@ displayed by the :php:`indexAction` of the :php:`BlogController`.
 
 .. include:: /CodeSnippets/Extbase/Controllers/ForwardAction.rst.txt
 
-You need to ensure that every target controller is listed as a valid
-target in the extension's `ext_localconf.php` file in the relevant
-:php:`ExtensionUtility::configurePlugin()` section. Otherwise, the object
-class name of your target controller cannot be resolved properly,
-and container instantiation would fail.
+Forwards only work when the target controller and action is properly registered
+as an allowed pair. This can be done via an extension's `ext_localconf.php` file
+in the relevant :php:`ExtensionUtility::configurePlugin()` section, or by
+filling the :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']`
+array and :typoscript:`tt_content.list.20.(pluginSignature)` TypoScript.
+Otherwise, the object class name of your target controller cannot be resolved properly,
+and container instantiation will fail.
 
-The corresponding example would be:
+The corresponding example is:
 
 .. include:: /CodeSnippets/FrontendPlugins/ConfigurePlugin.rst.txt
 
@@ -136,8 +138,15 @@ Here, the plugin `BlogExample` would allow jumping between the controllers
 like this:
 
 .. code-block:: php
+   :caption: EXT:blog_example/ext_localconf.php
+
    <?php
    // ...
+   use FriendsOfTYPO3\BlogExample\Controller\CommentController;
+   use FriendsOfTYPO3\BlogExample\Controller\PostController;
+   use FriendsOfTYPO3\BlogExample\Controller\CommentController;
+   use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+
    ExtensionUtility::configurePlugin(
       'BlogExample',
       'PostSingle',

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -120,6 +120,36 @@ displayed by the :php:`indexAction` of the :php:`BlogController`.
 
 .. include:: /CodeSnippets/Extbase/Controllers/ForwardAction.rst.txt
 
+You need to ensure that every target controller is listed as a valid
+target in the extension's `ext_localconf.php` file in the relevant
+:php:`ExtensionUtility::configurePlugin()` section. Otherwise, the object
+class name of your target controller cannot be resolved properly,
+and container instantiation would fail.
+
+The corresponding example would be:
+
+.. include:: /CodeSnippets/FrontendPlugins/ConfigurePlugin.rst.txt
+
+Here, the plugin `BlogExample` would allow jumping between the controllers
+:php:`PostController` and :php:`CommentController`. To also allow
+:php:`BlogController` in the example above, it would need to get added
+like this:
+
+.. code-block:: php
+   <?php
+   // ...
+   ExtensionUtility::configurePlugin(
+      'BlogExample',
+      'PostSingle',
+      [
+         PostController::class => 'show',
+         CommentController::class => 'create',
+         BlogController::class => 'index'
+      ],
+      [CommentController::class => 'create']
+   );
+
+
 Events
 ======
 


### PR DESCRIPTION
Current documentation was lacking information, that ForwardResponses only work properly, if all allowed controller action targets are listed within the ext_localconf.php - ExtensionUtility::configurePlugin() array.

References: https://forge.typo3.org/issues/101824
References: https://forge.typo3.org/issues/91671
References: https://forge.typo3.org/issues/99049