### PR TITLE
[BUGFIX] Add missing TypoScript code snippets

### DIFF
--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock1.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock1.rst.txt
@@ -1,0 +1,8 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlock/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier.stdWrap.field = title
+   myIdentifier.stdWrap.ifEmpty.data = leveltitle:0

--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock2.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock2.rst.txt
@@ -1,0 +1,10 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlock2/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier {
+      stdWrap.field = title
+      stdWrap.ifEmpty.data = leveltitle:0
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock3.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlock3.rst.txt
@@ -1,0 +1,14 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlock3/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier {
+      stdWrap {
+         field = title
+         ifEmpty {
+            data = leveltitle:0
+         }
+      }
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidClosingBrace.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidClosingBrace.rst.txt
@@ -1,0 +1,8 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlockInvalidClosingBrace/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier {
+      value = bar }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidCondition.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidCondition.rst.txt
@@ -1,0 +1,12 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlockInvalidCondition/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier {
+      value = foo
+      [frontend.user.isLoggedIn]
+         value = bar
+      [end]
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidImport.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/CodeBlockInvalidImport.rst.txt
@@ -1,0 +1,10 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/CodeBlockInvalidCondition/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier {
+      @import 'EXT:my_extension/Configuration/TypoScript/bar.typoscript'
+      value = foo
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Comments.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Comments.rst.txt
@@ -1,0 +1,25 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Comments/setup.typoscript
+
+    # This is a comment
+    // This is a comment
+    /* This is a
+       multiline comment */
+
+    foo < bar // This is a comment
+    foo < bar /* This is a valid comment, too */
+
+    foo > # Another valid comment
+
+    foo := addToList(1) # Yes, a comment
+
+    [foo = bar] # Many comment. Much wow.
+
+    foo (
+      # This is NOT a comment but part of the value assignment!
+      bar = barValue
+    ) # This is a comment
+
+    foo = bar // This is NOT a comment but part of the value assignment!

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Conditions1.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Conditions1.rst.txt
@@ -1,0 +1,11 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Conditions1/setup.typoscript
+
+   [date("j") == 9]
+      page.10.value = It is the 9th day of the month!
+   [ELSE]
+      page.10.value = It is NOT the 9th day of the month!
+   [END]
+

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Conditions2.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Conditions2.rst.txt
@@ -1,0 +1,13 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Conditions2/setup.typoscript
+
+   # Some TypoScript, always parsed
+   [condition criteria]
+      # Some TypoScript, only parsed if the condition criteria is met
+   [ELSE]
+      # Some TypoScript, only parsed if the condition criteria is *not* met
+      # [ELSE] is optional
+   [GLOBAL]
+   # ... some TypoScript, always parsed

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Conditions3.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Conditions3.rst.txt
@@ -1,0 +1,16 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Conditions3/setup.typoscript
+
+   page = PAGE
+   page.10 = TEXT
+   page.10.value = HELLO WORLD!
+
+   [frontend.user.isLoggedIn || ip('127.0.0.1')]
+      page.20 = TEXT
+      page.20 {
+         value = A frontend user is logged in, or the browser IP is 127.0.0.1
+         stdWrap.case = upper
+      }
+   [GLOBAL]

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Conditions4.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Conditions4.rst.txt
@@ -1,0 +1,19 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Conditions4/setup.typoscript
+
+   page = PAGE
+   page.10 = TEXT
+   page.10.value = You are logged in
+
+   # This is hard to read
+   [frontend.user.isLoggedIn]
+   [ELSE]
+      page.10.value = You are *not* logged in
+   [END]
+
+   # This is faster to read
+   [!frontend.user.isLoggedIn]
+      page.10.value = You are *not* logged in
+   [END]

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Conditions5.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Conditions5.rst.txt
@@ -1,0 +1,12 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Conditions5/setup.typoscript
+
+   # Invalid: Conditions must not be used within code blocks
+   someIdentifier {
+      someProperty = foo
+      [frontend.user.isloggedIn]
+         someProperty = bar
+      [GLOBAL]
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Identifiers1.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Identifiers1.rst.txt
@@ -1,0 +1,6 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/General/setup.typoscript
+
+   myIdentifier.mySubIdentifier = myValue

--- a/Documentation/CodeSnippets/TypoScriptSyntax/Identifiers2.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/Identifiers2.rst.txt
@@ -1,0 +1,6 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Escaping/setup.typoscript
+
+   myIdentifier.my\.identifier\.with\.dots = myValue

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorAssignment.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorAssignment.rst.txt
@@ -1,0 +1,31 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/Assignment/setup.typoscript
+
+   # Identifier "myIdentifier" is set to the value "foo"
+   myIdentifier = foo
+
+   # Identifier path "myIdentifier.mySubIdentifier" is set to the value "foo"
+   myIdentifier.mySubIdentifier = foo
+
+   # "myIdentifier.mySubIdentifier" it set to the value "foo",
+   # but is immediately overwritten to value "bar"
+   myIdentifier.mySubIdentifier = foo
+   myIdentifier.mySubIdentifier = bar
+
+   # Same as above, value of "myIdentifier.mySubIdentifier" is "bar"
+   myIdentifier.mySubIdentifier = foo
+   myIdentifier {
+      mySubIdentifier = bar
+   }
+
+   # Value assignments are not comment-aware, "#", "//" and "/*" after a
+   # "=" operator do not start a comment. The value of identifier
+   # "myIdentifier.mySubIdentifier" is "foo // not a comment"
+   myIdentifier.mySubIdentifier = foo // not a comment
+
+   # Value assignment using a constant:
+   # Ends up as "foo myConstantValue bar" if constant "myConstant" is set to "myConstantValue"
+   # Ends up as "foo {$myConstantValue} bar" if constant "myConstant" is not set
+   myIdentifier. mySubIdentifier = foo {$myConstantValue} bar

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy1.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy1.rst.txt
@@ -1,0 +1,14 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorCopy1/setup.typoscript
+
+   myIdentifier = TEXT
+   myIdentifier.value = Hello world
+   myOtherIdentifier = TEXT
+   myOtherIdentifier.value = Hello world
+
+   # The above is identical to this:
+   myIdentifier = TEXT
+   myIdentifier.value = Hello world
+   myOtherIdentifier < myIdentifier

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy2.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy2.rst.txt
@@ -1,0 +1,10 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorCopy2/setup.typoscript
+
+   myIdentifier {
+      10 = TEXT
+      10.value = Hello world
+      20 < myIdentifier.10
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy3.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy3.rst.txt
@@ -1,0 +1,10 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorCopy3/setup.typoscript
+
+   myIdentifier {
+      10 = TEXT
+      10.value = Hello world
+      20 < .10
+   }

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy4.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorCopy4.rst.txt
@@ -1,0 +1,19 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorCopy4/setup.typoscript
+
+   # The above is identical to this:
+   myIdentifier = TEXT
+   myIdentifier.value = Hello world
+   myOtherIdentifier < myIdentifier
+
+   # Changing myIdentifier *after* it has been copied over to myOtherIdentifier,
+   # does *not* change myOtherIdentifier. The below line only changes the
+   # value of myIdentifier, not myOtherIdentifier:
+   myIdentifier.value = Hello world 2
+
+   # Changing myOtherIdentifier *after* it has been copied from to myIdentifier,
+   # does *not* change myIdentifier. The below line only changes the
+   # value of myOtherIdentifier, not myIdentifier:
+   myOtherIdentifier.value = Hello world 3

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorMultiLine.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorMultiLine.rst.txt
@@ -1,0 +1,24 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorMultiLine/setup.typoscript
+
+   myIdentifier= TEXT
+   myIdentifier.value (
+      This is a
+      multiline assignment
+   )
+
+   myIdentifier= TEXT
+   myIdentifier.value (
+      <p class="warning">
+         This is HTML code.
+      </p>
+   )
+
+   myIdentifier= TEXT
+   myIdentifier.value (
+      This looks up the value for constant {$myConstant}
+      and falls back to the string "{$myConstant}" if it can
+      not be resolved.
+   )

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorReference.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorReference.rst.txt
@@ -1,0 +1,17 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/OperatorReference/setup.typoscript
+
+   lib.myIdentifier = TEXT
+   lib.myIdentifier {
+      value = Hello world
+      stdWrap.wrap = <p>|</p>
+   }
+   tt_content.text =< lib.myIdentifier
+   tt_content.textpic =< lib.myIdentifier
+
+   # This changes lib.myIdentifier.stdWrap.wrap *and* tt_content.text.stdWrap.wrap
+   lib.myIdentifier.stdWrap.wrap = <h1>|</h1>
+   # This changes only tt_content.textpic.stdWrap.wrap
+   tt_content.textpic.stdWrap.wrap = <h2>|</h2>

--- a/Documentation/CodeSnippets/TypoScriptSyntax/OperatorUnset.rst.txt
+++ b/Documentation/CodeSnippets/TypoScriptSyntax/OperatorUnset.rst.txt
@@ -1,0 +1,15 @@
+.. Automatic screenshot: Remove this line if you want to manually change this file
+
+.. code-block:: typoscript
+   :caption: Extension examples, file Configuration/TypoScript/Syntax/ObjectUnset/setup.typoscript
+
+   myIdentifier.mySubIdentifier = TEXT
+   myIdentifier.mySubIdentifier = myValue
+   myIdentifier.mySubIdentifier.stdWrap = <p>|</p>
+
+   # "myIdentifier.mySubIdentifier" is completely removed, including value
+   # assignment and sub identifier "stdWrap"
+   myIdentifier.mySubIdentifier >
+
+   # Same as above: Everything after ">" operator is considered a comment
+   myIdentifier.mySubIdentifier > // Some comment


### PR DESCRIPTION
Somehow the got lost in main branch. They are copied over again from the 12.4 branch.

Releases: main