### PR TITLE
[TASK]  Add a note for extbase module registration params

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -304,6 +304,12 @@ Extbase module configuration options
 
 ..  _backend-modules-configuration-extensionName:
 
+..  note::
+    Using these extbase configurations tells the core to bootstrap extbase and expecting
+    controllers based on :php:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`.
+    Do not use it for non-extbase controller. Use :ref:`routes <backend-modules-configuration-routes>`
+    intead.
+
 ..  confval:: extensionName
 
     :Scope: Backend module configuration

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/ModuleConfiguration.rst
@@ -305,10 +305,10 @@ Extbase module configuration options
 ..  _backend-modules-configuration-extensionName:
 
 ..  note::
-    Using these extbase configurations tells the core to bootstrap extbase and expecting
+    Using these Extbase configurations tells the Core to bootstrap Extbase and expecting
     controllers based on :php:`\TYPO3\CMS\Extbase\Mvc\Controller\ActionController`.
-    Do not use it for non-extbase controller. Use :ref:`routes <backend-modules-configuration-routes>`
-    intead.
+    Do not use it for non-Extbase controller. Use :ref:`routes <backend-modules-configuration-routes>`
+    instead.
 
 ..  confval:: extensionName
 


### PR DESCRIPTION
The backend module registration lists the shared options and
the special extbase options, but for unexperienced developers
it may not be obvious to avoid using the extbase config
`controllerAction` for non-extbase based controllers.

This change adds a note to the extbase module registration
parameters in `ModuleConfiguration.rst` to emphasize the
impact and provide an alternative.

Releases: main, 12.4