### PR TITLE
[BUGFIX] Correct spelling of Configuration/TsConfig folder

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
@@ -46,7 +46,7 @@ folder:
     │    ├── tx_myextension_domain_model_something.php
     │    ├── ...
     │    └── tx_myextension_sometable.php
-    ├── TSconfig
+    ├── TsConfig
     │    ├── Page
     │    └── User
     ├── TypoScript


### PR DESCRIPTION
In the "Common content" tree view the folder is wrongly written "TSconfig". Below on the link to the detail page this is written correctly "TsConfig".

Releases: main, 12.4, 11.5