### PR TITLE
[BUGFIX] #102607 - Use "da" instead of "dk" for Danish language locale

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
+++ b/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
@@ -12,7 +12,7 @@ languages:
     languageId: 0
   - title: 'danish'
     enabled: true
-    locale: dk_DK.UTF-8
+    locale: da_DK.UTF-8
     base: /da/
     websiteTitle: ''
     navigationTitle: Dansk


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/749
Releases: main, 12.4, 11.5