### PR TITLE
[TASK] Add information about blocked sys_file in DataHandler

### DIFF
--- a/Documentation/ApiOverview/Fal/Architecture/Database.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Database.rst
@@ -53,6 +53,15 @@ Some important fields:
     :ref:`TCA <t3tca:start>` of the :sql:`sys_file` table.
 
 
+.. caution::
+   .. versionchanged:: 13.0.1/12.4.11/11.5.35
+   Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
+   version 11.5.35, 12.4.11, and 13.0.1. The table
+   should not be extended and additional fields should be added to 
+   :sql:`sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
+   for more information.
+
+
 ..  index:: Tables; sys_file_metadata
 ..  _fal-architecture-database-sys-file-metadata:
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -441,7 +441,7 @@ Description of keywords in syntax:
 
 .. caution::
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
-   version 8.7.57, 9.5.46, 10.4.43, 11.5.35, 12.4.11, and 13.0.1. The table
+   version 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to 
    :sql:`sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
    for more information.

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -439,6 +439,14 @@ Description of keywords in syntax:
    FlexForm fields always end with a "regular value" of course.
 
 
+.. caution::
+   Modifying the `sys_file` table using DataHandler is blocked since TYPO3
+   version 8.7.57, 9.5.46, 10.4.43, 11.5.35, 12.4.11, and 13.0.1. The table
+   should not be extended and additional fields should be added to 
+   `sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
+   for more information.
+
+
 .. index:: DataHandler; Data submission
 .. _tce-data-examples:
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -440,7 +440,7 @@ Description of keywords in syntax:
 
 
 .. caution::
-   Modifying the `sys_file` table using DataHandler is blocked since TYPO3
+   Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 8.7.57, 9.5.46, 10.4.43, 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to 
    `sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -443,7 +443,7 @@ Description of keywords in syntax:
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 8.7.57, 9.5.46, 10.4.43, 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to 
-   `sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
+   :sql:`sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
    for more information.
 
 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -439,8 +439,8 @@ Description of keywords in syntax:
    FlexForm fields always end with a "regular value" of course.
 
 
-..  caution::
-    ..  versionchanged:: 13.0.1/12.4.11/11.5.35
+.. caution::
+   .. versionchanged:: 13.0.1/12.4.11/11.5.35
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to 

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -439,7 +439,8 @@ Description of keywords in syntax:
    FlexForm fields always end with a "regular value" of course.
 
 
-.. caution::
+..  caution::
+    ..  versionchanged:: 13.0.1/12.4.11/11.5.35
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to 


### PR DESCRIPTION
Adds a warning concerning the inability to modify the sys_file table using DataHandler since the security advisory "TYPO3-CORE-SA-2024-006: Improper Access Control Persisting File Abstraction Layer Entities via Data Handler" (see: https://typo3.org/security/advisory/typo3-core-sa-2024-006)