### PR TITLE
[BUGFIX] #102406 - Properly handle aliases with the AsCommand registration

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Tutorial.rst
+++ b/Documentation/ApiOverview/CommandControllers/Tutorial.rst
@@ -164,9 +164,10 @@ When using this attribute there is no need to register the command in the
 :file:`Services.yaml` file.
 
 ..  note::
-    Only the parameters `command`, `description` and `hidden` are available. In
-    order to overwrite the parameter `schedulable`  use the registration
-    via :ref:`Services.yaml <console-command-tutorial-registration-services>`.
+    Only the parameters `command`, `description`, `aliases` and `hidden` are
+    available. In order to overwrite the parameter `schedulable` use the
+    registration via
+    :ref:`Services.yaml <console-command-tutorial-registration-services>`.
     By default, `schedulable` is true.
 
 The :ref:`example above <console-command-tutorial-create>` can also be

--- a/Documentation/ApiOverview/CommandControllers/_Tutorial/_DoSomethingCommandViaAttribute.php
+++ b/Documentation/ApiOverview/CommandControllers/_Tutorial/_DoSomethingCommandViaAttribute.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(
     name: 'examples:dosomething',
     description: 'A command that does nothing and always succeeds.',
+    aliases: ['examples:dosomethingalias']
 )]
 class DoSomethingCommand extends Command
 {


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/726
Releases: main, 12.4