### PR TITLE
[TASK] Remove examples from site confiuration events

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationBeforeWriteEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationBeforeWriteEvent.rst
@@ -20,14 +20,7 @@ before writing the configuration to disk.
 Example
 =======
 
-To register an event listener to the new event, use the following code in your
-:file:`Services.yaml`:
-
-..  literalinclude:: _SiteConfigurationBeforeWriteEvent/_Services.yaml
-    :language: yaml
-    :caption: EXT:my_extension/Configuration/Services.yaml
-
-Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
@@ -20,14 +20,7 @@ before loading the configuration.
 Example
 =======
 
-To register an event listener to the new event, use the following code in your
-:file:`Services.yaml`:
-
-..  literalinclude:: _SiteConfigurationLoadedEvent/_Services.yaml
-    :language: yaml
-    :caption: EXT:my_extension/Configuration/Services.yaml
-
-Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
+..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationBeforeWriteEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationBeforeWriteEvent/_Services.yaml
@@ -1,7 +1,0 @@
-services:
-  # Place here the default dependency injection configuration
-
-  MyVendor\MyExtension\Configuration\EventListener\MyEventListener:
-    tags:
-      - name: event.listener
-        identifier: 'my-extension/site-configuration-before-write'

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_Services.yaml
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_Services.yaml
@@ -1,7 +1,0 @@
-services:
-  # Place here the default dependency injection configuration
-
-  MyVendor\MyExtension\Configuration\EventListener\MyEventListener:
-    tags:
-      - name: event.listener
-        identifier: 'my-extension/site-configuration-loaded'


### PR DESCRIPTION
Only the registration via Services.yaml is not really helpful for users. Also an example for the event listener was not given in the according changelogs. So, the Services.yaml snippets were removed.

Releases: main, 12.4