### PR TITLE
[Backport 11.5] [TASK] Revise Crowdin FAQ page (#3424)

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -1,25 +1,50 @@
-.. include:: /Includes.rst.txt
-.. index:: Crowdin; FAQ
-.. _crowdin-faq:
+..  include:: /Includes.rst.txt
+..  index:: Crowdin; FAQ
+..  _crowdin-faq:
 
 ================================
-Frequently Asked Questions (FAQ)
+Frequently asked questions (FAQ)
 ================================
 
-.. only:: html
+..  contents::
+    :local:
+    :depth: 2
 
-.. contents::
-        :local:
-        :depth: 2
+..  note::
+    If you miss a question, please share it in the Slack channel
+    `#cig-crowdin-localization <https://typo3.slack.com/app_redirect?channel=CMUG7C04F>`__.
 
-.. note::
 
-   If you miss a question, please share it in the slack channel `cig-crowdin-localization`.
-
-General Questions
+General questions
 =================
 
-.. _crowdin-faq-pootle:
+.. _crowdin-faq-extension-missing:
+
+My favorite extension is not available on Crowdin
+-------------------------------------------------
+If you miss an extension on Crowdin, contact the extension owner to create a
+project on Crowdin.
+
+It is important that they follow the description on the page
+:ref:`Extension integration <crowdin-extension-integration>`.
+The setup is a simple process and done within minutes.
+
+
+..  _crowdin-faq-extension-language-missing:
+
+My favorite language is not available for an extension
+------------------------------------------------------
+
+If you are missing the support for a specific language in an extension on
+Crowdin please contact either the maintainer of the extension or the
+:ref:`crowdin-initiative`.
+
+..  seealso::
+    The language needs to be supported by TYPO3 itself as well, see
+    :ref:`i18n_languages` for a list of all languages.
+
+
+..  _crowdin-faq-pootle:
 
 Will the old translation server be disabled?
 --------------------------------------------
@@ -27,47 +52,30 @@ Will the old translation server be disabled?
 The old translation server under :samp:`https://translation.typo3.org/` has been
 turned off in July 2023.
 
-The existing and exported translations which are downloaded within the Install Tool will be available for longer time.
+The existing and exported translations which are downloaded within the Install
+Tool will be available for longer time.
 
 
-.. _crowdin-faq-extension-missing:
+..  _crowdin-faq-language-xlf-format:
 
-My favorite extension is not available on Crowdin
--------------------------------------------------
-If you miss an extension on Crowdin, contact the extension owner to create a project on Crowdin.
-It is important that they follow the description on the page :ref:`Extension integration <crowdin-extension-integration>`.
-The setup is a simple process and done within minutes.
+How to convert to the new language XLIFF file format
+----------------------------------------------------
 
-.. _crowdin-faq-extension-language-missing:
+If you have :ref:`downloaded an XLIFF file <migrate-from-pootle>` from the
+deactivated Pootle language server or an old version of an extension, then it
+does not have the correct format. You need to remove some attributes. And you
+need to add the :xml:`resname` attribute. For this you can use a Linux tool or a
+sophisticated editor to copy the :xml:`id` attribute into the :xml:`resname` of
+the :ref:`XLIFF <xliff>` file based on regular expressions.
 
-My favorite language is not available for an extension
-------------------------------------------------------
-If you are missing the support for a specific language in an extension on Crowdin please contact either the maintainer
-of the extension or the :ref:`crowdin-initiative`.
+In most editors you can use regular expressions, for example, in PhpStorm:
 
-.. seealso::
-
-   The language needs to be supported by TYPO3 itself as well, see :ref:`i18n_languages` for a list of all languages.
-
-.. _crowdin-faq-language-xlf-format:
-
-How to convert to the new language xlf file format
---------------------------------------------------
-If you have :ref:`downloaded an xlf file <migrate-from-pootle>` from the
-deactivated Pootle language server or an old version of an extension,
-then it does not have the correct format. You need to remove some attributes.
-And you need to add the "resname" attribute.
-For this you can use a linux tool or a sophisticated editor to copy the `id` attribute into the `resname` of
-the xlf file based on regular expressions.
-
-In most editors you can use regular expressions. For example in the KDE Kate editor:
-
-#. Open the xlf file into the editor.
-#. Press :kbd:`Ctrl` + :kbd:`R` to get into the replace mode
-#. Find:    `id="(.+)"`
-   Replace: `id="\1" resname="\1"`
-#. Mode:     Regular expression
-#. Click on button `Replace all`
+#.  Open the XLIFF file in the editor.
+#.  Press :kbd:`Ctrl` + :kbd:`R` to open the search and replace pane
+#.  | Find: `id="(.+?)"`
+    Replace: `id="$1" resname="$1"`
+#.  Click the regex icon (:guilabel:`.*`) to enable regular expressions.
+#.  Click on button :guilabel:`Replace All`
 
 
 Questions about extension integration
@@ -77,11 +85,15 @@ Questions about extension integration
 
 Why does Crowdin show me translations in source language?
 ---------------------------------------------------------
-If you just have setup Crowdin and you ship translated xlf files within your extension, those will be shown as well as to be translated.
 
-You need to exlude those in your `.crowdin.yaml` configuration which can be found in the extension root directory.
+If you have just set up Crowdin and ship translated XLIFF files in your
+extension, they will also show up as files to be translated.
 
-.. code-block:: yaml
+You need to exclude them in your :file:`crowdin.yml` configuration, which is
+located in the extension root directory.
+
+..  code-block:: yaml
+    :caption: EXT:my_extension/crowdin.yml
 
     files:
       - source: /Resources/Private/Language/
@@ -89,11 +101,33 @@ You need to exlude those in your `.crowdin.yaml` configuration which can be foun
         ignore:
           - /Resources/Private/Language/de.*
 
-.. important::
+..  attention::
+    You should remove the translations from your extension as those will be
+    provided by the translation server.
 
-   In the long run, you should remove the translations from your extension as those will be provided by the translation server.
+..  seealso::
+    `Crowdin configuration file <https://support.crowdin.com/configuration-file/>`__
 
-More information can be found in the documentation on crowdin: https://support.crowdin.com/configuration-file/
+
+..  index:: Crowdin; Upload XLIFF files
+..  _crowdin-faq-upload-xliff-files:
+
+Can I upload translated XLIFF files?
+------------------------------------
+
+Yes, you can! Switch to the settings area of your project (you need to have the
+proper permissions for that) and you can upload XLIFF files or even ZIP files
+containing the XLIFF files.
+
+..  figure:: /Images/ExternalImages/Crowdin/Upload.png
+    :alt: Upload translations
+    :class: with-shadow
+
+    Upload translations
+
+After triggering the upload, Crowdin tries to find the matching source files and
+target languages. You may have to accept both if they are not found
+automatically.
 
 
 ..  index:: Crowdin; Migration from Pootle
@@ -101,63 +135,75 @@ More information can be found in the documentation on crowdin: https://support.c
 
 How can I migrate translations from Pootle?
 -------------------------------------------
-If translations existed on Pootle, there is no need to retranslate everything on Crowdin again - you can import those.
+
+If there were already translations on the old, discontinues translation server
+powered by Pootle, you do not need to translate everything again on Crowdin -
+you can import them.
+
+#.  **Fetch translations:**
+    Download the translations you need. You will need to download them directly
+    from the :abbr:`TER (TYPO3 Extension Repository)` with the following URL
+    pattern:
+
+    :samp:`https://extensions.typo3.org/fileadmin/ter/<e>/<x>/<extension_key>-l10n/<extension_key>-l10n-<lang>.zip`
+
+    `<extension_key>`
+        The full extension key.
+
+    `<e>`
+        The first letter of that extension key.
+
+    `<x>`
+        The second letter of that extension key.
+
+    `<lang>`
+        The `ISO 639-1 code`_ of the language, for example, `de` for German.
+
+    For example, to download the German translations of the *news* extension:
+
+    ..  code-block:: bash
+
+        wget https://extensions.typo3.org/fileadmin/l10n/n/e/news-l10n/news-l10n-de.zip
+
+    ..  _ISO 639-1 code: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 
 
-#. **Fetch translations**
-   Download the translations you need. You will need to download them directly from the TER with the following URL pattern:
+#.  **Open and Cleanup:**
+    Unzip the translations and switch to, for example,
+    :file:`Resources/Private/Language/` which is the typical directory
+    of translations. Remove the :file:`.xml` files as only the :file:`.xlf`
+    files are important.
 
-   :samp:`https://extensions.typo3.org/fileadmin/ter/<e>/<x>/<extension_key>-l10n/<extension_key>-l10n-<lang>.zip`
+#.  **Match the files**
+    The attribute :xml:`original` of the translations must match the ones of the
+    default translations.
 
-   Here `<extension_key>` is the full extension key, `<e>` the 1st and `<x>` the 2nd letter of that extension key.
-   Finally `<lang>` is the 2-lettered language identifier, e.g. `de`.
+    **Example**: The file :file:`Resources/Private/Language/locallang.xlf`
+    starts with the following snippet:
 
-   For example to download the German translations of the extension *powermail*:
-   `wget 'https://extensions.typo3.org/fileadmin/ter/p/o/powermail-l10n/powermail-l10n-de.zip'`
+    ..  code-block:: xml
 
-#. **Open and Cleanup**
-   Unzip the translations and switch to e.g. `Resources/Private/Language` which is the typical directory
-   of translations. Remove the *xml* files as only the *xlf* files are important.
+        <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+            <xliff version="1.0">
+                <file source-language="en" datatype="plaintext" original="EXT:news/Resources/Private/Language/locallang.xlf">
 
-#. **Match the Files**
-   The attribute `original` of the translations must match the ones of the default translations.
-   **Example**: The file :file:`Resources/Private/Language/locallang.xlf` starts with the following snippet:
+    The file :file:`de.locallang.xlf` must be modified and
+    :xml:`original="messages"` must be changed to
+    :xml:`original="EXT:news/Resources/Private/Language/locallang.xlf"`
 
-   .. code-block:: xml
-
-      <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-         <xliff version="1.0">
-            <file source-language="en" datatype="plaintext" original="EXT:powermail/Resources/Private/Language/locallang.xlf">
-
-   The file :file:`de.locallang.xlf` must be modified and `original="messages"` must be changed to `original="EXT:powermail/Resources/Private/Language/locallang.xlf"`
-
-#. **Upload the Translations**
-   Just keep on reading the next question.
+#.  **Upload the Translations**
+    Have a look at :ref:`crowdin-faq-upload-xliff-files`.
 
 
-.. index:: Crowdin; Upload xlf files
-
-Can I upload translated xlf files?
-----------------------------------
-Yes, you can! Switch to the settings area of your project (you need to have the proper permissions for that) and you can upload xlf files or even zip files containg the xlf files.
-
-.. figure:: /Images/ExternalImages/Crowdin/Upload.png
-   :alt: Upload translations
-   :width: 600px
-
-   Upload translations
-
-After triggering the upload Crowdin tries to find the matching source files and the target languages.
-It might be that you need to adopt both if not found automatically.
-
-
-
-Questions about TYPO3 CMS core integration
-==========================================
+Questions about TYPO3 Core integration
+======================================
 
 .. _crowdin-faq-duplicated-labels:
 
 The Core Team added a new system extension. Why are language packs not available even though it has already been translated into language XY?
 ---------------------------------------------------------------------------------------------------------------------------------------------
-The new system extension needs to be added to the configuration of https://github.com/TYPO3/crowdin-bridge/. You can speed up the change by creating
-a pull request like this one https://github.com/TYPO3/crowdin-bridge/pull/6/commits
+
+The new system extension needs to be added to the configuration of
+https://github.com/TYPO3/crowdin-bridge/. You can speed up the change by
+creating a pull request like this one:
+https://github.com/TYPO3/crowdin-bridge/pull/6/commits.


### PR DESCRIPTION
Mainly:
- Move questions about Pootle to the end of the sections
- Use PhpStorm in example on how to adjust XLIFF file instead KDE Kate editor as it should be more common.
- Use "crowdin.yml" instead of ".crowdin.yaml" file as this is the default.

Releases: main, 12.4, 11.5