### PR TITLE
[TASK] Document QueryBuilder::setMaxResults(null) to get all results

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -828,6 +828,8 @@ Remarks:
     out the first n records". Internally, :sql:`LIMIT` will be added by
     Doctrine DBAL and set to a very high value.
 
+*   Use :php:`->setMaxResults(null)` to retrieve all results.
+
 
 .. _database-query-builder-add:
 


### PR DESCRIPTION
`null` will be mandatory with Doctrine DBAL v4/TYPO3 v13. Before, also `0` was possible. The upgrade-safe method call is now documented. Doctrine DBAL v2.13 (used in TYPO3 v11) also accepts `null`, so this change can also be backported.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/811
Releases: main, 12.4, 11.5