### PR TITLE
Fix $GLOBALS[TYPO3_CONF_VARS][MAIL] documentation for symfony/mailer

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -430,7 +430,7 @@ transport_spool_type
 
    file
       Messages get stored to the file system till they get sent through the
-      command mailer:spool:send.
+      command :bash:`mailer:spool:send`.
    memory
       Messages get sent at the end of the running process.
    *classname*

--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -176,7 +176,7 @@ transport
 
    *classname*
       Custom class which implements
-      \\Symfony\\Component\\Mailer\\Transport\\TransportInterface. The constructor
+      :php:`\Symfony\Component\Mailer\Transport\TransportInterface`. The constructor
       receives all settings from the MAIL section to make it possible to add
       custom settings.
 

--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -175,9 +175,10 @@ transport
       setting below
 
    *classname*
-      Custom class which implements Swift_Transport. The constructor
-      receives all settings from the MAIL section to make it possible to
-      add custom settings.
+      Custom class which implements
+      \\Symfony\\Component\\Mailer\\Transport\\TransportInterface. The constructor
+      receives all settings from the MAIL section to make it possible to add
+      custom settings.
 
 .. index::
    TYPO3_CONF_VARS MAIL; transport_smtp_server
@@ -428,12 +429,13 @@ transport_spool_type
    :Default: ''
 
    file
-      Messages get stored to the file system till they get sent through
-      the command swiftmailerspoolsend.
+      Messages get stored to the file system till they get sent through the
+      command mailer:spool:send.
    memory
-      Messages get send at the end of the running process.
+      Messages get sent at the end of the running process.
    *classname*
-      Custom class which implements the Swift_Spool interface.
+      Custom class which implements the
+      \\TYPO3\\CMS\\Core\\Mail\\DelayedTransportInterface interface.
 
 .. index::
    TYPO3_CONF_VARS MAIL; transport_spool_filepath

--- a/Documentation/Configuration/Typo3ConfVars/MAIL.rst
+++ b/Documentation/Configuration/Typo3ConfVars/MAIL.rst
@@ -435,7 +435,7 @@ transport_spool_type
       Messages get sent at the end of the running process.
    *classname*
       Custom class which implements the
-      \\TYPO3\\CMS\\Core\\Mail\\DelayedTransportInterface interface.
+      :php:`\TYPO3\CMS\Core\Mail\DelayedTransportInterface` interface.
 
 .. index::
    TYPO3_CONF_VARS MAIL; transport_spool_filepath


### PR DESCRIPTION
Fixes the documentation for $GLOBALS[TYPO3_CONF_VARS][MAIL] configuration for the symfony mailer introduced in TYPO3 11.5.

The updated descriptions are copied from https://github.com/TYPO3/typo3/blob/main/typo3/sysext/core/Configuration/DefaultConfigurationDescription.yaml 

While at it, also escape the class name for \TYPO3\CMS\Core\Mail\DelayedTransportInterface.

This should also be backported to v11 and v12.