### PR TITLE
[Backport 11.5] [TASK] Remove mentions of the Pootle translation serv…

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin.rst
@@ -30,8 +30,10 @@ Crowdin is a localization management platform and offers the Core features essen
 Crowdin initiative
 ==================
 
-A TYPO3 initiative has been created which takes care of integrating Crowdin into TYPO3.
-The initiative’s scope is to fulfill all features which have been available with Pootle and its integration.
+A TYPO3 initiative has been created which takes care of integrating Crowdin into
+TYPO3. The scope of the initiative is to fulfil all the features that were
+available with the previously used translation server powered by Pootle and its
+integration.
 
 .. seealso::
 

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -23,7 +23,9 @@ General Questions
 
 Will the old translation server be disabled?
 --------------------------------------------
-The existing translation server will be turned off some time after Crowdin will have been announced stable.
+
+The old translation server under :samp:`https://translation.typo3.org/` has been
+turned off in July 2023.
 
 The existing and exported translations which are downloaded within the Install Tool will be available for longer time.
 
@@ -46,6 +48,27 @@ of the extension or the :ref:`crowdin-initiative`.
 .. seealso::
 
    The language needs to be supported by TYPO3 itself as well, see :ref:`i18n_languages` for a list of all languages.
+
+.. _crowdin-faq-language-xlf-format:
+
+How to convert to the new language xlf file format
+--------------------------------------------------
+If you have :ref:`downloaded an xlf file <migrate-from-pootle>` from the
+deactivated Pootle language server or an old version of an extension,
+then it does not have the correct format. You need to remove some attributes.
+And you need to add the "resname" attribute.
+For this you can use a linux tool or a sophisticated editor to copy the `id` attribute into the `resname` of
+the xlf file based on regular expressions.
+
+In most editors you can use regular expressions. For example in the KDE Kate editor:
+
+#. Open the xlf file into the editor.
+#. Press :kbd:`Ctrl` + :kbd:`R` to get into the replace mode
+#. Find:    `id="(.+)"`
+   Replace: `id="\1" resname="\1"`
+#. Mode:     Regular expression
+#. Click on button `Replace all`
+
 
 Questions about extension integration
 =====================================
@@ -73,11 +96,12 @@ You need to exlude those in your `.crowdin.yaml` configuration which can be foun
 More information can be found in the documentation on crowdin: https://support.crowdin.com/configuration-file/
 
 
-.. index:: Crowdin; Migration from Pootle
+..  index:: Crowdin; Migration from Pootle
+..  _migrate-from-pootle:
 
 How can I migrate translations from Pootle?
 -------------------------------------------
-If translations exist on Pootle there is no need to retranslate everything on Crowdin again - you can import those.
+If translations existed on Pootle, there is no need to retranslate everything on Crowdin again - you can import those.
 
 
 #. **Fetch translations**

--- a/Documentation/ApiOverview/Localization/TranslationServer/Index.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Index.rst
@@ -12,5 +12,4 @@ A translation server holds all translations which can be fetched by multiple TYP
    :titlesonly:
 
    Crowdin
-   Pootle
    Custom

--- a/Documentation/ApiOverview/Localization/TranslationServer/Pootle.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Pootle.rst
@@ -1,18 +1,14 @@
-.. include:: /Includes.rst.txt
-.. index:: Localization; Pootle
-.. _xliff-translating-server-pootle:
+:orphan:
 
-=========================
+..  include:: /Includes.rst.txt
+..  _xliff-translating-server-pootle:
+
+========================
 Localization with Pootle
-=========================
+========================
 
-.. important::
-
-   Pootle has been superseded by the usage of Crowdin which is described in
-   detail at :ref:`xliff-translating-server-crowdin`.
-
-To manage translations of extensions uploaded to the TYPO3 Extension Repository (TER),
-the TYPO3 community runs an `official translation server <https://translation.typo3.org/>`_,
-based on `Pootle <https://pootle.translatehouse.org/>`__. Localization files of TER extensions
-in English are uploaded on that server and translations are packaged nightly.
-They can be fetched in the TYPO3 backend, via the Install Tool and on the command line.
+..  attention::
+    The previous translation server using Pootle (under the URL
+    :samp:`https://translation.typo3.org/`) has been deactivated in July 2023.
+    It is superseded by the usage of Crowdin which is described in detail at
+    :ref:`xliff-translating-server-crowdin`.


### PR DESCRIPTION
…er (#3414)

The translation server powered by Pootle (known as translation.typo3.org) has been deactivated in July 2023. The page describing that translation server is now not linked anymore and set to orphan. In a follow-up patch the orphaned page will be removed for the main version (v13). This way, users can still find updated information about that server in the docs of the supported LTS versions (switching from older versions or coming from an external link).

Resolves: #3413
Releases: main, 12.4, 11.5