### PR TITLE
[BUGFIX] Correct minimum value of image quality settings

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -241,7 +241,7 @@ jpg_quality
 
     :type: int
     :Default: 85
-    :Allowed values: Between 1 (lowest quality) and 100 (highest quality)
+    :Allowed values: Between 10 (lowest quality) and 100 (highest quality)
 
     Default JPEG generation quality
 
@@ -258,7 +258,7 @@ webp_quality
 
     :type: int
     :Default: 85
-    :Allowed values: Between 1 (lowest quality) and 100 (highest quality)
+    :Allowed values: Between 10 (lowest quality) and 100 (highest quality)
 
     Default WebP generation quality
 


### PR DESCRIPTION
See:
- https://github.com/TYPO3/typo3/blob/12.4/typo3/sysext/core/Classes/Imaging/GraphicalFunctions.php#L327
- https://github.com/TYPO3/typo3/blob/main/typo3/sysext/frontend/Classes/Imaging/GifBuilder.php#L177-L178

Releases: main, 12.4