### PR TITLE
[FEATURE] #101553 - Auto-create DB fields from TCA columns for various types

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
@@ -170,7 +170,20 @@ are considered for auto-generated fields, if they are not manually defined in
 the :file:`ext_tables.sql` file:
 
 *   :ref:`TCA type "category" <t3tca:columns-category>` (since TYPO3 v12.0)
+*   :ref:`TCA type "check" <t3tca:columns-check>` (since TYPO3 v13.0)
+*   :ref:`TCA type "color" <t3tca:columns-color>` (since TYPO3 v13.0)
 *   :ref:`TCA type "datetime" <t3tca:columns-datetime>`
+*   :ref:`TCA type "email" <t3tca:columns-email>` (since TYPO3 v13.0)
+*   :ref:`TCA type "file" <t3tca:columns-file>` (since TYPO3 v13.0)
+*   :ref:`TCA type "flex" <t3tca:columns-flex>` (since TYPO3 v13.0)
+*   :ref:`TCA type "folder" <t3tca:columns-folder>` (since TYPO3 v13.0)
+*   :ref:`TCA type "group" <t3tca:columns-group>` (since TYPO3 v13.0)
+*   :ref:`TCA type "imageManipulation" <t3tca:columns-imageManipulation>` (since TYPO3 v13.0)
 *   :ref:`TCA type "json" <t3tca:columns-json>`
+*   :ref:`TCA type "language" <t3tca:columns-language>` (since TYPO3 v13.0)
+*   :ref:`TCA type "link" <t3tca:columns-link>` (since TYPO3 v13.0)
+*   :ref:`TCA type "password" <t3tca:columns-password>` (since TYPO3 v13.0)
+*   :ref:`TCA type "radio" <t3tca:columns-radio>` (since TYPO3 v13.0)
 *   :ref:`TCA type "slug" <t3tca:columns-slug>` (since TYPO3 v12.0)
+*   :ref:`TCA type "text" <t3tca:columns-text>` (since TYPO3 v13.0)
 *   :ref:`TCA type "uuid" <t3tca:columns-uuid>`


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/697
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/696
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/688
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/687
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/677
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/666
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/660
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/655
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/652
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/648
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/647
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/641
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/632
Releases: main