### PR TITLE
[DOCS] Add note on accessing defaults in FlexForm attributs

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -475,11 +475,11 @@ The key `flexform` is followed by the field which holds the FlexForm data
    * :ref:`TypoScript: flexform <t3tsref:data-type-gettext-flexform>`
 
 
-.. index:: pair: FlexForms; Fluid
-.. _read-flexforms-fluid:
+.. index:: pair: FlexForms; Typoscript
+.. _default-flexforms-attribute:
 
 Providing default values for FlexForms attributes
-------------------------------------------------
+-------------------------------------------------
 
 When a new content element with an attached FlexForm is created, the 
 default values for each FlexForm attribute is fetched from the
@@ -488,12 +488,14 @@ FlexForm attribute. If that is missing, an empty value will be
 shown in the backend (:ref:`FormEngine <FormEngine>`)
 fields.
 
-While you can use TypoScript :typoscript:`TCAdefaults` (see
-:ref:`TCAdefaults <TCAdefaults>`) to modify defaults of usual
-TCA-based attributes, this is not possible on FlexForms. This
-is because the values are calculated at an earlier step in
-the core workflow, where FlexForm values have not yet been
-extracted.
+While you can use TypoScript :ref:`t3tsref:pageTsTcaDefaults` to 
+modify defaults of usual TCA-based attributes, this is not 
+possible on FlexForms. This is because the values are calculated 
+at an earlier step in the Core workflow, where FlexForm values 
+have not yet been extracted.
+
+.. index:: pair: FlexForms; Fluid
+.. _read-flexforms-fluid:
 
 How to access FlexForms from Fluid
 ----------------------------------

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -475,7 +475,7 @@ The key `flexform` is followed by the field which holds the FlexForm data
    * :ref:`TypoScript: flexform <t3tsref:data-type-gettext-flexform>`
 
 
-.. index:: pair: FlexForms; Typoscript
+.. index:: pair: FlexForms; Default value
 .. _default-flexforms-attribute:
 
 Providing default values for FlexForms attributes
@@ -488,7 +488,7 @@ FlexForm attribute. If that is missing, an empty value will be
 shown in the backend (:ref:`FormEngine <FormEngine>`)
 fields.
 
-While you can use TypoScript :ref:`t3tsref:pageTsTcaDefaults` to 
+While you can use page TSconfig's :ref:`t3tsref:pageTsTcaDefaults` to 
 modify defaults of usual TCA-based attributes, this is not 
 possible on FlexForms. This is because the values are calculated 
 at an earlier step in the Core workflow, where FlexForm values 

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -478,6 +478,23 @@ The key `flexform` is followed by the field which holds the FlexForm data
 .. index:: pair: FlexForms; Fluid
 .. _read-flexforms-fluid:
 
+Providing default values for FlexForms attributes
+------------------------------------------------
+
+When a new content element with an attached FlexForm is created, the 
+default values for each FlexForm attribute is fetched from the
+:xml:`<default>` XML attribute within the specification of each 
+FlexForm attribute. If that is missing, an empty value will be 
+shown in the backend (:ref:`FormEngine <FormEngine>`)
+fields.
+
+While you can use TypoScript :typoscript:`TCAdefaults` (see
+:ref:`TCAdefaults <TCAdefaults>`) to modify defaults of usual
+TCA-based attributes, this is not possible on FlexForms. This
+is because the values are calculated at an earlier step in
+the core workflow, where FlexForm values have not yet been
+extracted.
+
 How to access FlexForms from Fluid
 ----------------------------------
 


### PR DESCRIPTION
Follow-up on https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TSconfig/pull/391 to also document at the "other end" how to access flexform defaults.

@TODO: I don't know if I linked to the `TCAdefaults` section properly, I don't really understand how/where to fetch external :ref: lookups.

Releases: main, 12.4, 11.5