### PR TITLE
[TASK] Revise FAL Collections page

### DIFF
--- a/Documentation/ApiOverview/Fal/Collections/Index.rst
+++ b/Documentation/ApiOverview/Fal/Collections/Index.rst
@@ -1,35 +1,40 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: File abstraction layer; File collections
-.. _collections:
-.. _collections-records:
-.. _collections-files:
+..  include:: /Includes.rst.txt
+..  index:: pair: File abstraction layer; File collections
+..  _collections:
+..  _collections-records:
+..  _collections-files:
 
 ================
 File collections
 ================
 
-File collections are collections of file references.
+File collections are collections of
+:ref:`file references <fal-architecture-components-file-references>`.
 They are used by the "File links" (download) content element.
 
-.. figure:: /Images/ManualScreenshots/Fal/FileDownloadWithCollection.png
-   :alt: A file links content element
+..  figure:: /Images/ManualScreenshots/Fal/FileDownloadWithCollection.png
+    :alt: A file links content element
+    :class: with-shadow
 
-   A "File links" content element referencing a file collection
+    A "File links" content element referencing a file collection
 
 
-File collections are stored in the :sql:`sys_file_collection` table.
-The selected files are stored in the :sql:`sys_file_reference` table.
+File collections are stored in the
+:ref:`sys_file_collection <fal-architecture-database-sys-file-collection>` table.
+The selected files are stored in the
+:ref:`sys_file_reference <fal-architecture-database-sys-file-reference>` table.
 
 Note that a file collection may also reference a folder, in which case
 all files inside the folder will be returned when calling that collection.
 
-.. figure:: /Images/ManualScreenshots/Fal/FolderCollection.png
-   :alt: A folder collection
+..  figure:: /Images/ManualScreenshots/Fal/FolderCollection.png
+    :alt: A folder collection
+    :class: with-shadow
 
-   A file collection referencing a folder
+    A file collection referencing a folder
 
 
-.. _collections-api:
+..  _collections-api:
 
 Collections API
 ===============
@@ -37,70 +42,43 @@ Collections API
 The TYPO3 Core provides an API to enable usage of collections
 inside extensions. The most important classes are:
 
-:code:`\TYPO3\CMS\Core\Resource\FileCollectionRepository`
-  Used to retrieve collections. It's not exactly an Extbase repository
-  but works in a similar way. The default "find" methods refer
-  to the "sys_file_collection" table and will fetch "static"-type collections.
+:php:`\TYPO3\CMS\Core\Resource\FileCollectionRepository`
+    Used to retrieve collections. It is not exactly an
+    :ref:`Extbase repository <extbase-repository>` but works in a similar way.
+    The default "find" methods refer to the
+    :ref:`sys_file_collection <fal-architecture-database-sys-file-collection>`
+    table and will fetch "static"-type collections.
 
-:code:`\TYPO3\CMS\Core\Resource\Collection\StaticFileCollection`
-  This class models the static file collection. It is important to note
-  that collections returned by the repository (described above) are "empty".
-  If you need to access their records, you need to load them first, using
-  method :code:`loadContents()`. On top of some specific API methods,
-  this class includes all setters and getters that you may need to access
-  the collection's data. For accessing the selected files, just loop
-  on the collection (see example).
+:php:`\TYPO3\CMS\Core\Resource\Collection\StaticFileCollection`
+    This class models the static file collection. It is important to note
+    that collections returned by the repository (described above) are "empty".
+    If you need to access their records, you need to load them first, using
+    method :code:`loadContents()`. On top of some specific API methods,
+    this class includes all setters and getters that you may need to access
+    the collection's data. For accessing the selected files, just loop
+    on the collection (see example).
 
-:code:`\TYPO3\CMS\Core\Resource\Collection\FolderBasedFileCollection`
-  Similar to the :php:`StaticFileCollection`, but for file collections based on a folder.
+:php:`\TYPO3\CMS\Core\Resource\Collection\FolderBasedFileCollection`
+    Similar to the :php:`StaticFileCollection`, but for file collections based
+    on a folder.
 
-:code:`\TYPO3\CMS\Core\Resource\Collection\CategoryBasedFileCollection`
-  File collection based on a single category.
+:php:`\TYPO3\CMS\Core\Resource\Collection\CategoryBasedFileCollection`
+    File collection based on a single :ref:`category <categories>`.
 
 
-.. _collections-example:
+..  _collections-example:
 
 Example
 =======
 
