### PR TITLE
[SEO] Mention "FlashMessageService" in the text

### DIFF
--- a/Documentation/ApiOverview/FlashMessages/FlashMessagesApi.rst
+++ b/Documentation/ApiOverview/FlashMessages/FlashMessagesApi.rst
@@ -70,9 +70,8 @@ In backend modules you can then make that message appear on top of the
 module after a page refresh or the rendering of the next page request
 or render it on your own where ever you want.
 
-This example adds the flash message at the top of modules when
-rendering the next request:
-
+In this example the :php:`FlashMessageService` (:php:`TYPO3\CMS\Core\Messaging\FlashMessageService`) 
+is used to add a flash message at the top a module:
 
 .. code-block:: php
    :caption: EXT:my_extension/Classes/Controller/SomeController.php


### PR DESCRIPTION
Our search seems to ignore Code Blocks and they seem to also be rated very low in Google.

I want to give a try if results can be improved by mentioning them in the document body.

releases: main, 12.4
resolves: https://github.com/TYPO3-Documentation/t3docs-search-indexer/issues/59