### PR TITLE
[TASK] Unify icon identifiers

### DIFF
--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -118,7 +118,7 @@ to render an icon in your view:
 ..  code-block:: html
 
     {namespace core = TYPO3\CMS\Core\ViewHelpers}
-    <core:icon identifier="my-icon-identifier" size="small" />
+    <core:icon identifier="tx-myext-svgicon" size="small" />
 
 This will render the desired icon using an :html:`img` tag. If you prefer having
 the SVG inlined into your HTML (for example, for being able to change colors
@@ -130,7 +130,7 @@ its surrounding element if you use this option.
 
     {namespace core = TYPO3\CMS\Core\ViewHelpers}
     <core:icon
-        identifier="my-icon-identifier"
+        identifier="tx-myext-svgicon"
         size="small"
         alternativeMarkupIdentifier="inline"
     />

--- a/Documentation/ApiOverview/Icon/_Icons.php
+++ b/Documentation/ApiOverview/Icon/_Icons.php
@@ -7,20 +7,20 @@ use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 
 return [
     // Icon identifier
-    'mysvgicon' => [
+    'tx-myext-svgicon' => [
         // Icon provider class
         'provider' => SvgIconProvider::class,
         // The source SVG for the SvgIconProvider
         'source' => 'EXT:my_extension/Resources/Public/Icons/mysvg.svg',
     ],
-    'mybitmapicon' => [
+    'tx-myext-bitmapicon' => [
         'provider' => BitmapIconProvider::class,
         // The source bitmap file
         'source' => 'EXT:my_extension/Resources/Public/Icons/mybitmap.png',
         // All icon providers provide the possibility to register an icon that spins
         'spinning' => true,
     ],
-    'anothersvgicon' => [
+    'tx-myext-anothersvgicon' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:my_extension/Resources/Public/Icons/anothersvg.svg',
         // Since TYPO3 v12.0 an extension that provides icons for broader


### PR DESCRIPTION
.. so that it is clear that no magic is going on with prefixes.

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/3897