### PR TITLE
[BUGFIX] Correct TypoScript example in "Advanced routing configuration"

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -410,10 +410,10 @@ Example in TypoScript:
 
     jsonview = PAGE
     jsonview.typeNum = 26
+    jsonview.config.disableAllHeaderCode = 1
+    jsonview.config.additionalHeaders.10.header = Content-Type: application/json
     jsonview.10 = USER
     jsonview.10.userFunc = MyVendor\MyExtension\Controller\JsonPageController->renderAction
-    jsonview.10.config.disableAllHeaderCode = 1
-    jsonview.10.config.additionalHeaders.10.header = Content-Type: application/json
 
 Now we configure the enhancer in your site's :file:`config.yaml` file like this:
 


### PR DESCRIPTION
The config object is part of the page object, not of a user object.

Related: #3778
Releases: main, 12.4, 11.5