### PR TITLE
[TASK] Overhaul Developing a custom ViewHelper

### DIFF
--- a/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
+++ b/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
@@ -1,8 +1,8 @@
-.. include:: /Includes.rst.txt
-.. index::
-   ViewHelpers; Custom
-   Fluid; Custom ViewHelpers
-.. _fluid-custom-viewhelper:
+..  include:: /Includes.rst.txt
+..  index::
+    ViewHelpers; Custom
+    Fluid; Custom ViewHelpers
+..  _fluid-custom-viewhelper:
 
 ==============================
 Developing a custom ViewHelper
@@ -16,9 +16,9 @@ and shows the picture from gravatar.com if it exists.
 The official documentation of Fluid for writing custom ViewHelpers can be found
 within the Fluid documentation: :ref:`fluid:creating-viewhelpers`.
 
-.. contents:: Contents of this page
-   :local:
-   :depth: 2
+..  contents:: Contents of this page
+    :local:
+    :depth: 2
 
 
 Fluid
@@ -26,14 +26,14 @@ Fluid
 
 The custom ViewHelper is not part of the default distribution. Therefore a
 namespace import is necessary to use this ViewHelper. In the following example,
-the namespace :php:`\MyVendor\BlogExample\ViewHelpers` is imported with the
-prefix `blog`. Now, all tags starting with `blog:` are interpreted as
+the namespace :php:`\MyVendor\MyExtension\ViewHelpers` is imported with the
+prefix `m`. Now, all tags starting with `m:` are interpreted as
 ViewHelper from within this namespace:
 
-.. code-block:: html
-   :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+..  code-block:: html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   {namespace blog=MyVendor\BlogExample\ViewHelpers}
+    {namespace m=MyVendor\MyExtension\ViewHelpers}
 
 For further information about namespace import, see
 :ref:`fluid-syntax-viewhelpers-import-namespaces`.
@@ -41,55 +41,27 @@ For further information about namespace import, see
 The ViewHelper should be given the name "gravatar" and only take an email
 address as a parameter. The ViewHelper is called in the template as follows:
 
-.. code-block:: html
-   :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+..  code-block:: html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   <blog:gravatar emailAddress="username@example.org" />
+    <m:gravatar emailAddress="username@example.org" />
 
 AbstractViewHelper implementation
 =================================
 
 Every ViewHelper is a PHP class. For the Gravatar ViewHelper, the name of the
-class is :php:`\MyVendor\BlogExample\ViewHelpers\GravatarViewHelper`.
+class is :php:`\MyVendor\MyExtension\ViewHelpers\GravatarViewHelper`.
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
-   :linenos:
+..  literalinclude:: _CustomViewHelper/_GravatarViewHelper.php
+    :language: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
+    :linenos:
 
-   <?php
-   namespace MyVendor\BlogExample\ViewHelpers;
-
-   use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-
-   final class GravatarViewHelper extends AbstractViewHelper
-   {
-      use CompileWithRenderStatic;
-
-      protected $escapeOutput = false;
-
-      public function initializeArguments()
-      {
-          // registerArgument($name, $type, $description, $required, $defaultValue, $escape)
-          $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
-      }
-
-      public static function renderStatic(
-          array $arguments,
-          \Closure $renderChildrenClosure,
-          RenderingContextInterface $renderingContext
-      ) {
-          // this is improved with the TagBasedViewHelper (see below)
-          return '<img src="http://www.gravatar.com/avatar/' .
-            md5($arguments['emailAddress']) .
-            '" />';
-      }
-   }
 
 :php:`AbstractViewHelper`
 -------------------------
 
