### PR TITLE
[Backport 11.5] [BUGFIX] Correct method name AjaxRequest.withQueryArguments in text (#3513)

### DIFF
--- a/Documentation/ApiOverview/Backend/AjaxClientSide.rst
+++ b/Documentation/ApiOverview/Backend/AjaxClientSide.rst
@@ -27,7 +27,7 @@ create a new instance of :js:`AjaxRequest` per request and pass the url as the c
 
    let request = new AjaxRequest('https://example.org/my-endpoint');
 
-The API offers a method :js:`withQueryString()` which allows to attach a query string to the URL. This comes in handy if
+The API offers a method :js:`withQueryArguments()` which allows to attach a query string to the URL. This comes in handy if
 the query string is programmatically generated. The method returns a clone of the :js:`AjaxRequest` object. It's possible
 to pass either strings, arrays or objects as an argument.
 


### PR DESCRIPTION
The example below the text uses the correct method name.

See: https://github.com/TYPO3/typo3/blob/12.4/Build/Sources/TypeScript/core/ajax/ajax-request.ts#L52
Releases: main, 12.4, 11.5