### PR TITLE
Drop obsolete "deleteTree" DataHandler flag

### DIFF
--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -650,20 +650,6 @@ commands or data submission. These are the most significant:
 
 
  - :Variable:
-         ->deleteTree
-   :Type:
-         Boolean
-   :Description:
-         Sets whether a page tree branch can be recursively deleted.
-
-         If this is set, then a page is deleted by deleting the whole branch
-         under it (user must have delete permissions to it all). If not set,
-         then the page is deleted *only* if it has no branch.
-
-         Default is false.
-
-
- - :Variable:
          ->copyTree
    :Type:
          Integer


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92560-BackendEditorsCanAlwaysDeletePagesRecursive.html?highlight=deletetree