-*line 7*
+*line 11*
 
 Every ViewHelper must inherit from the class
 :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`.
@@ -100,12 +72,12 @@ Several subclasses are offering additional functionality. The
 :php:`TagBasedViewHelper` will be explained :ref:`later on in this chapter
 <creating-xml-tags-using-tagbasedviewhelper>` in detail.
 
-.. _fluid-viewhelper-custom-escaping-of-output:
+..  _fluid-viewhelper-custom-escaping-of-output:
 
 Escaping of output
 ------------------
 
-*line 11*
+*line 15*
 
 By default, all output is escaped by :php:`htmlspecialchars` to prevent cross
 site scripting.
@@ -122,12 +94,12 @@ disabled explicitly.
 
 Passing in children is explained in :ref:`prepare-viewhelper-for-inline-syntax`.
 
-.. _fluid-viewhelper-custom-initializeArguments:
+..  _fluid-viewhelper-custom-initializeArguments:
 
 :php:`initializeArguments()`
 ----------------------------
 
-*line 13*
+*line 17*
 
 The :php:`Gravatar` ViewHelper must hand over the email address which
 identifies the Gravatar. Every ViewHelper has to declare which parameters are
@@ -138,28 +110,28 @@ type `string`. These arguments can be accessed
 through the array :php:`$arguments`, which is passed into the :php:`renderStatic()`
 method (see :ref:`next section <fluid-viewhelper-custom-renderStatic>`).
 
-.. tip::
+..  tip::
 
-   Sometimes arguments can take various types. In this case, the type `mixed`
-   should be used.
+    Sometimes arguments can take various types. In this case, the type `mixed`
+    should be used.
 
-.. _fluid-viewhelper-custom-renderStatic:
+..  _fluid-viewhelper-custom-renderStatic:
 
 :php:`renderStatic()`
 ---------------------
 
-*line 19*
+*line 23*
 
 The method :php:`renderStatic()` is called once the ViewHelper is rendered. The
 return value of the method is rendered directly.
 
-* line 9*
+*line 13*
 
 The trait :php:`CompileWithRenderStatic` must be used if the class implements
 :php:`renderStatic()`.
 
-.. _creating-xml-tags-using-tagbasedviewhelper:
-.. _creating-html-tags-using-tagbasedviewhelper:
+..  _creating-xml-tags-using-tagbasedviewhelper:
+..  _creating-html-tags-using-tagbasedviewhelper:
 
 Creating HTML/XML tags with the :php:`AbstractTagBasedViewHelper`
 =================================================================
@@ -171,44 +143,18 @@ base class provides an instance of
 HTML-tags. It takes care of the syntactically correct creation and, for example,
 escapes single and double quotes in attribute values.
 
-.. attention::
+..  attention::
 
-   Correctly escaping the attribute values is mandatory as it affects security
-   and prevents cross-site scripting attacks.
+    Correctly escaping the attribute values is mandatory as it affects security
+    and prevents cross-site scripting attacks.
 
 Because the Gravatar ViewHelper creates an :html:`img` tag the use of the
 :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder` is advised:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
-   :linenos:
-
-   <?php
-   namespace MyVendor\BlogExample\ViewHelpers;
-
-   use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
-
-   class GravatarViewHelper extends AbstractTagBasedViewHelper
-   {
-       protected $tagName = 'img';
-
-       public function initializeArguments()
-       {
-           parent::initializeArguments();
-           $this->registerUniversalTagAttributes();
-           $this->registerTagAttribute('alt', 'string', 'Alternative Text for the image');
-           $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
-       }
-
-       public function render()
-       {
-           $this->tag->addAttribute(
-               'src',
-               'http://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress'])
-           );
-           return $this->tag->render();
-       }
-   }
+..  literalinclude:: _CustomViewHelper/_GravatarTagBasedViewHelper.php
+    :language: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
+    :linenos:
 
 What is different in this code?
 
@@ -225,7 +171,7 @@ from :php:`AbstractTagBasedViewHelper`, which provides and initializes the tag b
 :php:`$tagName`
 ---------------
 
-*line 8*
+*line 9*
 
 There is a class property :php:`$tagName` which stores the name of the tag to be
 created (:html:`<img>`).
@@ -233,7 +179,7 @@ created (:html:`<img>`).
 :php:`$this->tag->addAttribute()`
 ---------------------------------
 
-*line 20*
+*line 23*
 
 The tag builder is available at property :php:`$this->tag`. It offers the method
 :php:`addAttribute()` to add new tag attributes. In our example the attribute
