### PR TITLE
[TASK] Add additional "workspaces" anchor

### DIFF
--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -3,6 +3,7 @@
    Versioning
    Workspaces
 .. _ext_workspaces:
+.. _workspaces:
 
 =========================
 Versioning and Workspaces


### PR DESCRIPTION
In main and 12.4 branch the anchor is already named "workspaces". To ease backporting, the "workspaces" anchor is also added in 11.5 (while leaving the old one).

Releases: 11.5