### PR TITLE
[FEATURE] #102960 - Clarify main tables must be on default connection

### DIFF
--- a/Documentation/ApiOverview/Database/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Database/Configuration/Index.rst
@@ -76,6 +76,20 @@ Remarks:
 Example: two connections
 ========================
 
+..  attention::
+    ..  versionchanged:: 13.0
+
+    TYPO3 expects all "main" Core system tables to be configured for the
+    :php:`Default` connection (especially :sql:`sys_*`, :sql:`pages`,
+    :sql:`tt_content` and in general all tables that have
+    :ref:`TCA <t3tca:start>` configured). The reason for this is to improve
+    performance with joins between tables. Cross-database joins are almost
+    impossible.
+
+    One scenario for using a separate database connection is to query data
+    directly from a third-party application in a custom extension. Another
+    use case is database-based caches.
+
 Another example with two connections, where the :sql:`be_sessions` table is
 mapped to a different endpoint:
 
@@ -118,12 +132,6 @@ Remarks:
 
 *   It is possible to map multiple tables to a different endpoint by adding
     further table name / connection name pairs to :php:`TableMapping`.
-
-*   However, this "connection per table" approach is limited: In the above
-    example, if a join query is executed that spans different connections, an
-    exception will be thrown. It is up to the administrator to group the
-    affected tables to the same connection in those cases, or a developer should
-    implement fallback logic to suppress the :sql:`join()`.
 
 
 ..  attention::

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -103,6 +103,20 @@ Connections
             'be_sessions' => 'Sessions',
         ]
 
+    ..  attention::
+        ..  versionchanged:: 13.0
+
+        TYPO3 expects all "main" Core system tables to be configured for the
+        :php:`Default` connection (especially :sql:`sys_*`, :sql:`pages`,
+        :sql:`tt_content` and in general all tables that have
+        :ref:`TCA <t3tca:start>` configured). The reason for this is to improve
+        performance with joins between tables. Cross-database joins are almost
+        impossible.
+
+        One scenario for using a separate database connection is to query data
+        directly from a third-party application in a custom extension. Another
+        use case is database-based caches.
+
     ..  note::
         The connection options described below are the most commonly used. These
         options correspond to the options of the underlying Doctrine DBAL


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/830
Releases: main