### PR TITLE
Fix class names in the code example

### DIFF
--- a/Documentation/ApiOverview/Events/SignalsSlots/Index.rst
+++ b/Documentation/ApiOverview/Events/SignalsSlots/Index.rst
@@ -101,10 +101,10 @@ Usage example:
 
    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
    $signalSlotDispatcher->connect(
-      '\TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class',  // Signal class name
-      'afterExtensionUninstall',                                    // Signal name
-      '\TYPO3\CMS\Core\Core\ClassLoadingInformation::class',        // Slot class name
-      'dumpClassLoadingInformation'                                 // Slot name
+      \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,  // Signal class name
+      'afterExtensionUninstall',                                  // Signal name
+      \TYPO3\CMS\Core\Core\ClassLoadingInformation::class,        // Slot class name
+      'dumpClassLoadingInformation'                               // Slot name
    );
 
 In this example, we define that we want to call the method


### PR DESCRIPTION
There should be either quotes on the class name, or no quotes and `::class`, not both.