### PR TITLE
Fix backend module registration for a plain (non-extbase) controller

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
@@ -30,7 +30,6 @@ return [
         'workspaces' => 'live',
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-        'extensionName' => 'Examples',
         'controllerActions' => [
             AdminModuleController::class => [
                 'index',


### PR DESCRIPTION
Related: #3661
Releases: main, 12.4