### PR TITLE
[Backport 11.5] [TASK] Add admonition about using Extbase in CLI context (#3495)

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -17,6 +17,14 @@ These commands can also be run from the TYPO3
 :ref:`scheduler <symfony-console-commands-scheduler>` if this option is not
 disabled in the :file:`Configuration/Services.yaml`.
 
+..  attention::
+    Using :ref:`Extbase <extbase>` repositories in CLI context is not
+    recommended as Extbase relies on frontend :ref:`TypoScript <t3tsref:start>`.
+    For example,
+    :ref:`conditions using the request object <t3tsref:condition-function-request>`
+    may cause problems. Use the :ref:`query builder <database-query-builder>`
+    or :ref:`DataHandler <tce-database-basics>` where appropriate.
+
 .. _symfony-console-commands-cli:
 
 Run a command from the command line


### PR DESCRIPTION
Related: https://typo3.slack.com/archives/C025BQLFA/p1695726759085809
Releases: main, 12.4, 11.5