### PR TITLE
[CI] Streamline GitHub workflow configuration for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,16 +7,12 @@ on:
 jobs:
   testsuite:
     name: all tests
-    runs-on: ubuntu-22.04
-    strategy:
-      # This prevents cancellation of matrix job runs, if one or more already failed
-      # and let the remaining matrix jobs be executed anyway.
-      fail-fast: false
+    runs-on: ubuntu-latest
     env:
       php: '8.1'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install testing system
         run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerUpdate


### PR DESCRIPTION
- Use "ubuntu-latest" as runner to avoid failing runs in the future when 22.04 is not supported anymore. Currently, this is an alias for ubuntu-22.04.
- The strategy option is removed. This is superfluous as no build matrix is defined.
- The actions/checkout action is updated to version 4.

Releases: main, 12.4