### PR TITLE
[TASK] #102800 - FAL enforces absolute paths to match project root or lockRootPath

### DIFF
--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -73,6 +73,8 @@ Is online?
     ..  code-block:: php
         :caption: config/system/settings.php
 
+        // Configure additional directories outside of the project's folder
+        // as absolute paths
         $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] = [
             ‘/var/shared/documents/’,
             ‘/var/shared/images/’,

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -61,7 +61,7 @@ Is online?
     projects) and the publicly accessible directory is located at
     :file:`/var/www/example.org/public/` (the "public root path"), accessing
     resources via the File Abstraction Layer component is limited to the
-    mentioned directories.
+    mentioned directories and its sub-directories.
 
     To grant **additional** access to directories, they must be explicitly
     configured in the system settings of

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -59,7 +59,7 @@ Is online?
     Assuming that a web project is located in the directory
     :file:`/var/www/example.org/` (the "project root path" for Composer-based
     projects) and the publicly accessible directory is located at
-    :file:`/var/www/example.org/public/` (the "public root path"), accessing
+    :file:`/var/www/example.org/public/` (the "public root path" or "web root"), accessing
     resources via the File Abstraction Layer component is limited to the
     mentioned directories and its sub-directories.
 

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -53,3 +53,33 @@ Is online?
         within your web root or accessible via a third-party storage service
         which is publicly available. The files will still be available to anyone
         who knows the path to the file.
+
+    ..  versionchanged:: 11.5.35/12.4.11
+
+    Assuming that a web project is located in the directory
+    :file:`/var/www/example.org/` (the "project root path" for Composer-based
+    projects) and the publicly accessible directory is located at
+    :file:`/var/www/example.org/public/` (the "public root path"), accessing
+    resources via the File Abstraction Layer component is limited to the
+    mentioned directories.
+
+    To grant **additional** access to directories, they must be explicitly
+    configured in the system settings of
+    :ref:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] <typo3ConfVars_be_lockRootPath>`
+    - either using the Install Tool or according to deployment techniques.
+
+    Example:
+
+    ..  code-block:: php
+        :caption: config/system/settings.php
+
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] = [
+            ‘/var/shared/documents/’,
+            ‘/var/shared/images/’,
+        ];
+
+    Storages that reference directories not explicitly granted will be marked as
+    "offline" internally - no resources can be used in the website's frontend
+    and backend context.
+
+    See also the `security bulletin "Path Traversal in TYPO3 File Abstraction Layer Storages" <https://typo3.org/security/advisory/typo3-core-sa-2024-001>`__.

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -42,20 +42,46 @@ fileadminDir
    :php:`\TYPO3\CMS\Core\Resource\ResourceFactory::getDefaultStorage().`
 
 
-.. index::
-   TYPO3_CONF_VARS BE; lockRootPath
-.. _typo3ConfVars_be_lockRootPath:
+..  index::
+    TYPO3_CONF_VARS BE; lockRootPath
+..  _typo3ConfVars_be_lockRootPath:
 
 lockRootPath
 ============
 
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
+..  versionchanged:: 11.5.35/12.4.11
+    This option has been extended to support an array of root path prefixes to
+    allow for multiple storages to be listed (before a string was expected).
 
-   :type: text
-   :Default: ''
+    It is suggested to use the new array-based syntax, which will be applied
+    automatically once this setting is updated via Install Tool configuration
+    wizard. Migration:
 
-   This path is used to evaluate if paths outside of the public web path should be
-   allowed. Ending slash required!
+    ..  code-block:: php
+        :caption: config/system/settings.php
+
+        // Before
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] = '/var/extra-storage';
+
+        // After
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath'] =  [
+            '/var/extra-storage1/',
+            '/var/extra-storage2/',
+        ];
+
+    See also the `security bulletin "Path Traversal in TYPO3 File Abstraction Layer Storages" <https://typo3.org/security/advisory/typo3-core-sa-2024-001>`__.
+
+..  confval:: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
+
+    :type: array of file paths
+    :Default: :php:`[]`
+
+    These absolute paths are used to evaluate, if paths outside of the project
+    path should be allowed. This restriction also applies for the local driver
+    of the :ref:`File Abstraction Layer <fal>`.
+
+    ..  attention::
+        Trailing slashes are enforced automatically.
 
 
 .. index::

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -51,7 +51,7 @@ lockRootPath
 
 ..  versionchanged:: 11.5.35/12.4.11
     This option has been extended to support an array of root path prefixes to
-    allow for multiple storages to be listed (before a string was expected).
+    allow for multiple storages to be listed (a string was expected before).
 
     It is suggested to use the new array-based syntax, which will be applied
     automatically once this setting is updated via Install Tool configuration


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/853
Related: https://typo3.org/security/advisory/typo3-core-sa-2024-001
Releases: main, 12.4, 11.5