### PR TITLE
[BUGFIX] Correct malformed hyperlink target in "Using DataHandler"

### DIFF
--- a/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/UsingDataHandler/Index.rst
@@ -22,7 +22,7 @@ array you want to pass to the class and call a few methods.
 
 
 .. index:: pair: DataHandler; Symfony
-.. _dataHandler-cli-command
+.. _dataHandler-cli-command:
 
 Using the DataHandler in a Symfony command
 ==========================================


### PR DESCRIPTION
Releases: main, 12.4, 11.5