@@ -242,17 +188,17 @@ The tag builder is available at property :php:`$this->tag`. It offers the method
 :php:`$this->tag->render()`
 ---------------------------------
 
-*line 24*
+*line 27*
 
 The GravatarViewHelper creates an img tag builder, which has a method named
 :php:`render()`. After configuring the tag builder instance, the rendered tag
 markup is returned.
 
-.. note::
+..  note::
 
-   As :php:`$this->tag` is an object property, :php:`render()` is used to
-   generate the output. :php:`renderStatic()` would have no access. For further
-   information take a look at :ref:`the-different-render-methods`.
+    As :php:`$this->tag` is an object property, :php:`render()` is used to
+    generate the output. :php:`renderStatic()` would have no access. For further
+    information take a look at :ref:`the-different-render-methods`.
 
 :php:`$this->registerTagAttribute()`
 ------------------------------------
@@ -265,14 +211,14 @@ If support for the :html:`<img>` attribute :html:`alt`
 should be provided in the ViewHelper, this can be done by initializing this in
 :php:`initializeArguments()` in the following way:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
 
-   public function initializeArguments()
-   {
+    public function initializeArguments(): void
+    {
        // registerTagAttribute($name, $type, $description, $required = false)
        $this->registerTagAttribute('alt', 'string', 'Alternative Text for the image');
-   }
+    }
 
 For registering the universal attributes id, class, dir, style, lang, title,
 accesskey and tabindex there is a helper method
@@ -282,17 +228,17 @@ If support for universal attributes should be provided and in addition to the
 `alt` attribute in the Gravatar ViewHelper the following
 :php:`initializeArguments()` method will be necessary:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
 
-   public function initializeArguments()
-   {
+    public function initializeArguments(): void
+    {
        parent::initializeArguments();
        $this->registerUniversalTagAttributes();
        $this->registerTagAttribute('alt', 'string', 'Alternative Text for the image');
-   }
+    }
 
-.. _insert-optional-arguments:
+..  _insert-optional-arguments:
 
 Insert optional arguments
 =========================
@@ -304,17 +250,17 @@ generated.
 
 The :php:`render()` method can be improved like this:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
 
-   public function initializeArguments()
-   {
+    public function initializeArguments(): void
+    {
        $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
        $this->registerArgument('size', 'integer', 'The size of the gravatar, ranging from 1 to 512', false, 80);
-   }
+    }
 
-   public function render()
-   {
+    public function render(): string
+    {
        $this->tag->addAttribute(
           'src',
           'http://www.gravatar.com/avatar/' .
@@ -322,12 +268,12 @@ The :php:`render()` method can be improved like this:
               '?s=' . urlencode($this->arguments['size'])
        );
        return $this->tag->render();
-   }
+    }
 
 With this setting of a default value and setting the fourth argument to `false`,
 the `size` attribute becomes optional.
 
-.. _prepare-viewhelper-for-inline-syntax:
+..  _prepare-viewhelper-for-inline-syntax:
 
 Prepare ViewHelper for inline syntax
 ====================================
@@ -336,31 +282,31 @@ So far, the Gravatar ViewHelper has focused on the tag structure of the
 ViewHelper. The call to render the ViewHelper was written with tag syntax, which
 seemed obvious because it itself returns a tag:
 
-.. code-block:: html
-   :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+..  code-block:: html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   <blog:gravatar emailAddress="{post.author.emailAddress}" />
+    <m:gravatar emailAddress="{post.author.emailAddress}" />
 
 Alternatively, this expression can be written using the inline notation:
 
-.. code-block:: html
-   :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+..  code-block:: html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   {blog:gravatar(emailAddress: post.author.emailAddress)}
+    {m:gravatar(emailAddress: post.author.emailAddress)}
 
 One should see the Gravatar ViewHelper as a kind of post-processor for an email
 address and would allow the following syntax:
 
-.. code-block:: html
-   :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+..  code-block:: html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   {post.author.emailAddress -> blog:gravatar()}
+    {post.author.emailAddress -> m:gravatar()}
 
 This syntax places focus on the variable that is passed to the ViewHelper as it
 comes first.
 
