### PR TITLE
[TASK] Add note about breaking flex form section change

### DIFF
--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -189,16 +189,16 @@ must be strings or integers.)
 
 .. versionchanged:: 13.0
 
-    The usage of available element types within flex form sections is
+    The usage of available element types within FlexForm sections is
     restricted. You should only use simple TCA types like 
-    :php:`type => 'input' within sections, and relations (:php:`type =>
-    'group'`, :php:`type => 'inline', :php:`type => 'select'` and similar)`
+    :php:`type => 'input'` within sections, and relations (:php:`type =>
+    'group'`, :php:`type => 'inline'`, :php:`type => 'select'` and similar)
     should be avoided.
     TYPO3 v13 specifically disallows using :php:`type => 'select'` with
     a :php:`foreign_table` set, which will raise an exception.
-    This does not apply for flex form fields outside of a :xml:`<section>`.
-    Details can be found in the
-    `patch notes <https://review.typo3.org/c/Packages/TYPO3.CMS/+/82689>`__.
+    This does not apply for FlexForm fields outside of a :xml:`<section>`.
+    Details can be found in
+    :ref:`ext_core:breaking-102970-1706447911`.
 
 
 .. _t3ds-elements-example:

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -182,9 +182,23 @@ must be strings or integers.)
          Defines for an object of the type <array> that it must contain other
          "array" type objects in each item of <el>. The meaning of this is application specific. For
          FlexForms it will allow the user to select between possible arrays of
-         objects to create in the form. For TemplaVoila it will select a
-         "container" element for another set of elements inside. This is quite
-         fuzzy unless you understand the contexts.
+         objects to create in the form. This is similar to the concept of
+         :ref:`IRRE / inline TCA definitions <t3tca:columns-inline>`.
+         For TemplaVoila it will select a "container" element for another set
+         of elements inside. This is quite fuzzy unless you understand the contexts.
+
+.. versionchanged:: 13.0
+
+    The usage of available element types within flex form sections is
+    restricted. You should only use simple TCA types like 
+    :php:`type => 'input' within sections, and relations (:php:`type =>
+    'group'`, :php:`type => 'inline', :php:`type => 'select'` and similar)`
+    should be avoided.
+    TYPO3 v13 specifically disallows using :php:`type => 'select'` with
+    a :php:`foreign_table` set, which will raise an exception.
+    This does not apply for flex form fields outside of a :xml:`<section>`.
+    Details can be found in the
+    `patch notes <https://review.typo3.org/c/Packages/TYPO3.CMS/+/82689>`__.
 
 
 .. _t3ds-elements-example:

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -185,7 +185,7 @@ must be strings or integers.)
          objects to create in the form. This is similar to the concept of
          :ref:`IRRE / inline TCA definitions <t3tca:columns-inline>`.
 
-.. versionchanged:: 13.0
+..  versionchanged:: 13.0
 
     The usage of available element types within FlexForm sections is
     restricted. You should only use simple TCA types like 

--- a/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/DataFormats/T3datastructure/Elements/Index.rst
@@ -184,8 +184,6 @@ must be strings or integers.)
          FlexForms it will allow the user to select between possible arrays of
          objects to create in the form. This is similar to the concept of
          :ref:`IRRE / inline TCA definitions <t3tca:columns-inline>`.
-         For TemplaVoila it will select a "container" element for another set
-         of elements inside. This is quite fuzzy unless you understand the contexts.
 
 .. versionchanged:: 13.0
 


### PR DESCRIPTION
type="select" is no longer allowed.
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/836