### PR TITLE
[TASK] #98517 - Emphasize TypoScript info on file includes within curly braces

### DIFF
--- a/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
+++ b/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
@@ -30,7 +30,7 @@ Neither :typoscript:`@import` nor :typoscript:`<INCLUDE_TYPOSCRIPT:` are allowed
 to be placed within code blocks.
 
 ..  versionchanged:: 12.2
-    :typoscript:`@include` and :typoscript:`<INCLUDE_TYPOSCRIPT:` basically
+    :typoscript:`@import` and :typoscript:`<INCLUDE_TYPOSCRIPT:` basically
     break any curly braces level, resetting current scope to top level. While
     inclusion of files has never been documented to be valid within braces
     assignments, it still worked until TYPO3 v11. This is now disallowed and

--- a/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
+++ b/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
@@ -41,7 +41,7 @@ to be placed within code blocks.
         page = PAGE
         page {
           # This include won't work!
-          @include 'EXT:my_extension/Configuration/TypoScript/bar.typoscript'
+          @import 'EXT:my_extension/Configuration/TypoScript/bar.typoscript'
           20 = TEXT
           20.value = bar
         }

--- a/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
+++ b/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
@@ -40,7 +40,7 @@ to be placed within code blocks.
 
         page = PAGE
         page {
-          # This include won't work!
+          # This import won't work!
           @import 'EXT:my_extension/Configuration/TypoScript/bar.typoscript'
           20 = TEXT
           20.value = bar

--- a/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
+++ b/Documentation/Configuration/TypoScript/Syntax/FileImports/Index.rst
@@ -29,6 +29,24 @@ imports with :typoscript:`@import`.
 Neither :typoscript:`@import` nor :typoscript:`<INCLUDE_TYPOSCRIPT:` are allowed
 to be placed within code blocks.
 
+..  versionchanged:: 12.2
+    :typoscript:`@include` and :typoscript:`<INCLUDE_TYPOSCRIPT:` basically
+    break any curly braces level, resetting current scope to top level. While
+    inclusion of files has never been documented to be valid within braces
+    assignments, it still worked until TYPO3 v11. This is now disallowed and
+    must not be used anymore. For example, a construct like this is **invalid**:
+
+    ..  code-block:: typoscript
+
+        page = PAGE
+        page {
+          # This include won't work!
+          @include 'EXT:my_extension/Configuration/TypoScript/bar.typoscript'
+          20 = TEXT
+          20.value = bar
+        }
+
+
 @import
 =======
 


### PR DESCRIPTION
The sentence above with the import of other TypoScript files is a change which might break installations on upgrade. This is now better documented to emphasize it.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/290
Releases: main, 12.4