### PR TITLE
[DOCS] Add Services.yaml example for interface injection

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -390,6 +390,25 @@ instance administrator can decide to configure the framework to inject some
 different implementation than the default, and that's fully transparent
 for consuming classes.
 
+Here's an example scenario that demonstrates how you can define the specific
+implementations that shall be used for an interface type hint:
+
+..  literalinclude:: _MyController.php
+    :language: php
+    :caption: EXT:my_extension/Controller/MyController.php
+
+..  literalinclude:: _MySecondController.php
+    :language: php
+    :caption: EXT:my_extension/Controller/MySecondController.php
+
+..  literalinclude:: _MyThirdController.php
+    :language: php
+    :caption: EXT:my_extension/Controller/MyThirdController.php
+
+..  literalinclude:: _ServicesWithInterfaceInjection.yaml
+    :language: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
+
 
 Using container->get()
 ======================

--- a/Documentation/ApiOverview/DependencyInjection/_MyController.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MyController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use MyVendor\MyExtension\Service\MyServiceInterface;
+
+class MyController
+{
+    public function __construct(
+        private readonly MyServiceInterface $myService
+    ) {}
+}

--- a/Documentation/ApiOverview/DependencyInjection/_MySecondController.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MySecondController.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+class MySecondController extends MyController {}

--- a/Documentation/ApiOverview/DependencyInjection/_MyThirdController.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MyThirdController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use MyVendor\MyExtension\Service\MyServiceInterface;
+
+class MyThirdController
+{
+    private MyServiceInterface $myService;
+
+    public function injectMyService(MyServiceInterface $myService)
+    {
+        $this->myService = $myService;
+    }
+}

--- a/Documentation/ApiOverview/DependencyInjection/_ServicesWithInterfaceInjection.yaml
+++ b/Documentation/ApiOverview/DependencyInjection/_ServicesWithInterfaceInjection.yaml
@@ -1,0 +1,23 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  # Define the default implementation of an interface
+  MyVendor\MyExtension\Service\MyServiceInterface: '@MyVendor\MyExtension\Service\MyDefaultService'
+
+  # Within MySecond- and MyThirdController different implementations for said
+  # interface shall be used instead.
+
+  # Version 1: when working with constructor injection
+  MyVendor\MyExtension\Controller\MySecondController:
+    arguments:
+      $service: '@MyVendor\MyExtension\Service\MySecondService'
+
+  # Version 2: when working with method injection
+  MyVendor\MyExtension\Controller\MyThirdController:
+    calls:
+      - method: 'injectMyService'
+        arguments:
+          $service: '@MyVendor\MyExtension\Service\MyThirdService'


### PR DESCRIPTION
I've noticed that the section on "interface injection" was lacking details on how the `Service.yaml` should look like.

This patch can be backported to at least 11.5, for I've just used those insights to work on that version of TYPO3 and it was obviously working ;-)