### PR TITLE
[TASK] #102916 - Use TrimMode class constants for ExpressionBuilder::trim()

### DIFF
--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -295,11 +295,11 @@ The call to :php:`$queryBuilder->expr()-trim()` can be one of the following:
 
 *   :php:`trim('fieldName')`
     results in :code:`TRIM("tableName"."fieldName")`
-*   :php:`trim('fieldName', AbstractPlatform::TRIM_LEADING, 'x')`
+*   :php:`trim('fieldName', TrimMode::LEADING, 'x')`
     results in :code:`TRIM(LEADING "x" FROM "tableName"."fieldName")`
-*   :php:`trim('fieldName', AbstractPlatform::TRIM_TRAILING, 'x')`
+*   :php:`trim('fieldName', TrimMode::TRAILING, 'x')`
     results in :code:`TRIM(TRAILING "x" FROM "tableName"."fieldName")`
-*   :php:`trim('fieldName', AbstractPlatform::TRIM_BOTH, 'x')`
+*   :php:`trim('fieldName', TrimMode::BOTH, 'x')`
     results in :code:`TRIM(BOTH "x" FROM "tableName"."fieldName")`
 
 


### PR DESCRIPTION
The `TrimMode` class is available at least since Doctrine DBAL v2.13 (which is shipped with TYPO3 v11).

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/815
Releases: main, 12.4, 11.5