### PR TITLE
[Backport 12.4] [TASK] Add allowed values for $GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality'] (#3605)

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -296,16 +296,17 @@ processor_interlace
 
    Possible values: None, Line, Plane, Partition
 
-.. index::
-   TYPO3_CONF_VARS GFX; jpg_quality
-.. _typo3ConfVars_gfx_jpg_quality:
+..  index::
+    TYPO3_CONF_VARS GFX; jpg_quality
+..  _typo3ConfVars_gfx_jpg_quality:
 
 jpg_quality
 ===========
 
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality']
+..  confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality']
 
-   :type: int
-   :Default: 85
+    :type: int
+    :Default: 85
+    :Allowed values: Between 1 (lowest quality) and 100 (highest quality)
 
-   Default JPEG generation quality
+    Default JPEG generation quality


### PR DESCRIPTION
Releases: main, 12.4