### PR TITLE
[TASK] Run "composer normalize" in current version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "typo3/cms-core": "dev-main as 12.1"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "^2.34",
+        "ergebnis/composer-normalize": "~2.39.0",
         "symfony/yaml": "^6.2",
         "t3docs/blog-example": "dev-main",
         "t3docs/codesnippet": "dev-main",
@@ -55,9 +55,9 @@
     "prefer-stable": true,
     "config": {
         "allow-plugins": {
-            "typo3/cms-composer-installers": true,
+            "ergebnis/composer-normalize": true,
             "typo3/class-alias-loader": true,
-            "ergebnis/composer-normalize": true
+            "typo3/cms-composer-installers": true
         },
         "bin-dir": ".Build/bin",
         "sort-packages": true,


### PR DESCRIPTION
Additionally, to avoid running in validation errors on CI on further updates of the composer-normalize package the version is bound to the minor version. This has then to be adjusted manually.

Releases: main, 12.4