### PR TITLE
Fix broken navigationComponent example

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ToplevelModules.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ToplevelModules.rst
@@ -58,6 +58,6 @@ Register a new toplevel module in your extension:
        'myextension' => [
            'labels' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_mod_web.xlf',
            'iconIdentifier' => 'modulegroup-myextension',
-           'navigationComponent' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
+           'navigationComponent' => '@typo3/backend/page-tree/page-tree-element',
        ]
    ];


### PR DESCRIPTION
Fix broken code example, streamlined with https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.html#confval-navigationComponent