### PR TITLE
[TASK] #102621 - Most TSFE members marked internal or read only

### DIFF
--- a/Documentation/ApiOverview/Assets/Index.rst
+++ b/Documentation/ApiOverview/Assets/Index.rst
@@ -220,13 +220,10 @@ The following methods can then be used:
 Using the TypoScriptFrontendController
 --------------------------------------
 
+..  versionchanged:: 13.0
+    The property :php:`additionalHeaderData` has been marked as internal
+    and should not be used.
+
 ..  code-block:: php
 
     $GLOBALS['TSFE']->additionalHeaderData[$name] = $javaScriptCode;
-
-..  tip::
-    Instead of using the global variable for retrieving the
-    :ref:`TypoScriptFrontendController <tsfe>` you should consider to use the
-    :ref:`PSR-7 request attribute <typo3-request-attributes>`
-    :ref:`frontend.controller <typo3-request-attribute-frontend-controller>`
-    wherever possible.

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
@@ -34,6 +34,9 @@ cache was enabled or not.
 Example
 =======
 
+..  todo: The property TSFE->content used in the example was marked as internal
+          in v13. A substitution is needed for this.
+
 ..  literalinclude:: _AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
     :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php

--- a/Documentation/ApiOverview/TSFE/Index.rst
+++ b/Documentation/ApiOverview/TSFE/Index.rst
@@ -88,6 +88,9 @@ where available:
 Access ContentObjectRenderer
 ----------------------------
 
+..  versionchanged:: 13.0
+    This property has been marked as read-only.
+
 Access the :php:`\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer`
 (often referred to as "cObj"):
 
@@ -115,6 +118,9 @@ a non-Extbase plugin) use setter injection:
 
 Access current page ID
 ----------------------
+
+..  versionchanged:: 13.0
+    This property has been marked as read-only.
 
 Access the current page ID:
 
@@ -146,16 +152,13 @@ Access frontend user information
 Get current base URL
 --------------------
 
-It used to be possible to get the base URL configuration (from TypoScript
-:typoscript:`config.baseURL`) with the :php:`TSFE` :php:`baseURL` property. The
-property is now protected and deprecated since TYPO3 v12. Already in
-earlier version, site configuration should be used to get the base URL
-of the current site.
+..  versionchanged:: 13.0
+    The variable :php:`$GLOBALS['TSFE']->baseURL` has been removed with TYPO3
+    v13.
 
-..  code-block:: php
-
-    // !!! deprecated
-    $GLOBALS['TSFE']->baseURL
+Use the :ref:`request object <typo3-request>` and retrieve the
+:ref:`site attribute <typo3-request-attribute-site>` which holds the
+:ref:`site configuration <sitehandling-create-new>`:
 
 ..  code-block:: php
 


### PR DESCRIPTION
This change adds appropriate versionchanged directive to the changed properties of TSFE.

The AfterCacheableContentIsGeneratedEvent provides an example which uses the property "content" that is marked as internal now. A todo was added for now as a solution is not known by now.

The methods marked as internal will be taken care of in a follow-up.

Additionally, TSFE->baseUrl was removed in a previous Core patch. This property was already deprecated with v12. This change also addresses this change.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/752
Releases: main