### PR TITLE
[BUGFIX] Correct some rendering issues

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -481,17 +481,17 @@ The key `flexform` is followed by the field which holds the FlexForm data
 Providing default values for FlexForms attributes
 -------------------------------------------------
 
-When a new content element with an attached FlexForm is created, the 
+When a new content element with an attached FlexForm is created, the
 default values for each FlexForm attribute is fetched from the
-:xml:`<default>` XML attribute within the specification of each 
-FlexForm attribute. If that is missing, an empty value will be 
+:xml:`<default>` XML attribute within the specification of each
+FlexForm attribute. If that is missing, an empty value will be
 shown in the backend (:ref:`FormEngine <FormEngine>`)
 fields.
 
-While you can use page TSconfig's :ref:`t3tsref:pageTsTcaDefaults` to 
-modify defaults of usual TCA-based attributes, this is not 
-possible on FlexForms. This is because the values are calculated 
-at an earlier step in the Core workflow, where FlexForm values 
+While you can use page TSconfig's :ref:`t3tsconfig:pageTsTcaDefaults` to
+modify defaults of usual TCA-based attributes, this is not
+possible on FlexForms. This is because the values are calculated
+at an earlier step in the Core workflow, where FlexForm values
 have not yet been extracted.
 
 .. index:: pair: FlexForms; Fluid

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -72,8 +72,7 @@ In most editors you can use regular expressions, for example, in PhpStorm:
 
 #.  Open the XLIFF file in the editor.
 #.  Press :kbd:`Ctrl` + :kbd:`R` to open the search and replace pane
-#.  | Find: `id="(.+?)"`
-    Replace: `id="$1" resname="$1"`
+#.  Find: `id="(.+?)"` / Replace: `id="$1" resname="$1"`
 #.  Click the regex icon (:guilabel:`.*`) to enable regular expressions.
 #.  Click on button :guilabel:`Replace All`
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -130,7 +130,7 @@ and container instantiation will fail.
 
 The corresponding example is:
 
-.. include:: /CodeSnippets/FrontendPlugins/ConfigurePlugin.rst.txt
+.. include:: /CodeSnippets/Extbase/FrontendPlugins/ConfigurePlugin.rst.txt
 
 Here, the plugin `BlogExample` would allow jumping between the controllers
 :php:`PostController` and :php:`CommentController`. To also allow

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -135,7 +135,7 @@ You can also define nested options using the TypoScript notation:
 
 This will result in a multidimensional array:
 
-.. code-block:: plain
+.. code-block:: text
    :caption: Example output of method `ExtensionConfiguration->get()`
 
    $extensionConfiguration['directories']['tmp']


### PR DESCRIPTION
The following issues have been fixed:

    ./Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst:133: CRITICAL: Problems with "include" directive path:
    InputError: [Errno 2] No such file or directory: '/ALL/Makedir/SYMLINK_THE_PROJECT/Documentation/CodeSnippets/FrontendPlugins/ConfigurePlugin.rst.txt'.

    ./Documentation/ApiOverview/FlexForms/Index.rst:491: WARNING: undefined label: t3tsref:pagetstcadefaults

    ./Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst:76: WARNING: Line block ends without a blank line.

    ./Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst:138: WARNING: Pygments lexer name 'plain' is not known

Releases: main, 12.4, 11.5