### PR TITLE
[TASK] Adjust example for mapping a TYPO3 table to another database

### DIFF
--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -76,8 +76,8 @@ Remarks:
 Example: two connections
 ========================
 
-Another example with two connections, where the :sql:`sys_log` table is mapped
-to a different endpoint:
+Another example with two connections, where the :sql:`be_sessions` table is
+mapped to a different endpoint:
 
 ..  code-block:: php
     :caption: config/system/settings.php
@@ -94,19 +94,19 @@ to a different endpoint:
                 'port' => 3306,
                 'user' => 'default_user',
             ],
-            'Syslog' => [
-                'charset' => 'utf8',
-                'dbname' => 'syslog_dbname',
+            'Sessions' => [
+                'charset' => 'utf8mb4',
                 'driver' => 'mysqli',
-                'host' => 'syslog_host',
+                'dbname' => 'sessions_dbname',
+                'host' => 'sessions_host',
                 'password' => '***',
                 'port' => 3306,
-                'user' => 'syslog_user',
+                'user' => 'some_user',
             ],
         ],
         'TableMapping' => [
-            'sys_log' => 'Syslog'
-        ],
+            'be_sessions' => 'Sessions',
+        ]
     ],
     // [...]
 

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -72,8 +72,8 @@ Connections
         ]
 
     It is possible to swap out tables from the default database and use a specific
-    setup (e.g. for logging or caching). For example, the following snippet could
-    be used to swap the :sql:`sys_log` table to another database or even another
+    setup (for instance, for caching). For example, the following snippet could
+    be used to swap the :sql:`be_sessions` table to another database or even another
     database server:
 
     ..  code-block:: php
@@ -89,18 +89,18 @@ Connections
                 'port' => 3306,
                 'user' => 'typo3',
             ],
-            'Syslog' => [
+            'Sessions' => [
                 'charset' => 'utf8mb4',
                 'driver' => 'mysqli',
-                'dbname' => 'syslog_dbname',
-                'host' => 'syslog_host',
+                'dbname' => 'sessions_dbname',
+                'host' => 'sessions_host',
                 'password' => '***',
                 'port' => 3306,
-                'user' => 'syslog_user',
+                'user' => 'some_user',
             ],
         ],
         'TableMapping' => [
-            'sys_log' => 'Syslog',
+            'be_sessions' => 'Sessions',
         ]
 
     ..  note::
@@ -298,7 +298,8 @@ TableMapping
     When a TYPO3 table is swapped to another database (either on the same host
     or another host) this table must be mapped to the other database.
 
-    For example, the :sql:`sys_log` table should be swapped to another database:
+    For example, the :sql:`be_sessions` table should be swapped to another
+    database:
 
     ..  code-block:: php
         :caption: config/system/settings.php | typo3conf/system/settings.php
@@ -307,16 +308,16 @@ TableMapping
             'Default' => [
                 // ...
             ],
-            'Syslog' => [
+            'Sessions' => [
                 'charset' => 'utf8mb4',
                 'driver' => 'mysqli',
-                'dbname' => 'syslog_dbname',
-                'host' => 'syslog_host',
+                'dbname' => 'sessions_dbname',
+                'host' => 'sessions_host',
                 'password' => '***',
                 'port' => 3306,
-                'user' => 'syslog_user',
+                'user' => 'some_user',
             ],
         ],
         'TableMapping' => [
-            'sys_log' => 'Syslog',
+            'be_sessions' => 'Sessions',
         ]


### PR DESCRIPTION
TYPO3 v13 expects all database Core system tables and especially all tables from extensions that have TCA attached to be configured for the main `Default` connection (especially `sys_*`, `pages`, `tt_content`).

Therefore, moving the `sys_log` table to another database should be avoided. The examples are now adjusted to use the `be_sessions` table instead.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/830
Releases: main, 12.4, 11.5