### PR TITLE
[FEATURE] #101507 - Add hotkey API to TYPO3 backend

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
@@ -1,0 +1,63 @@
+..  include:: /Includes.rst.txt
+..  index:: Hotkey API
+..  _js-hotkey-api:
+
+==========
+Hotkey API
+==========
+
+..  versionadded:: 13.0
+
+TYPO3 provides the :js:`@typo3/backend/hotkeys.js` module that allows developers
+to register custom keyboard shortcuts in the TYPO3 backend.
+
+It is also possible and highly recommended to register hotkeys in a dedicated
+scope to avoid conflicts with other hotkeys, perhaps registered by other
+extensions.
+
+The module provides an enum with common modifier keys: :kbd:`Ctrl`, :kbd:`Meta`,
+:kbd:`Alt`, and :kbd:`Shift`), and also a public property describing the common
+hotkey modifier based on the user's operating system: :kbd:`Cmd` (Meta) on macOS,
+:kbd:`Ctrl` on anything else. Using any modifier is optional, but highly
+recommended.
+
+A hotkey is registered with the :js:`register()` method. The method takes three
+arguments:
+
+:js:`hotkey`
+    An array defining the keys that must be pressed.
+
+:js:`handler`
+    A callback that is executed when the hotkey is invoked.
+
+:js:`options`
+    An object that configures a hotkey's behavior:
+
+    :js:`scope`
+        The scope a hotkey is registered in.
+
+    :js:`allowOnEditables`
+        If :js:`false` (default), handlers are not executed when an editable
+        element is focussed.
+
+    :js:`allowRepeat`
+        If :js:`false` (default), handlers are not executed when the hotkey is
+        pressed for a long time.
+
+    :js:`bindElement`
+        If given, an :html:`aria-keyshortcuts` attribute is added to the
+        element. This is recommended for accessibility reasons.
+
+Example:
+
+..  literalinclude:: _example.js
+    :language: js
+    :caption: EXT:my_extension/Resources/Public/JavaScript/hotkey.js
+
+..  note::
+    TYPO3-specific hotkeys may be registered in the reserved :js:`all` scope.
+    When invoking a hotkey from a different scope, the :js:`all` scope is
+    handled in any case at first.
+
+..  seealso::
+    :ref:`Keyboard commands in TYPO3 <t3editors:keyboard_commands>`

--- a/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
@@ -36,6 +36,11 @@ arguments:
     :js:`scope`
         The scope a hotkey is registered in.
 
+        ..  note::
+            TYPO3-specific hotkeys may be registered in the reserved :js:`all`
+            scope. When invoking a hotkey from a different scope, the :js:`all`
+            scope is handled in any case at first.
+
     :js:`allowOnEditables`
         If :js:`false` (default), handlers are not executed when an editable
         element is focussed.
@@ -48,16 +53,15 @@ arguments:
         If given, an :html:`aria-keyshortcuts` attribute is added to the
         element. This is recommended for accessibility reasons.
 
-Example:
+..  seealso::
+    :ref:`Keyboard commands in TYPO3 <t3editors:keyboard_commands>`
+
+
+..  _js-hotkey-api-example:
+
+Example
+=======
 
 ..  literalinclude:: _example.js
     :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/hotkey.js
-
-..  note::
-    TYPO3-specific hotkeys may be registered in the reserved :js:`all` scope.
-    When invoking a hotkey from a different scope, the :js:`all` scope is
-    handled in any case at first.
-
-..  seealso::
-    :ref:`Keyboard commands in TYPO3 <t3editors:keyboard_commands>`

--- a/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/_example.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/_example.js
@@ -1,0 +1,14 @@
+import {Hotkeys, ModifierKeys} from '@typo3/backend/hotkeys.js';
+
+Hotkeys.register([Hotkeys.normalizedCtrlModifierKey, ModifierKeys.ALT, 'e'], keyboardEvent => {
+  console.log('Triggered on Ctrl/Cmd+Alt+E');
+}, {
+  scope: 'my-extension/module',
+  bindElement: document.querySelector('.some-element')
+});
+
+// Get the currently active scope
+const currentScope = Hotkeys.getScope();
+
+// Make use of registered scope
+Hotkeys.setScope('my-extension/module');

--- a/Documentation/ApiOverview/Backend/JavaScript/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Index.rst
@@ -23,5 +23,6 @@ APIs in that regard.
     Modules/Index
     AjaxRequest/Index
     EventApi/Index
+    HotkeyApi/Index
     Navigation/Index
     Forms/Index


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/736
Releases: main