### PR TITLE
[BUGFIX] Remove outdated information about ext_tables_static+adt.sql

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
@@ -25,7 +25,7 @@ interface and the :guilabel:`Reload extension data` action. The static data is
 then only re-evaluated, if the file has different contents than on the last
 execution. In that case, the table is truncated and the new data imported.
 
-The table structure of static tables must be declared in the file
+The table structure of static tables must be declared in the
 :file:`ext_tables.sql` file, otherwise data cannot be added to a static table.
 
 .. warning::

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
@@ -9,28 +9,22 @@
 Static SQL tables and their data.
 
 If the extension requires static data you can dump it into an SQL file
-by this name. Example for dumping mysql data from bash (being in the
-extension directory):
+by this name. Example for dumping MySQL/MariaDB data from shell (executed in the
+extension's root directory):
 
 .. code-block:: shell
 
-   mysqldump --add-drop-table \
-               --password=[password] [database name] \
-               [tablename]  > ./ext_tables_static+adt.sql
+   mysqldump --user=[user] --password [database name] \
+             [tablename] > ./ext_tables_static+adt.sql
 
-:code:`--add-drop-table` will make sure to include a DROP TABLE
-statement so any data is inserted in a fresh table.
+Note that only :sql:`INSERT INTO` statements are allowed. If the contents of the
+SQL file change, the table is truncated and the new data is inserted.
 
-You can also drop the table content using the Extension Manager in the backend.
-
-.. note::
-
-   The table structure of static tables needs to be in the
-   :file:`ext_tables.sql` file as well - otherwise an installed static
-   table will be reported as being in excess in the Install Tool.
+The table structure of static tables needs to be in the
+:file:`ext_tables.sql` file as well - otherwise an installed static
+table will be reported as being in excess in the Install Tool.
 
 .. warning::
 
    Static data is not meant to be extended by other extensions. On
-   re-import all extended fields and data is lost due to `DROP TABLE`
-   statements.
+   re-import all extended fields and data is lost.

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesStaticAdtSql.rst
@@ -17,12 +17,16 @@ extension's root directory):
    mysqldump --user=[user] --password [database name] \
              [tablename] > ./ext_tables_static+adt.sql
 
-Note that only :sql:`INSERT INTO` statements are allowed. If the contents of the
-SQL file change, the table is truncated and the new data is inserted.
+Note that only :sql:`INSERT INTO` statements are allowed. The file is
+interpreted whenever the corresponding extension's setup routines get called:
+Upon first time installation, command task execution of
+:bash:`bin/typo3 extension:setup` or via the :guilabel:`Admin Tools > Extensions`
+interface and the :guilabel:`Reload extension data` action. The static data is
+then only re-evaluated, if the file has different contents than on the last
+execution. In that case, the table is truncated and the new data imported.
 
-The table structure of static tables needs to be in the
-:file:`ext_tables.sql` file as well - otherwise an installed static
-table will be reported as being in excess in the Install Tool.
+The table structure of static tables must be declared in the file
+:file:`ext_tables.sql` file, otherwise data cannot be added to a static table.
 
 .. warning::
 


### PR DESCRIPTION
Additionally:
- Added the user option to mysqldump as this is needed in most cases
- Remove the password value: This avoids the password being stored in the shell's history file. 
  When it is omitted, mysqldump asks interactively before executing the command.

Resolves: #3964
Releases: main, 12.4, 11.5