### PR TITLE
[TASK] Emphasize query builder reuse is considered harmful

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -70,13 +70,17 @@ injected via :ref:`dependency injection <DependencyInjection>`.
     dependency injection or :php:`GeneralUtility::makeInstance()`, otherwise you
     will miss essential dependencies and runtime setup.
 
-..  note::
-    The QueryBuilder holds internal state and should not be reused for
-    different queries: Use one query builder per query. Get a fresh one by
-    calling :php:`$connection->createQueryBuilder()` if the same table is
+..  warning::
+    The QueryBuilder holds internal state and must not be reused for
+    different queries. In addition, a reuse comes with a
+    `significant performance penalty and memory consumption`_.
+    **Use one query builder per query.** Get a fresh one by calling
+    :php:`$connection->createQueryBuilder()` if the same table is
     involved, or use :php:`$connectionPool->getQueryBuilderForTable()` for a
-    query to a different table. Don't worry, creating those object instances
+    query to a different table. Do not worry, creating those object instances
     is quite fast.
+
+..  _significant performance penalty and memory consumption: https://www.derhansen.de/2023/10/the-pitfalls-of-reusing-typo3-querybuilder-analyzing-a-performance-bottleneck.html
 
 
 ..  _database-query-builder-select:


### PR DESCRIPTION
Use a warning to emphasize not to reuse a query builder instance. Additionally, add results from blog post by Torben Hansen.

Releases: main, 12.4, 11.5