### PR TITLE
[TASK] Adjust condition in example for PolicyMutatedEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
@@ -7,7 +7,6 @@ namespace MyVendor\MyExtension\ContentSecurityPolicy\EventListener;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Directive;
 use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Event\PolicyMutatedEvent;
-use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Scope;
 use TYPO3\CMS\Core\Security\ContentSecurityPolicy\UriValue;
 
 #[AsEventListener(

--- a/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
@@ -17,8 +17,8 @@ final class MyEventListener
 {
     public function __invoke(PolicyMutatedEvent $event): void
     {
-        if ($event->scope !== Scope::backend()) {
-            // Only the backend policy should be adjusted
+        if ($event->scope->type->isFrontend()) {
+            // In our example, only the backend policy should be adjusted
             return;
         }
 


### PR DESCRIPTION
The condition only works for Scope::backend(). The now used example is the preferred way to check the scope (if in frontend or not).

See: https://typo3.slack.com/archives/C0K5MU94J/p1706696324998799?thread_ts=1706622765.449429&cid=C0K5MU94J
Releases: main, 12.4