### PR TITLE
[FEATURE] #101970 - Ajax API accepts native URL and URLSearchParams objects as arguments

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/Index.rst
@@ -13,6 +13,9 @@ example, Chrome, Edge, Firefox, Safari).
 Prepare a request
 =================
 
+..  versionadded:: 13.0
+    Native URL-related objects (:js:`URL` and :js:`URLSearchParams`) can be used.
+
 To be able to send a request, the module :js:`@typo3/core/ajax/ajax-request.js`
 must be imported. To prepare a request, create a new instance of
 :js:`AjaxRequest` per request and pass the URL as the constructor argument:

--- a/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/_MyRequest1.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/_MyRequest1.js
@@ -1,3 +1,7 @@
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 
-let request = new AjaxRequest('https://example.org/my-endpoint');
+let url = 'https://example.org/my-endpoint';
+// or:
+let url = new URL('https://example.org/my-endpoint');
+
+let request = new AjaxRequest(url);

--- a/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/_MyRequest2.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/_MyRequest2.js
@@ -2,12 +2,20 @@ import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 
 let request = new AjaxRequest('https://example.org/my-endpoint');
 
-const qs = {
+let queryArguments = {
   foo: 'bar',
   bar: {
     baz: ['foo', 'bencer']
   }
 };
-request = request.withQueryArguments(qs);
+// or:
+let queryArguments = new URLSearchParams({
+  foo: 'bar',
+  baz: {
+    baz: ['foo', 'bencer']
+  }
+});
+
+request = request.withQueryArguments(queryArguments);
 
 // The query string compiles to ?foo=bar&bar[baz][0]=foo&bar[baz][1]=bencer


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/665
Releases: main