### PR TITLE
[BUGFIX] Correct php-cs-fixer path

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,8 +8,7 @@ use PhpCsFixer\Finder;
 return (new Config())
     ->setFinder(
         (new Finder())
-            ->ignoreVCSIgnored(true)
-            ->in(realpath(__DIR__ . '/../../'))
+            ->in(__DIR__)
     )
     ->setRiskyAllowed(true)
     ->setRules([


### PR DESCRIPTION
Additionally, remove ignoreVCSIgnored option as this is not needed.

Related: #3870
Releases: main