### PR TITLE
[TASK] Simplify ModifyUrlForCanonicalTagEvent listener example

### DIFF
--- a/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
@@ -16,13 +16,8 @@ final class MyEventListener
     public function __invoke(ModifyUrlForCanonicalTagEvent $event): void
     {
         // Note: $event->getUrl() is dispatched with the empty string value ''
-        $currentUrl = $this->getRequest()->getUri();
+        $currentUrl = $event->getRequest()->getUri();
         $newCanonical = $currentUrl->withHost('example.com');
         $event->setUrl((string)$newCanonical);
-    }
-
-    private function getRequest(): ServerRequestInterface
-    {
-        return $GLOBALS['TYPO3_REQUEST'];
     }
 }

--- a/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Seo\EventListener;
 
-use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Seo\Event\ModifyUrlForCanonicalTagEvent;
 


### PR DESCRIPTION
The request object is available via the event, there is no need to use the superglobal `$GLOBALS['TYPO3_REQUEST']` variable.

Releases: main, 12.4