### PR TITLE
[DOCS] Change non-existant API `all` method to `getAll`

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -143,7 +143,7 @@ or even fetching all settings:
 
 ..  code-block:: php
 
-    $siteSettings->all();
+    $siteSettings->getAll();
 
 API
 ---


### PR DESCRIPTION
The SiteSettings API method name is `getAll()` and not just `all`.