-The `"examples" extension <https://github.com/TYPO3-Documentation/t3docs-examples>`_
-provides a simple frontend plugin to demonstrate
-usage of collections. Here is what happens in the controller:
+The following example demonstrates the usage of collections. Here is what
+happens in the controller:
 
-.. code-block:: php
-   :emphasize-lines: 17-27
+..  literalinclude:: _MyController.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Controller/MyController.php
 
-   /**
-    * @var \TYPO3\CMS\Core\Resource\FileCollectionRepository
-    */
-   protected $collectionRepository;
-
-   public function __construct(FileCollectionRepository $collectionRepository) {
-     $this->collectionRepository = $collectionRepository;
-   }
-
-   /**
-    * Renders the list of all existing collections and their content
-    *
-    * @return void
-    */
-   public function indexAction()
-   {
-     // Get all existing collections
-     /** @var \TYPO3\CMS\Core\Resource\Collection\AbstractFileCollection[] $collections */
-     $collections = $this->collectionRepository->findAll();
-
-     // Load the records in each collection
-     foreach ($collections as $aCollection) {
-         $aCollection->loadContents();
-     }
-
-     // Assign the "loaded" collections to the view
-     $this->view->assign('collections', $collections);
-   }
-
-
-The base is code is quite simple: all collections are fetched and passed
+All collections are fetched and passed
 to the view. The one specific step is the loop over all collections to load
 their referenced records. Remember that a collection is otherwise "empty".
 
@@ -108,25 +86,16 @@ In the view we can then either use collection member variables as usual
 (like their title) or put them directly in a loop to iterate over the
 record selection:
 
-.. code-block:: xml
-
-   <f:section name="main">
-       <ul class="collection with-header">
-           <f:for each="{collections}" as="collection">
-               <li class="collection-header"><h4>{collection.title} (Records from <code>{collection.itemTableName}</code>)</h4></li>
-               <f:for each="{collection}" as="record">
-                   <li class="collection-item">{record.name}</li>
-               </f:for>
-           </f:for>
-       </ul>
-   </f:section>
-
+..  literalinclude:: _List.html
+    :language: html
+    :caption: EXT:my_extension/Resources/Private/Templates/List.html
 
 Here is what the result may look like (the exact result will obviously
 depend on the content of the selection):
 
-.. figure:: /Images/ManualScreenshots/Frontend/Fal/CollectionsOutput.png
-   :alt: Collections plugin output
+..  figure:: /Images/ManualScreenshots/Frontend/Fal/CollectionsOutput.png
+    :alt: Collections plugin output
+    :class: with-shadow
 
-   Typical output from the "Collections" plugin of extension "examples"
+    Typical output from the "Collections" plugin
 

--- a/Documentation/ApiOverview/Fal/Collections/_List.html
+++ b/Documentation/ApiOverview/Fal/Collections/_List.html
@@ -1,0 +1,12 @@
+<f:section name="main">
+    <ul class="collection with-header">
+        <f:for each="{collections}" as="collection">
+            <li class="collection-header">
+                <h4>{collection.title} (Records from <code>{collection.itemTableName}</code>)</h4>
+            </li>
+            <f:for each="{collection}" as="record">
+                <li class="collection-item">{record.name}</li>
+            </f:for>
+        </f:for>
+    </ul>
+</f:section>

--- a/Documentation/ApiOverview/Fal/Collections/_MyController.php
+++ b/Documentation/ApiOverview/Fal/Collections/_MyController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Collections;
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Resource\FileCollectionRepository;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+final class MyController extends ActionController
+{
+    public function __construct(
+        private readonly FileCollectionRepository $collectionRepository,
+    ) {}
+
+    /**
+     * Renders the list of all existing collections and their content
+     */
+    public function listAction(): ResponseInterface
+    {
+        // Get all existing collections
+        $collections = $this->collectionRepository->findAll() ?? [];
+
+        // Load the records in each collection
+        foreach ($collections as $aCollection) {
+            $aCollection->loadContents();
+        }
+
+        // Assign the "loaded" collections to the view
+        $this->view->assign('collections', $collections);
+
+        return $this->htmlResponse();
+    }
+}


### PR DESCRIPTION
Besides adding references to corresponding sections, the example is reworked:
- EXT:examples does not provide an example of file collections, therefore the code snippet is generalized.
- The code snippets are moved to separate files.
- The controller class is now fully displayed, not only a part of the class.

Releases: main, 12.4, 11.5