### PR TITLE
[TASK] #102875 - Add note about dropped "\PDO::PARAM_*" in Doctrine DBAL v4

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -1051,6 +1051,12 @@ Remarks:
 createNamedParameter()
 ======================
 
+..  versionchanged:: 13.0
+    Doctrine DBAL v4 dropped the support for using the :php:`\PDO::PARAM_*`
+    constants in favor of the enum types. Be aware of this and use
+    :php:`\TYPO3\CMS\Core\Database\Connection\::PARAM_*`, which can already be
+    used in TYPO3 v12 and v11.
+
 This method creates a placeholder for a field value of a prepared statement.
 **Always** use this when dealing with user input in expressions to protect the
 statement from SQL injections:


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/811
Releases: main, 12.4, 11.5