### PR TITLE
[TASK] #102260 - Remove NotifySoftReferenceParser

### DIFF
--- a/Documentation/ApiOverview/SoftReferences/Index.rst
+++ b/Documentation/ApiOverview/SoftReferences/Index.rst
@@ -1,4 +1,4 @@
-..  include:: /Includes.rst.txt
+﻿..  include:: /Includes.rst.txt
 ..  index:: Soft references
 ..  _soft-references:
 
@@ -52,11 +52,6 @@ installations. This is the list of the pre-registered keys:
 substitute
     A full field value targeted for manual substitution (for import/export
     features).
-
-..  _soft-references-default-parsers-notify:
-
-notify
-    Just report, if a value is found, nothing more.
 
 ..  _soft-references-default-parsers-typolink:
 

--- a/Documentation/ApiOverview/SoftReferences/Index.rst
+++ b/Documentation/ApiOverview/SoftReferences/Index.rst
@@ -1,4 +1,4 @@
-﻿..  include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 ..  index:: Soft references
 ..  _soft-references:
 

--- a/Documentation/ApiOverview/SoftReferences/_Services.yaml
+++ b/Documentation/ApiOverview/SoftReferences/_Services.yaml
@@ -7,11 +7,6 @@ services:
       - name: softreference.parser
         parserKey: substitute
 
-  TYPO3\CMS\Core\DataHandling\SoftReference\NotifySoftReferenceParser:
-    tags:
-      - name: softreference.parser
-        parserKey: notify
-
   TYPO3\CMS\Core\DataHandling\SoftReference\TypolinkSoftReferenceParser:
     tags:
       - name: softreference.parser


### PR DESCRIPTION
As the "notify" soft reference parser fits no apparent use case, it is removed altogether without a note.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/708
Releases: main