### PR TITLE
[TASK] Add missing info about auto-created DB fields from TCA in v12 (#3546)

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
@@ -149,9 +149,30 @@ the :file:`ext_tables.sql` file:
     *   :ref:`TCA type "inline" <t3tca:columns-inline-properties-mm>`
     *   :ref:`TCA type "select" <t3tca:columns-select-properties-mm>`
 
+:php:`['config']['type'] => 'category'`
+    ..  versionadded:: 12.0
+        Database table fields for TCA type :php:`category` are created automatically.
+
+    See also :ref:`t3tca:columns-category`.
+
+:php:`['config']['type'] => 'datetime'`
+    Database table fields for TCA type :php:`datetime` are created automatically.
+
+    See also :ref:`t3tca:columns-datetime`.
+
+:php:`['config']['type'] => 'json'`
+    Database table fields for TCA type :php:`json` are created automatically.
+
+    See also :ref:`t3tca:columns-json`.
+
 :php:`['config']['type'] => 'slug'`
     ..  versionadded:: 12.0
         Database table fields for TCA type :php:`slug` are created automatically.
 
     See also :ref:`t3tca:columns-slug`.
 
+:php:`['config']['type'] => 'uuid'`
+    ..  versionadded:: 12.3
+        Database table fields for TCA type :php:`uuid` are created automatically.
+
+    See also :ref:`t3tca:columns-uuid`.


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Feature-101553-Auto-createDBFieldsFromTCAColumns.html#impact
Releases: main, 12.4