### PR TITLE
[BUGFIX] Correct mentioned hooks for FlexForm events

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -10,7 +10,7 @@ AfterFlexFormDataStructureIdentifierInitializedEvent
 ..  versionadded:: 12.0
     This event was introduced to replace and improve the method
     :php:`parseDataStructureByIdentifierPostProcess()` of the hook
-    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['workspaces']['modifyDifferenceArray']`.
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing']`.
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureIdentifierInitializedEvent`

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureParsedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureParsedEvent.rst
@@ -10,7 +10,7 @@ AfterFlexFormDataStructureParsedEvent
 ..  versionadded:: 12.0
     This event was introduced to replace and improve the method
     :php:`getDataStructureIdentifierPostProcess()` of the hook
-    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['workspaces']['modifyDifferenceArray']`.
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing']`.
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Configuration\Event\AfterFlexFormDataStructureParsedEvent`

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -10,7 +10,7 @@ BeforeFlexFormDataStructureIdentifierInitializedEvent
 ..  versionadded:: 12.0
     This event was introduced to replace and improve the method
     :php:`getDataStructureIdentifierPreProcess()` of the hook
-    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['workspaces']['modifyDifferenceArray']`.
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing']`.
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureIdentifierInitializedEvent`

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureParsedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeFlexFormDataStructureParsedEvent.rst
@@ -10,7 +10,7 @@ BeforeFlexFormDataStructureParsedEvent
 ..  versionadded:: 12.0
     This event was introduced to replace and improve the method
     :php:`parseDataStructureByIdentifierPreProcess()` of the hook
-    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['workspaces']['modifyDifferenceArray']`.
+    :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'][FlexFormTools::class]['flexParsing']`.
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureParsedEvent`


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/672
Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97449-PSR-14EventsForModifyingFlexFormParsing.html
See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/75158/24/typo3/sysext/core/Classes/Configuration/FlexForm/FlexFormTools.php
Releases: main, 12.4