### PR TITLE
[TASK] Use published version of typo3/cms-styleguide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "typo3/cms-scheduler": "^12.4",
         "typo3/cms-seo": "^12.4",
         "typo3/cms-setup": "^12.4",
-        "typo3/cms-styleguide": "^12.4",
+        "typo3/cms-styleguide": "^12.0",
         "typo3/cms-sys-note": "^12.4",
         "typo3/cms-t3editor": "^12.4",
         "typo3/cms-tstemplate": "^12.4",


### PR DESCRIPTION
A 12.4 release does not exist for this package. Instead, the current dev package "12.x-dev" is used. We should rely on the released version in this case.

Releases: 12.4