### PR TITLE
[TASK] Replace PDO constants with those from Connection class

### DIFF
--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -162,6 +162,8 @@ Examples:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // `bodytext` = 'foo' - string comparison
     ->eq('bodytext', $queryBuilder->createNamedParameter('foo'))
 
@@ -172,10 +174,10 @@ Examples:
     ->eq('aTableAlias.bodytext', $queryBuilder->createNamedParameter('foo'))
 
     // `uid` = 42 - integer comparison
-    ->eq('uid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT))
+    ->eq('uid', $queryBuilder->createNamedParameter(42, Connection::PARAM_INT))
 
     // `uid` >= 42
-    ->gte('uid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT))
+    ->gte('uid', $queryBuilder->createNamedParameter(42, Connection::PARAM_INT))
 
     // `bodytext` LIKE 'lorem'
     ->like(

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -565,6 +565,8 @@ of the table on the right, and the join restriction as fourth argument:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // SELECT `sys_language`.`uid`, `sys_language`.`title`
     // FROM `sys_language`
     // INNER JOIN `pages` `p`
@@ -590,7 +592,7 @@ of the table on the right, and the join restriction as fourth argument:
            $queryBuilder->expr()->eq('p.sys_language_uid', $queryBuilder->quoteIdentifier('sys_language.uid'))
        )
        ->where(
-           $queryBuilder->expr()->eq('p.uid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT))
+           $queryBuilder->expr()->eq('p.uid', $queryBuilder->createNamedParameter(42, Connection::PARAM_INT))
        )
        ->executeQuery();
 
@@ -642,6 +644,8 @@ uses the alias of the first join target as left side:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // SELECT `tt_content_orig`.`sys_language_uid`
     // FROM `tt_content`
     // INNER JOIN `tt_content` `tt_content_orig` ON `tt_content`.`t3_origuid` = `tt_content_orig`.`uid`
@@ -654,9 +658,9 @@ uses the alias of the first join target as left side:
     // GROUP BY `tt_content_orig`.`sys_language_uid`
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('sys_language')
     $constraints = [
-        $queryBuilder->expr()->eq('tt_content.colPos', $queryBuilder->createNamedParameter(1, \PDO::PARAM_INT)),
-        $queryBuilder->expr()->eq('tt_content.pid', $queryBuilder->createNamedParameter(42, \PDO::PARAM_INT)),
-        $queryBuilder->expr()->eq('tt_content.sys_language_uid', $queryBuilder->createNamedParameter(2, \PDO::PARAM_INT)),
+        $queryBuilder->expr()->eq('tt_content.colPos', $queryBuilder->createNamedParameter(1, Connection::PARAM_INT)),
+        $queryBuilder->expr()->eq('tt_content.pid', $queryBuilder->createNamedParameter(42, Connection::PARAM_INT)),
+        $queryBuilder->expr()->eq('tt_content.sys_language_uid', $queryBuilder->createNamedParameter(2, Connection::PARAM_INT)),
     ];
     $queryBuilder
         ->select('tt_content_orig.sys_language_uid')

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -254,13 +254,15 @@ Workspace-related API for backend modules
    .. code-block:: php
       :caption: EXT:some_extension/Classes/SomeClass.php
 
-      // use \TYPO3\CMS\Backend\Utility\BackendUtility
+      // use TYPO3\CMS\Backend\Utility\BackendUtility
+      // use TYPO3\CMS\Core\Database\Connection;
+
       $result = $queryBuilder
          ->select('*')
          ->from('pages')
          ->where(
             $queryBuilder->expr()->eq('uid',
-               $queryBuilder->createNamedParameter($id, \PDO::PARAM_INT)
+               $queryBuilder->createNamedParameter($id, Connection::PARAM_INT)
             )
          )
          ->executeQuery();


### PR DESCRIPTION
Doctrine DBAL v4 dropped the support for using the `\PDO::PARAM_*` constants in favor of the enum types on several methods. Instead, the `Connection::PARAM_*` constants can be used (which acts as a fascade) - also in older versions. This saves problems on upgrades beforehand.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/811
Releases: main, 12.4, 11.5