### PR TITLE
[CI] Run tests with at least PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,4 +45,4 @@ jobs:
         run: Build/Scripts/runTests.sh -p ${{ env.php }} -s checkRst
 
       - name: Lint YAML
-        run: .Build/bin/yaml-lint Documentation/
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s yamlLint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.1'
           - '8.2'
           - '8.3'
     steps:
@@ -25,7 +24,7 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     env:
-      php: '8.1'
+      php: '8.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -46,6 +46,7 @@ Options:
             - cgl: cgl test and fix all php files
             - composerUpdate: "composer update", handy if host has no PHP
             - lint: PHP linting
+            - yamlLint: YAML linting
             - rector: Apply Rector rules
 
     -p <8.2|8.3>
@@ -195,6 +196,12 @@ case ${TEST_SUITE} in
         docker images typo3/core-testing-*:latest --format "{{.Repository}}:latest" | xargs -I {} docker pull {}
         # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
         docker images typo3/core-testing-* --filter "dangling=true" --format "{{.ID}}" | xargs -I {} docker rmi {}
+        ;;
+    yamlLint)
+        setUpDockerComposeDotEnv
+        docker-compose run yaml_lint
+        SUITE_EXIT_CODE=$?
+        docker-compose down
         ;;
     *)
         echo "Invalid -s option argument ${TEST_SUITE}" >&2

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -37,7 +37,7 @@ a recent docker-compose (tested >=1.21.2) is needed.
 
 Usage: $0 [options] [file]
 
-No arguments: Run all checks with PHP 8.1
+No arguments: Run all checks with PHP 8.2
 
 Options:
     -s <...>
@@ -48,10 +48,10 @@ Options:
             - lint: PHP linting
             - rector: Apply Rector rules
 
-    -p <8.1|8.2>
+    -p <8.2|8.3>
         Specifies the PHP minor version to be used
-            - 8.1 (default): use PHP 8.1
-            - 8.2: use PHP 8.2
+            - 8.2 (default): use PHP 8.2
+            - 8.3: use PHP 8.3
 
     -u
         Update existing typo3/core-testing-*:latest docker images. Maintenance call to docker pull latest
@@ -66,7 +66,7 @@ Options:
         Show this help.
 
 Examples:
-    # Run checks using PHP 8.1
+    # Run checks using PHP 8.2
     ./Build/Scripts/runTests.sh
 EOF
 
@@ -92,7 +92,7 @@ else
   ROOT_DIR=`realpath ${PWD}/../../`
 fi
 TEST_SUITE="cgl"
-PHP_VERSION="8.1"
+PHP_VERSION="8.2"
 SCRIPT_VERBOSE=0
 CGLCHECK_DRY_RUN=""
 IMAGE_PREFIX="ghcr.io/typo3/"
@@ -145,7 +145,7 @@ if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
     exit 1
 fi
 
-# Move "8.1" to "php81", the latter is the docker container name
+# Move "8.2" to "php82", the latter is the docker container name
 DOCKER_PHP_IMAGE=`echo "php${PHP_VERSION}" | sed -e 's/\.//'`
 
 # Suite execution

--- a/Build/testing-docker/docker-compose.yml
+++ b/Build/testing-docker/docker-compose.yml
@@ -50,6 +50,20 @@ services:
         find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null
       "
 
+  yaml_lint:
+    image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
+    user: "${HOST_UID}"
+    volumes:
+      - ${ROOT_DIR}:${ROOT_DIR}
+    working_dir: ${ROOT_DIR}
+    command: >
+      /bin/sh -c "
+        if [ ${SCRIPT_VERBOSE} -eq 1 ]; then
+          set -x
+        fi
+        .Build/bin/yaml-lint Documentation/
+      "
+
   composer_normalize:
     image: ${IMAGE_PREFIX}core-testing-${DOCKER_PHP_IMAGE}:latest
     user: "${HOST_UID}"

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "check:yaml": [
             "@check:yaml:lint"
         ],
-        "check:yaml:lint": ".Build/bin/yaml-lint Documentation/",
+        "check:yaml:lint": "Build/Scripts/runTests.sh -s yamlLint",
         "fix": [
             "@fix:composer",
             "@fix:php"


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/781
Releases: main