### PR TITLE
[TASK] Adjust ModifyPageLayoutContentEvent page

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -7,6 +7,10 @@ ModifyPageLayoutContentEvent
 =============================
 
 ..  versionadded:: 12.0
+    This event serves as a replacement for the removed hooks:
+
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook']`
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']`
 
 The PSR-14 event :php:`\TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent`
 allows to modify page module content.
@@ -31,27 +35,3 @@ API
 ===
 
 ..  include:: /CodeSnippets/Events/Backend/ModifyPageLayoutContentEvent.rst.txt
-
-History / Migration
-===================
-
-The event :php:class:`TYPO3\\CMS\\Backend\\Controller\\Event\\ModifyPageLayoutContentEvent`
-has been introduced to serve as a more powerful and flexible alternative
-for the removed hooks
-:php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawHeaderHook']`
-and :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['cms/layout/db_layout.php']['drawFooterHook']`.
-
-In contrast to the removed hooks, this event does not provide the
-:php:`PageLayoutController` as :php:`$parentObject`, since :php:`getModuleTemplate()`
-has been the only public method, which is now directly included in the event.
-
-An example to get the current :php:`$id`:
-
-..  code-block:: php
-    :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
-
-    public function __invoke(ModifyPageLayoutContentEvent $event): void
-    {
-        $id = (int)($event->getRequest()->getQueryParams()['id'] ?? 0);
-    }
-

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_MyEventListener.php
@@ -14,6 +14,9 @@ final class MyEventListener
 {
     public function __invoke(ModifyPageLayoutContentEvent $event): void
     {
+        // Get the current page ID
+        $id = (int)($event->getRequest()->getQueryParams()['id'] ?? 0);
+
         $event->addHeaderContent('Additional header content');
 
         $event->setFooterContent('Overwrite footer content');


### PR DESCRIPTION
The information about the replaced hooks is moved to the top (like for other events and easier overview). The "History / Migration" section is removed, the code snippet to access the page ID is moved into the example.

Releases: main, 12.4