### PR TITLE
[TASK] Clean up link handler events section

### DIFF
--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/Events.rst
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/Events.rst
@@ -9,20 +9,7 @@ Events to modify link handler
 =============================
 
 You may have to modify the list of available link handlers based on
-some dynamic value.
-
-..  versionchanged:: 12.0
-    Starting with TYPO3 version 12.0 you can use the following PSR-14 events:
+some dynamic value:
 
 *  :ref:`ModifyAllowedItemsEvent`
 *  :ref:`ModifyLinkHandlersEvent`
-
-Supporting both TYPO3 v12 and v11 to modify the available link handlers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you want to be compatible to both TYPO3 v12 and v11, you can keep your
-implementation of the hooks
-:php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['LinkBrowser']['hooks']` as
-described in :ref:`t3coreapi11:modifyLinkHandlers` and implement the
-event listeners at the same time. Remove the hook implementation upon dropping
-TYPO3 v11 support.


### PR DESCRIPTION
The transition phase is over with TYPO3 v13, so remove the section about compatibility with TYPO3 v11 and v12.

Releases: main