### PR TITLE
Update RestrictAccessToFiles.rst

### DIFF
--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -86,7 +86,7 @@ and common package files like :file:`composer.json`.
 This "black list" approach needs maintenance: The Core Team tries to keep the template files
 :file:`.htaccess` and :file:`web.config` updated. If running Apache or IIS, administrators
 should compare their specific version with the reference files found at
-:t3src:`install/Resources/Private/FolderStructureTemplateFiles/root-htaccess>`
+:t3src:`install/Resources/Private/FolderStructureTemplateFiles/root-htaccess`
 and :t3src:`install/Resources/Private/FolderStructureTemplateFiles/root-web-config`
 and adapt or update local versions if needed.
 


### PR DESCRIPTION
Fix broken link which included a > character at the end of the link.

This also applies to the 12.4 tag.