### PR TITLE
[BUGFIX] Remove unavailable include from IsContentUsedOnPageLayoutEvent page

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -32,8 +32,6 @@ The corresponding event listener class:
     :language: php
     :caption: EXT:my_extension/Classes/Listener/ContentUsedOnPage.php
 
-..  include:: /_includes/EventsAttributeAdded.rst.txt
-
 API
 ===
 


### PR DESCRIPTION
This got accidentally merged from v13 and is not available in v12.

Releases: 12.4