-The syntax `{post.author.emailAddress -> blog:gravatar()}` is an alternative
-syntax for `<blog:gravatar>{post.author.emailAddress}</blog:gravatar>`. To
+The syntax `{post.author.emailAddress -> m:gravatar()}` is an alternative
+syntax for `<m:gravatar>{post.author.emailAddress}</m:gravatar>`. To
 support this, the email address comes either from the argument `emailAddress`
 or, if it is empty, the content of the tag should be interpreted as email
 address.
@@ -371,7 +317,7 @@ support both tag mode and inline syntax.
 Depending on the implemented method for rendering, the implementation is
 different:
 
-.. _with-renderstatic:
+..  _with-renderstatic:
 
 With :php:`renderStatic()`
 --------------------------
@@ -382,41 +328,12 @@ between the opening and closing tag.
 
 Lets have a look at the new code of the :php:`renderStatic()` method:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
+..  literalinclude:: _CustomViewHelper/_GravatarWithContentElementsViewHelper.php
+    :language: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
+    :linenos:
 
-   <?php
-   namespace MyVendor\BlogExample\ViewHelpers;
-
-   use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-
-   class GravatarViewHelper extends AbstractViewHelper
-   {
-       use CompileWithContentArgumentAndRenderStatic;
-
-       protected $escapeOutput = false;
-
-       public function initializeArguments()
-       {
-           $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for');
-       }
-
-       public static function renderStatic(
-           array $arguments,
-           \Closure $renderChildrenClosure,
-           RenderingContextInterface $renderingContext
-       ) {
-           $emailAddress = $renderChildrenClosure();
-
-           return '<img src="http://www.gravatar.com/avatar/' .
-               md5($emailAddress) .
-               '" />';
-       }
-   }
-
-.. _with-render:
+..  _with-render:
 
 With :php:`render()`
 --------------------
@@ -427,39 +344,12 @@ between the opening and closing tag.
 
 Lets have a look at the new code of the :php:`render()` method:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/GravatarViewHelper.php
+..  literalinclude:: _CustomViewHelper/_GravatarTagBasedViewHelper2.php
+    :language: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php
+    :linenos:
 
-    <?php
-    namespace MyVendor\BlogExample\ViewHelpers;
-
-    use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
-
-    class GravatarViewHelper extends AbstractTagBasedViewHelper
-    {
-        protected $tagName = 'img';
-
-        public function initializeArguments()
-        {
-            $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', false, null);
-        }
-
-        public function render()
-        {
-            $emailAddress = $this->arguments['emailAddress'] ?? $this->renderChildren();
-
-            $this->tag->addAttribute(
-                'src',
-                'http://www.gravatar.com/avatar/' . md5($emailAddress)
-            );
-
-            return $this->tag->render();
-        }
-    }
-
-
-
-.. _handle-additional-arguments:
+..  _handle-additional-arguments:
 
 Handle additional arguments
 ===========================
