### PR TITLE
[TASK] Revise "Ajax in the backend" chapter (#3471)

### DIFF
--- a/Documentation/ApiOverview/Backend/Ajax.rst
+++ b/Documentation/ApiOverview/Backend/Ajax.rst
@@ -1,174 +1,101 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Ajax; Backend
-.. _ajax-backend:
+..  include:: /Includes.rst.txt
+..  index:: pair: Ajax; Backend
+..  _ajax-backend:
 
 ===================
-Ajax in the Backend
+Ajax in the backend
 ===================
 
-An Ajax endpoint in the TYPO3 backend is usually implemented as a method in a regular controller. The method receives a
-request object implementing the :php:`Psr\Http\Message\ServerRequestInterface`, which allows to access all aspects of
-the requests and returns an appropriate response in a normalized way. This approach is standardized as `PSR-7`_.
+An Ajax endpoint in the TYPO3 backend is usually implemented as a method in a
+regular controller. The method receives a request object implementing the
+:php:`\Psr\Http\Message\ServerRequestInterface`, which allows to access all
+aspects of the requests and returns an appropriate response in a normalized way.
+This approach is standardized as `PSR-7`_.
 
 ..  seealso::
     You can find information on how to handle Ajax requests in the frontend
     in the chapter :ref:`Ajax in the Extension Development section <ajax-client-side>`.
 
-.. index:: pair: Ajax; Controller
+..  index:: pair: Ajax; Controller
 
 Create a controller
 ===================
 
-By convention, a controller is placed within the extension's :file:`Controller` directory, optionally in a subdirectory.
-To have such controller, create a new :php:`ExampleController` in :file:`Classes/Controller/ExampleController.php`
+By convention, a controller is placed within the extension's :file:`Controller/`
+directory, optionally in a subdirectory. To have such controller, create a new
+:php:`ExampleController` in :file:`Classes/Controller/ExampleController.php`
 inside your extension.
 
-The controller doesn't need that much logic right now. We'll create a method called :php:`doSomethingAction()` which
-will be our Ajax endpoint.
+The controller needs not that much logic right now. We create a method called
+:php:`doSomethingAction()` which will be our Ajax endpoint.
 
-.. code-block:: php
+..  literalinclude:: _Ajax/_ExampleController1.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
-   <?php
-   declare(strict_types = 1);
+In its current state, the method does nothing yet. We can add a very generic
+handling that exponentiates an incoming number by 2. The incoming value will be
+passed as a query string argument named `input`.
 
-   namespace MyVendor\MyExtension\Controller;
+..  literalinclude:: _Ajax/_ExampleController2.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
-   use Psr\Http\Message\ResponseInterface;
-   use Psr\Http\Message\ServerRequestInterface;
-
-   class ExampleController
-   {
-       public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
-       {
-           // TODO: return ResponseInterface
-       }
-   }
+..  note::
+    This is a really simple example. Something like this should not be used in
+    production, as such a feature is available via JavaScript as well.
 
 
-In its current state, the method doesn't do anything yet. We can add a very generic handling that exponentiates an
-incoming number by 2. The incoming value will be passed as a query string argument named `input`.
+We have computed our result by using the `exponentiation operator`_, but we
+do nothing with it yet. It is time to build a proper response:
 
-.. code-block:: php
-
-   public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
-   {
-       $input = $request->getQueryParams()['input'] ?? null;
-       if ($input === null) {
-           throw new \InvalidArgumentException('Please provide a number', 1580585107);
-       }
-
-       $result = $input ** 2;
-       // TODO: return ResponseInterface
-   }
+..  literalinclude:: _Ajax/_ExampleController3.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
 
-.. note::
-   This is a really simple example. Something like this should not be used in production, as such feature is available
-   in JavaScript as well.
-
-
-We have computed our result by using the `exponentiation operator`_, but we don't do anything with it yet. It's time to
-build a proper response. A response implements the :php:`Psr\Http\Message\ResponseInterface` and its constructor
-accepts the following arguments:
-
-.. rst-class:: dl-parameters
-
-$body
-   :sep:`|` :aspect:`Condition:` required
-   :sep:`|` :aspect:`Type:` string
-   :sep:`|`
-
-   The content of the response.
-
-$statusCode
-   :sep:`|` :aspect:`Condition:` optional
-   :sep:`|` :aspect:`Type:` int
-   :sep:`|` :aspect:`Default:` 200
-   :sep:`|`
-
-   The HTTP status code of the response. The default of `200` means `OK`.
-
-$headers
-   :sep:`|` :aspect:`Condition:` optional
-   :sep:`|` :aspect:`Type:` array
-   :sep:`|` :aspect:`Default:` '[]'
-   :sep:`|`
-
-   Headers to be sent with the response.
-
-$reasonPhrase
-   :sep:`|` :aspect:`Condition:` optional
-   :sep:`|` :aspect:`Type:` string
-   :sep:`|` :aspect:`Default:` ''
-   :sep:`|`
-
-   A reason for the given status code. If omitted, the default for the used status code will be used.
-
-.. code-block:: php
-
-   use Psr\Http\Message\ResponseFactoryInterface;
-   
-   public function __construct(
-       private readonly ResponseFactoryInterface $responseFactory
-   ) {
-   }
-
-   public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
-   {
-       // our previous computation
-       $response = $this->responseFactory->createResponse()
-           ->withHeader('Content-Type', 'application/json; charset=utf-8');
-       $response->getBody()->write(json_encode(['result' => $result], JSON_THROW_ON_ERROR));
-       return $response;
-   }
-
-.. index:: Ajax; Endpoint
-.. index:: Ajax; Routes
-.. index:: File; EXT:{extkey}/Configuration/Backend/AjaxRoutes.php
+..  index:: Ajax; Endpoint
+..  index:: Ajax; Routes
+..  index:: File; EXT:{extkey}/Configuration/Backend/AjaxRoutes.php
 
 Register the endpoint
 =====================
 
-The endpoint must be registered as route. Create a file called :file:`Configuration/Backend/AjaxRoutes.php` in your
-extension. The file basically just returns an array of route definitions. Every route in this file will be exposed to
-JavaScript automatically. Let's register our endpoint now:
+The endpoint must be registered as :ref:`route <backend-routing>`. Create a
+file called :file:`Configuration/Backend/AjaxRoutes.php` in your extension. The
+file basically just returns an array of route definitions. Every route in this
+file will be exposed to JavaScript automatically. Let us register our endpoint
+now:
 
-.. include:: /CodeSnippets/Manual/Extension/Configuration/BackendAjaxRoutes.rst.txt
+..  literalinclude:: _Ajax/_AjaxRoutes.php
+    :language: php
+    :caption: EXT:my_extension/Configuration/Backend/AjaxRoutes.php
 
+The naming of the key `myextension_example_dosomething` and path
+`/my-extension/example/do-something` are up to you, but should contain the
+extension name, controller name and action name to avoid potential conflicts
+with other existing routes.
 
-The naming of the key `example_dosomething` and path `/example/do-something` are up to you, but should contain the
-controller name and action name to avoid potential conflicts with other existing routes.
-
-For further reading, take a look at :ref:`backend-routing`.
-
-.. attention::
-   Flushing caches is mandatory after modifying any route definition.
+..  attention::
+    Flushing caches is mandatory after modifying any route definition.
 
 
 Use in Ajax
 ===========
 
-Since the route is registered in :file:`AjaxRoutes.php` its exposed to JavaScript now and stored in the global
-:js:`TYPO3.settings.ajaxUrls` object identified by the used key in the registration. In this example it's
-:js:`TYPO3.settings.ajaxUrls.example_dosomething`.
+Since the route is registered in :file:`AjaxRoutes.php` it is exposed to
+JavaScript now and stored in the global :js:`TYPO3.settings.ajaxUrls` object
+identified by the used key in the registration. In this example it is
+:js:`TYPO3.settings.ajaxUrls.myextension_example_dosomething`.
 
-You are now free to use the endpoint in any of your Ajax calls. To complete this example, we'll ask the server to
-compute our input and write the result into the console.
+Now you are free to use the endpoint in any of your Ajax calls. To complete this
+example, we will ask the server to compute our input and write the result into
+the console.
 
-.. code-block:: js
-
-   import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
-
-   // Generate a random number between 1 and 32
-   const randomNumber = Math.ceil(Math.random() * 32);
-   new AjaxRequest(TYPO3.settings.ajaxUrls.example_dosomething)
-     .withQueryArguments({input: randomNumber})
-     .get()
-     .then(async function (response) {
-     const resolved = await response.resolve();
-     console.log(resolved.result);
-   });
+..  literalinclude:: _Ajax/_Calculate.js
+    :language: js
+    :caption: EXT:my_extension/Resources/Public/JavaScript/Calculate.js
 
 
-.. _`PSR-7`: https://www.php-fig.org/psr/psr-7/
-.. _`exponentiation operator`: https://www.php.net/manual/en/language.operators.arithmetic.php
+..  _`PSR-7`: https://www.php-fig.org/psr/psr-7/
+..  _`exponentiation operator`: https://www.php.net/manual/en/language.operators.arithmetic.php

--- a/Documentation/ApiOverview/Backend/_Ajax/_AjaxRoutes.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_AjaxRoutes.php
@@ -1,0 +1,10 @@
+<?php
+
+use MyVendor\MyExtension\Controller\ExampleController;
+
+return [
+    'myextension_example_dosomething' => [
+        'path' => '/my-extension/example/do-something',
+        'target' => ExampleController::class . '::doSomethingAction',
+    ],
+];

--- a/Documentation/ApiOverview/Backend/_Ajax/_Calculate.js
+++ b/Documentation/ApiOverview/Backend/_Ajax/_Calculate.js
@@ -1,0 +1,11 @@
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+
+// Generate a random number between 1 and 32
+const randomNumber = Math.ceil(Math.random() * 32);
+new AjaxRequest(TYPO3.settings.ajaxUrls.myextension_example_dosomething)
+  .withQueryArguments({input: randomNumber})
+  .get()
+  .then(async function (response) {
+    const resolved = await response.resolve();
+    console.log(resolved.result);
+  });

--- a/Documentation/ApiOverview/Backend/_Ajax/_ExampleController1.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_ExampleController1.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ExampleController
+{
+    public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
+    {
+        // TODO: return ResponseInterface
+    }
+}

--- a/Documentation/ApiOverview/Backend/_Ajax/_ExampleController2.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_ExampleController2.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ExampleController
+{
+    public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $input = $request->getQueryParams()['input']
+            ?? throw new \InvalidArgumentException(
+                'Please provide a number',
+                1580585107
+            );
+
+        $result = $input ** 2;
+
+        // TODO: return ResponseInterface
+    }
+}

--- a/Documentation/ApiOverview/Backend/_Ajax/_ExampleController3.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_ExampleController3.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ExampleController
+{
+    public function __construct(
+        private readonly ResponseFactoryInterface $responseFactory
+    ) {}
+
+    public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
+    {
+        $input = $request->getQueryParams()['input']
+            ?? throw new \InvalidArgumentException(
+                'Please provide a number',
+                1580585107
+            );
+
+        $result = $input ** 2;
+
+        $response = $this->responseFactory->createResponse()
+            ->withHeader('Content-Type', 'application/json; charset=utf-8');
+        $response->getBody()->write(
+            json_encode(['result' => $result], JSON_THROW_ON_ERROR)
+        );
+        return $response;
+    }
+}


### PR DESCRIPTION
- Move PHP/JS snippets into separate files
- Recommend to add the extension name to the route key for better uniqueness
- Substitute included BackendAjaxRoutes.rst.txt with a custom one to be in-line with the PHP controller example namespace (the BackendAjaxRoutes.rst.txt is still in use in another place)

Related: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/2331
Releases: main, 12.4