### PR TITLE
[TASK] Modernize XLIFF example

### DIFF
--- a/Documentation/ApiOverview/Localization/_de.locallang_modadministration.xlf
+++ b/Documentation/ApiOverview/Localization/_de.locallang_modadministration.xlf
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" date="2013-03-09T18:44:59Z" product-name="examples">
-        <header/>
         <body>
-            <trans-unit id="pages.title_formlabel" xml:space="preserve">
+            <trans-unit id="pages.title_formlabel" resname="pages.title_formlabel" approved="yes">
                 <source>Most important title</source>
                 <target>Wichtigster Titel</target>
             </trans-unit>


### PR DESCRIPTION
The "resname" attribute is useful when using Crowdin as translation service. The empty header tag is superfluous and therefore removed.

Releases: main, 12.4, 11.5