### PR TITLE
[BUGFIX] #102688 - Display inherited module workspace access restriction

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -83,7 +83,8 @@ Module configuration options
     :Scope: Backend module configuration
     :type: string
 
-    Can be `*` (= always), `live` or `offline`
+    Can be `*` (= always), `live` or `offline`. If not set, the value of the
+    parent module - if any - is used.
 
 
 ..  _backend-modules-configuration-position:


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/768
Releases: main, 12.4