### PR TITLE
[CI] Lint every supported PHP version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,24 @@ on:
   pull_request:
 
 jobs:
-  testsuite:
-    name: all tests
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+          - '8.2'
+          - '8.3'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
     env:
       php: '8.1'
@@ -22,9 +38,6 @@ jobs:
 
       - name: Composer normalize
         run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerNormalize -n
-
-      - name: Lint PHP
-        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s lint
 
       - name: CGL
         run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s cgl -n


### PR DESCRIPTION
This way, we are getting aware of a problem in the code snippets early for a newer PHP version.

Releases: main, 12.4