### PR TITLE
[TASK] #102043 - Adjust namespace for InMemoryTransport/InMemoryTransportFactory

### DIFF
--- a/Documentation/ApiOverview/MessageBus/Index.rst
+++ b/Documentation/ApiOverview/MessageBus/Index.rst
@@ -217,7 +217,7 @@ The TYPO3 Core has been tested with three transports:
     (default)
 *   :php:`\Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport`
     (using the Doctrine DBAL messenger transport)
-*   :php:`\Symfony\Component\Messenger\Transport\InMemoryTransport`
+*   :php:`\Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport`
     (for testing)
 
 

--- a/Documentation/ApiOverview/MessageBus/_custom-transport.yaml
+++ b/Documentation/ApiOverview/MessageBus/_custom-transport.yaml
@@ -11,8 +11,8 @@ messenger.transport.demo:
       identifier: 'demo'
 
 messenger.transport.default:
-  factory: [ '@Symfony\Component\Messenger\Transport\InMemoryTransportFactory', 'createTransport' ]
-  class: 'Symfony\Component\Messenger\Transport\InMemoryTransport'
+  factory: [ '@Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory', 'createTransport' ]
+  class: 'Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport'
   arguments:
     $dsn: 'in-memory://default'
     $options: [ ]

--- a/Documentation/ApiOverview/MessageBus/_in-memory-transport.yaml
+++ b/Documentation/ApiOverview/MessageBus/_in-memory-transport.yaml
@@ -1,6 +1,6 @@
 messenger.transport.default:
-  factory: [ '@Symfony\Component\Messenger\Transport\InMemoryTransportFactory', 'createTransport' ]
-  class: 'Symfony\Component\Messenger\Transport\InMemoryTransport'
+  factory: [ '@Symfony\Component\Messenger\Transport\InMemory\InMemoryTransportFactory', 'createTransport' ]
+  class: 'Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport'
   public: true
   arguments:
     $dsn: 'in-memory://default'


### PR DESCRIPTION
TYPO3 in main/12.4 now requires Symfony 6.3, since this version the namespace for the mentioned classes has been changed.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/673
Releases: main, 12.4