### PR TITLE
[TASK] Deprecate $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -633,6 +633,10 @@ defaultUserTSconfig
 defaultPageTSconfig
 ===================
 
+..  deprecated:: 13.0
+    This setting will be ignored with TYPO3 v14.0.
+    Use :ref:`Configuration/page.tsconfig <extension-configuration-page_tsconfig>` instead.
+
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPageTSconfig']
 
    :type: text


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/642
Releases: main