### PR TITLE
[BUGFIX] Update _Registration.php

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
@@ -33,7 +33,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-        // non-Extbase modules is route based, provide them
+        // non-Extbase modules are route-based, provide them
         'routes' => [
             '_default' => [
                 'target' => AdminModuleController::class . '::manage',

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
@@ -9,6 +9,7 @@ use T3docs\Examples\Controller\ModuleController;
  * Definitions for modules provided by EXT:examples
  */
 return [
+    // Example for a module registration with extbase controller
     'web_examples' => [
         'parent' => 'web',
         'position' => ['after' => 'web_info'],
@@ -16,6 +17,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/page/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf',
+        // extbase specific configuration telling the TYPO3 core to bootstrap extbase
         'extensionName' => 'Examples',
         'controllerActions' => [
             ModuleController::class => [
@@ -23,6 +25,7 @@ return [
             ],
         ],
     ],
+    // non-extbase module registration
     'admin_examples' => [
         'parent' => 'system',
         'position' => ['top'],
@@ -30,9 +33,14 @@ return [
         'workspaces' => 'live',
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-        'controllerActions' => [
-            AdminModuleController::class => [
-                'index',
+        // non-extbase modules is route based, provide them
+        'routes' => [
+            '_default' => [
+                'target' => AdminModuleController::class . '::manage',
+            ],
+            'edit' => [
+                'path' => '/edit-me',
+                'target' => AdminModuleController::class . '::edit',
             ],
         ],
     ],

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
@@ -9,7 +9,7 @@ use T3docs\Examples\Controller\ModuleController;
  * Definitions for modules provided by EXT:examples
  */
 return [
-    // Example for a module registration with extbase controller
+    // Example for a module registration with Extbase controller
     'web_examples' => [
         'parent' => 'web',
         'position' => ['after' => 'web_info'],
@@ -17,7 +17,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/page/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf',
-        // extbase specific configuration telling the TYPO3 core to bootstrap extbase
+        // extbase specific configuration telling the TYPO3 core to bootstrap Extbase
         'extensionName' => 'Examples',
         'controllerActions' => [
             ModuleController::class => [
@@ -25,7 +25,7 @@ return [
             ],
         ],
     ],
-    // non-extbase module registration
+    // non-Extbase module registration
     'admin_examples' => [
         'parent' => 'system',
         'position' => ['top'],
@@ -33,7 +33,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/system/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
-        // non-extbase modules is route based, provide them
+        // non-Extbase modules is route based, provide them
         'routes' => [
             '_default' => [
                 'target' => AdminModuleController::class . '::manage',

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Registration.php
@@ -17,7 +17,7 @@ return [
         'workspaces' => 'live',
         'path' => '/module/page/example',
         'labels' => 'LLL:EXT:examples/Resources/Private/Language/Module/locallang_mod.xlf',
-        // extbase specific configuration telling the TYPO3 core to bootstrap Extbase
+        // Extbase-specific configuration telling the TYPO3 Core to bootstrap Extbase
         'extensionName' => 'Examples',
         'controllerActions' => [
             ModuleController::class => [


### PR DESCRIPTION
The example backend module registration example [1]
tells the reader that the first example is for a
extbase based module and the second for a non-extbase
module.

Sadly, the example is not reflecting this statement.

This change modifies the code example include and
adds php comments to emphasize this in the code
also. For the non-extbase example, the extbase config
parameters are removed and the corresponding module
route configuration for non-extbase modules added.

[1] https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.html#example-register-two-backend-modules)

Releases: main, 12.4