### PR TITLE
[TASK] #87193 - Remove TSFE->sys_language_uid

### DIFF
--- a/Documentation/ApiOverview/TSFE/Index.rst
+++ b/Documentation/ApiOverview/TSFE/Index.rst
@@ -131,36 +131,6 @@ Can be done using the
     $pageArguments = $request->getAttribute('routing');
     $pageId = $pageArguments->getPageId();
 
-.. _tsfe_language:
-
-Access language settings
-------------------------
-
-In order to get current language settings, such as the current language ID,
-obtain :php:`\TYPO3\CMS\Core\Site\Entity\SiteLanguage` object from the
-:ref:`language request attribute <typo3-request-attribute-language>`:
-
-..  code-block:: php
-
-    // !!! outdated
-    $languageId = $GLOBALS['TSFE']->sys_language_uid;
-
-..  code-block:: php
-
-    /** @var \TYPO3\CMS\Core\Site\Entity\SiteLanguage $language */
-    $language = $request->getAttribute('language');
-    $languageId = $language->getLanguageId();
-
-
-If the request is not available, accessing language settings
-can be done using the :ref:`language aspect <context_api_aspects_language>`.
-
-Get the language of the current page as integer:
-
-..  code-block:: php
-
-    $languageId = (int) $context->getPropertyFromAspect('language', 'id');
-
 ..  _tsfe_frontendUser:
 
 Access frontend user information


### PR DESCRIPTION
This property has been dropped with TYPO3 v10.0.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Breaking-87193-DeprecatedFunctionalityRemoved.html
Releases: main, 12.4, 11.5