### PR TITLE
[TASK] Add missing modes to code editor

### DIFF
--- a/Documentation/ApiOverview/CodeEditor/Index.rst
+++ b/Documentation/ApiOverview/CodeEditor/Index.rst
@@ -38,7 +38,9 @@ the mode for syntax highlighting can be chosen. Allowed values:
 *   :php:`css`
 *   :php:`html`
 *   :php:`javascript`
+*   :php:`json`
 *   :php:`php`
+*   :php:`sql`
 *   :php:`typoscript`
 *   :php:`xml`
 *   and any :ref:`custom mode <code-editor-register-mode>` registered by an


### PR DESCRIPTION
`json` and `sql` are also available.

See: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/backend/Configuration/Backend/T3editor/Modes.php
Releases: main