### PR TITLE
fix regular expression example

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -177,7 +177,7 @@ The configuration looks like this:
           tag: ''
         requirements:
           category_id: '[0-9]{1,3}'
-          tag: '[a-zA-Z0-9].*'
+          tag: '[a-zA-Z0-9]+'
         _arguments:
           category_id: 'category'
 


### PR DESCRIPTION
"Benni" is found, but also "B e n n i" and "b&".