### PR TITLE
[TASK] Add note about outdated example for AfterCacheableContentIsGeneratedEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
@@ -37,6 +37,10 @@ Example
 ..  todo: The property TSFE->content used in the example was marked as internal
           in v13. A substitution is needed for this.
 
+..  note::
+    Currently, the example below is outdated. It uses a - now internal -
+    property :php:`TypoScriptFrontendController->content`.
+
 ..  literalinclude:: _AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
     :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php


### PR DESCRIPTION
See: https://typo3.slack.com/archives/C03AM9R17/p1704729359842859
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/752
Releases: main