### PR TITLE
[TASK] #102583 - Remove TypoScriptAspect

### DIFF
--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -217,26 +217,6 @@ the following property:
 Returns, whether the frontend is currently in preview mode.
 
 
-..  _context_api_aspects_typoscript:
-
-TypoScript aspect
------------------
-
-The TypoScript aspect can be used to manipulate/check whether
-TemplateRendering is forced.
-
-..  _context_api_aspects_typoscript_properties:
-
-The TypoScript aspect, `\TYPO3\CMS\Core\Context\TypoScriptAspect` contains the
-following property:
-
-..  confval:: forcedTemplateParsing
-
-    :Call: :php:`$this->context->getPropertyFromAspect('typoscript', 'forcedTemplateParsing');`
-
-    Returns, whether TypoScript template parsing is forced.
-
-
 ..  _context_api_aspects_user:
 
 User aspect


### PR DESCRIPTION
The information is removed altogether without a "versionchanged" directive by intention.

From the changelog: "Extensions typically do not use this context aspect since it only carried an EXT:adminpanel related information. There should be little reason for extensions to work with this EXT:adminpanel related detail."

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/741
Releases: main