### PR TITLE
Fix backend module registration for a plain (non-extbase) controller

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -61,7 +61,6 @@ Extbase while the second uses a plain controller.
            'workspaces' => 'live',
            'path' => '/module/system/example',
            'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-           'extensionName' => 'Examples',
            'controllerActions' => [
                AdminModuleController::class => [
                    'index',


### PR DESCRIPTION
The extensionName option can be omitted when using a plain controller according to the TYPO3 ChangeLog documentation