### PR TITLE
[TASK] Adjust ordering of the "Request life cycle" TOC

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/Index.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Index.rst
@@ -11,6 +11,6 @@ Request Life Cycle
     :maxdepth: 1
     :glob:
 
-    */Index
     *
+    */Index
 


### PR DESCRIPTION
Pages directly under the chapter should be listed first, then the subpages.

Before:
- TYPO3 request attributes
- Bootstrapping
- Middlewares (Request handling)
- TYPO3 request object

After:
- Bootstrapping
- Middlewares (Request handling)
- TYPO3 request object
- TYPO3 request attributes

Releases: main, 12.4, 11.5