@@ -470,33 +360,22 @@ configured, the :php:`handleAdditionalArguments()` method can be implemented.
 The :php:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper` makes use
 of this, to allow setting any `data-` argument for tag based ViewHelpers.
 
-The method will receive an array of all arguments, which are passed in addition
-to the registered arguments. The array uses the argument name as the key and the
-argument value as the value. Within the method, these arguments can be handled.
-
 For example, the :php:`AbstractTagBasedViewHelper` implements the following:
 
-.. code-block:: php
-   :caption: EXT:fluid/Classes/ViewHelpers/AbstractTagBasedViewHelper.php
+..  code-block:: php
+    :caption: EXT:fluid/Classes/ViewHelpers/AbstractTagBasedViewHelper.php
 
     public function handleAdditionalArguments(array $arguments)
     {
-        $unassigned = [];
-        foreach ($arguments as $argumentName => $argumentValue) {
-            if (strpos($argumentName, 'data-') === 0) {
-                $this->tag->addAttribute($argumentName, $argumentValue);
-            } else {
-                $unassigned[$argumentName] = $argumentValue;
-            }
-        }
-        parent::handleAdditionalArguments($unassigned);
+        $this->additionalArguments = $arguments;
+        parent::handleAdditionalArguments($arguments);
     }
 
 To keep the default behavior, all unwanted arguments should be passed to the
 parent method call :php:`parent::handleAdditionalArguments($unassigned);`, to
 throw exceptions accordingly.
 
-.. _the-different-render-methods:
+..  _the-different-render-methods:
 
 The different render methods
 ============================
@@ -505,7 +384,7 @@ ViewHelpers can have one or more of the following three methods for
 implementing the rendering. The following section will describe the differences
 between all three implementations.
 
-.. _compile-method:
+..  _compile-method:
 
 :php:`compile()`-Method
 -----------------------
@@ -519,55 +398,19 @@ The :php:`compile()` has to return the compiled PHP code for the ViewHelper.
 Also the argument :php:`$initializationPhpCode` can be used to add further PHP
 code before the execution.
 
-.. note::
+..  note::
 
-   The :php:`renderStatic()` method still has to be implemented for the non
-   compiled version of the ViewHelper. In the future, this should no longer be
-   necessary.
+    The :php:`renderStatic()` method still has to be implemented for the non
+    compiled version of the ViewHelper. In the future, this should no longer be
+    necessary.
 
 Example implementation:
 
-.. code-block:: php
-   :caption: EXT:blog_example/Classes/ViewHelpers/StrtolowerViewHelper.php
+..  literalinclude:: _CustomViewHelper/_StrtolowerViewHelper.php
+    :language: php
+    :caption: EXT:my_extension/Classes/ViewHelpers/StrtolowerViewHelper.php
 
-   <?php
-   namespace MyVendor\BlogExample\ViewHelpers;
-
-   use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
-   use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
-   use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
-   use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
-
-   class StrtolowerViewHelper extends AbstractViewHelper
-   {
-       use CompileWithRenderStatic;
-
-       public function initializeArguments()
-       {
-           $this->registerArgument('string', 'string', 'The string to lowercase.', true);
-       }
-
-       public static function renderStatic(
-           array $arguments,
-           \Closure $renderChildrenClosure,
-           RenderingContextInterface $renderingContext
-       ) {
-           return strtolower($arguments['string']);
-       }
-
-       public function compile(
-           $argumentsName,
-           $closureName,
-           &$initializationPhpCode,
-           ViewHelperNode $node,
-           TemplateCompiler $compiler
-       ) {
-           return 'strtolower(' . $argumentsName. '[\'string\'])';
-       }
-   }
-
-.. _renderstatic-method:
+..  _renderstatic-method:
 
 :php:`renderStatic()`-Method
 ----------------------------
@@ -583,13 +426,13 @@ As this method has to be static, there is no access to object properties such as
 :php:`$this->tag` (in a subclass of :php:`AbstractTagBasedViewHelper`) from within
 :php:`renderStatic`.
 
-.. note::
+..  note::
 
-   This method can not be used when access to child nodes is necessary. This is
-   the case for ViewHelpers like `if` or `switch` which need to access their
-   children like `then` or `else`. In that case, :php:`render()` has to be used.
+    This method can not be used when access to child nodes is necessary. This is
+    the case for ViewHelpers like `if` or `switch` which need to access their
+    children like `then` or `else`. In that case, :php:`render()` has to be used.
 
-.. _render-method:
+..  _render-method:
 
 :php:`render()`-Method
 ----------------------

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
@@ -22,7 +22,7 @@ final class GravatarViewHelper extends AbstractTagBasedViewHelper
     {
         $this->tag->addAttribute(
             'src',
-            'http://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress'])
+            'https://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress'])
         );
         return $this->tag->render();
     }

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+final class GravatarViewHelper extends AbstractTagBasedViewHelper
+{
+    protected $tagName = 'img';
+
+    public function initializeArguments(): void
+    {
+        parent::initializeArguments();
+        $this->registerUniversalTagAttributes();
+        $this->registerTagAttribute('alt', 'string', 'Alternative Text for the image');
+        $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
+    }
+
+    public function render(): string
+    {
+        $this->tag->addAttribute(
+            'src',
+            'http://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress'])
+        );
+        return $this->tag->render();
+    }
+}

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
@@ -14,7 +14,7 @@ final class GravatarViewHelper extends AbstractTagBasedViewHelper
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
-        $this->registerTagAttribute('alt', 'string', 'Alternative Text for the image');
+        $this->registerTagAttribute('alt', 'string', 'Alternative text for the image');
         $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
     }
 

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
@@ -21,7 +21,7 @@ final class GravatarViewHelper extends AbstractTagBasedViewHelper
 
         $this->tag->addAttribute(
             'src',
-            'http://www.gravatar.com/avatar/' . md5($emailAddress)
+            'https://www.gravatar.com/avatar/' . md5($emailAddress)
         );
 
         return $this->tag->render();

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\BlogExample\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
+
+final class GravatarViewHelper extends AbstractTagBasedViewHelper
+{
+    protected $tagName = 'img';
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', false, null);
+    }
+
+    public function render(): string
+    {
+        $emailAddress = $this->arguments['emailAddress'] ?? $this->renderChildren();
+
+        $this->tag->addAttribute(
+            'src',
+            'http://www.gravatar.com/avatar/' . md5($emailAddress)
+        );
+
+        return $this->tag->render();
+    }
+}

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+final class GravatarViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        // registerArgument($name, $type, $description, $required, $defaultValue, $escape)
+        $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for', true);
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): string {
+        // this is improved with the TagBasedViewHelper (see below)
+        return sprintf('<img src="http://www.gravatar.com/avatar/%s" />', md5($arguments['emailAddress']));
+    }
+}

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
@@ -26,6 +26,6 @@ final class GravatarViewHelper extends AbstractViewHelper
         RenderingContextInterface $renderingContext
     ): string {
         // this is improved with the TagBasedViewHelper (see below)
-        return sprintf('<img src="http://www.gravatar.com/avatar/%s" />', md5($arguments['emailAddress']));
+        return sprintf('<img src="https://www.gravatar.com/avatar/%s" />', md5($arguments['emailAddress']));
     }
 }

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderStatic;
+
+final class GravatarViewHelper extends AbstractViewHelper
+{
+    use CompileWithContentArgumentAndRenderStatic;
+
+    protected $escapeOutput = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('emailAddress', 'string', 'The email address to resolve the gravatar for');
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): string {
+        $emailAddress = $renderChildrenClosure();
+
+        return sprintf('<img src="http://www.gravatar.com/avatar/%s" />', md5($emailAddress));
+    }
+}

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
@@ -26,6 +26,6 @@ final class GravatarViewHelper extends AbstractViewHelper
     ): string {
         $emailAddress = $renderChildrenClosure();
 
-        return sprintf('<img src="http://www.gravatar.com/avatar/%s" />', md5($emailAddress));
+        return sprintf('<img src="https://www.gravatar.com/avatar/%s" />', md5($emailAddress));
     }
 }

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_StrtolowerViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_StrtolowerViewHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\BlogExample\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+final class StrtolowerViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('string', 'string', 'The string to lowercase.', true);
+    }
+
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ): string {
+        return strtolower($arguments['string']);
+    }
+
+    public function compile(
+        $argumentsName,
+        $closureName,
+        &$initializationPhpCode,
+        ViewHelperNode $node,
+        TemplateCompiler $compiler
+    ): string {
+        return 'strtolower(' . $argumentsName . '[\'string\'])';
+    }
+}


### PR DESCRIPTION
- Use "my_extension" instead of "blog_example"
- Normalize indentation
- move code examples to includes
- use typed returns, final and strict types
- Update line numbers where they are refered
- AbstractTagBasedViewHelper::handleAdditionalArguments changed in the Core, however I am not sure what this section wants to say. Lets deal with it in a follow up?

Releases: main, 12.4