### PR TITLE
[Backport 11.5] [TASK] Revise "Custom translation servers" chapter (#3443)

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePackRemoteBaseUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Install/ModifyLanguagePackRemoteBaseUrlEvent.rst
@@ -7,7 +7,29 @@
 ModifyLanguagePackRemoteBaseUrlEvent
 ====================================
 
-Event to modify the main URL of a language.
+The PSR-14 event
+:php:`\TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent`
+allows to modify the main URL of a language pack.
+
+..  seealso::
+    :ref:`custom-translation-server`
+
+Example
+=======
+
+Registration of the event listener in the extension's :file:`Services.yaml`:
+
+..  literalinclude:: _ModifyLanguagePackRemoteBaseUrlEvent/_Services.yaml
+    :language: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
+
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+
+The corresponding event listener class:
+
+..  literalinclude:: _ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
+    :language: php
+    :caption: EXT:my_extension/Classes/EventListener/CustomMirror.php
 
 API
 ---

--- a/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
+++ b/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\EventListener;
+
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent;
+
+final class CustomMirror
+{
+    private const EXTENSION_KEY = 'my_extension';
+    private const MIRROR_URL = 'https://example.org/typo3-packages/';
+
+    public function __invoke(ModifyLanguagePackRemoteBaseUrlEvent $event): void
+    {
+        if ($event->getPackageKey() === self::EXTENSION_KEY) {
+            $event->setBaseUrl(new Uri(self::MIRROR_URL));
+        }
+    }
+}

--- a/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_Services.yaml
@@ -1,0 +1,7 @@
+services:
+  # Place here the default dependency injection configuration
+
+  MyVendor\MyExtension\EventListener\CustomMirror:
+    tags:
+      - name: event.listener
+        identifier: 'my-extension/custom-mirror'

--- a/Documentation/ApiOverview/Localization/TranslationServer/Custom.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Custom.rst
@@ -1,98 +1,57 @@
-.. include:: /Includes.rst.txt
-.. index:: Localization; Custom translation servers
-.. _custom-translation-server:
+..  include:: /Includes.rst.txt
+..  index:: Localization; Custom translation servers
+..  _custom-translation-server:
 
 ==========================
 Custom translation servers
 ==========================
 
-With the usage of XLIFF and the freely available `Pootle <https://pootle.translatehouse.org/>`__
-translation server, companies and individuals may easily set up a custom translation server
-for their extensions.
+With the usage of :ref:`XLIFF <xliff>` and the freely available `Pootle`_
+translation server, companies and individuals may easily set up a custom
+translation server for their extensions.
 
-There is an event that can be caught to change the translation server URL to use. The first
-step is to register one's listener for the event. Such code would be placed in an
-extension's :file:`services.yml` file:
+..  _Pootle: http://pootle.translatehouse.org/
 
-.. code-block:: php
+The event :ref:`ModifyLanguagePackRemoteBaseUrlEvent` can be caught to change
+the translation server URL. The first step is to register your custom listener
+for the event. Such code would be placed in an extension's :file:`Services.yml`
+file:
 
-   services:
-     Company\Extensions\Listener\CustomMirror:
-       tags:
-         - name: event.listener
-           identifier: 'ext-extensions/customMirror'
-           method: 'postProcessMirrorUrl'
-           event: \TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent
+..  literalinclude:: /ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_Services.yaml
+    :language: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
 
+Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
 
-The class (listener) which receives the event
-(:file:`EXT:extensions/Classes/Listeners/CustomMirror.php`) could look something like:
+The class (listener) that receives the event might look something like this:
 
-.. code-block:: php
+..  literalinclude:: /ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
+    :language: php
+    :caption: EXT:my_extension/Classes/EventListener/CustomMirror.php
 
-   <?php
-   namespace Company\Extensions\Listener;
-   use \TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent;
-   class CustomMirror {
-      static protected $extensionKey = 'myext';
-
-      public function postProcessMirrorUrl(ModifyLanguagePackRemoteBaseUrlEvent $event): void
-      {
-         if ($event->getPackageKey() === self::$extensionKey) {
-            $mirrorUrl = 'https://example.org/typo3-packages/';
-            $event->setBaseUrl($mirrorUrl);
-         }
-      }
-   }
-
-In the above example, the URL is changed only for a given
-extension, but of course it could be changed on a more general basis.
+In the above example, the URL is changed only for a given extension, but of
+course it could be changed on a more general basis.
 
 On the custom translation server side, the structure needs to be:
 
-.. code-block:: text
+..  code-block:: text
 
-   https://example.org/typo3-packages/
-   `-- <first-letter-of-extension-key>
-      `-- <second-letter-of-extension-key>
-         `-- <extension-key>-l10n
-            |-- <extension-key>-l10n-de.zip
-            |-- <extension-key>-l10n-fr.zip
-            |-- <extension-key>-l10n-it.zip
-            `-- <extension-key>-l10n.xml
+    https://example.org/typo3-packages/
+    `-- <first-letter-of-extension-key>
+        `-- <second-letter-of-extension-key>
+            `-- <extension-key>-l10n
+                |-- <extension-key>-l10n-de.zip
+                |-- <extension-key>-l10n-fr.zip
+                `-- <extension-key>-l10n-it.zip
 
 hence in our example:
 
-.. code-block:: text
+..  code-block:: text
 
-   https://example.org/typo3-packages/
-   `-- m
-      `-- y
-         `-- myext-l10n
-            |-- myext-l10n-de.zip
-            |-- myext-l10n-fr.zip
-            |-- myext-l10n-it.zip
-            `-- myext-l10n.xml
-
-And the :file:`myext-l10n.xml` file contains something like:
-
-.. code-block:: xml
-
-   <?xml version="1.0" standalone="yes" ?>
-   <TERlanguagePackIndex>
-      <meta>
-         <timestamp>1374841386</timestamp>
-         <date>2013-07-26 14:23:06</date>
-      </meta>
-      <languagePackIndex>
-         <languagepack language="de">
-            <md5>1cc7046c3b624ba1fb1ef565343b84a1</md5>
-         </languagepack>
-         <languagepack language="fr">
-            <md5>f00f73ae5c43cb68392e6c508b65de7a</md5>
-         </languagepack>
-         <languagepack language="it">
-            <md5>cd59530ce1ee0a38e6309544be6bcb3d</md5>
-         </languagepack>
-      </languagePackIndex>
-   </TERlanguagePackIndex>
+    https://example.org/typo3-packages/
+    `-- m
+        `-- y
+            `-- my_extension-l10n
+                |-- my_extension-l10n-de.zip
+                |-- my_extension-l10n-fr.zip
+                `-- my_extension-l10n-it.zip


### PR DESCRIPTION
- The example was reworked as it had errors (like setBaseUrl() expects an Uri object, not a string).
- The XML file ("TERlanguagePackIndex") is not available anymore.
- The example for the event is now also available on the ModifyLanguagePackRemoteBaseUrlEvent page.

Releases: main, 12.4, 11.5