### PR TITLE
[FEATURE] #100268 - Provide full userdata in password recovery email

### DIFF
--- a/Documentation/ApiOverview/Backend/AccessControl/PasswordReset/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/PasswordReset/Index.rst
@@ -31,6 +31,11 @@ is entered correctly, it will be updated for the user and they can log in.
     The username of the backend user is displayed in the password recovery
     email alongside the reset link.
 
+..  versionadded:: 13.0
+    A new array variable :html:`{userData}` has been added to the password
+    recovery :php:`FluidEmail` object. It contains the values of all fields
+    belonging to the affected frontend user.
+
 
 Notes on security
 =================

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/SendRecoveryEmailEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/SendRecoveryEmailEvent.rst
@@ -11,6 +11,18 @@ The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\SendRecoveryEmailEvent`
 contains the email to be sent and additional information about the user who
 requested a new password.
 
+..  hint::
+    Before TYPO3 v13, only the variables :html:`{receiverName}`, :html:`{url}`
+    and :html:`{validUntil}` are available in the Fluid template of the password
+    recovery email. If more user-related data was required in the recovery email,
+    integrators had to use this PSR-14 event to add additional variables to the
+    email object.
+
+    Since TYPO3 v13, a new array variable :html:`{userData}` is available in
+    the password recovery :php:`FluidEmail` object. It contains the values of
+    all fields belonging to the affected frontend user. Therefore, for this
+    use case, this event is not needed anymore.
+
 Example
 =======
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/743
Releases: main