### PR TITLE
[TASK] Add missing version to processor_stripColorProfileParameters

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -219,6 +219,8 @@ processor_stripColorProfileCommand
 processor_stripColorProfileParameters
 =====================================
 
+..  versionchanged:: 11.5.35/12.4.11
+
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters']
 
    :type: array of strings


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/852
Releases: main, 12.4, 11.5