### PR TITLE
[BUGFIX] Fix typo in code example for backend module registration

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -296,7 +296,7 @@ Default module configuration options (without Extbase)
     ..  code-block:: php
         :caption: EXT:my_extension/Configuration/Backend/Modules.php
 
-        routes' => [
+        'routes' => [
             '_default' => [
                 'target' => MyModuleController::class . '::overview',
             ],


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/721
Releases: main, 12.4