### PR TITLE
[BUGFIX] #102607 - Use "da" instead of "dk" for Danish language local…

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
+++ b/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
@@ -16,7 +16,7 @@ languages:
     title: 'danish'
     navigationTitle: Dansk
     base: /da/
-    locale: dk_DK.UTF-8
+    locale: da_DK.UTF-8
     iso-639-1: da
     hreflang: dk-DK
     direction: ltr


### PR DESCRIPTION
…e (#3760)

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/749
Releases: main, 12.4, 11.5