### PR TITLE
[TASK] Add section about using DI inside ext_conf_template.txt userfuncs

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -646,6 +646,32 @@ interface is given:
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
+User functions and their restrictions
+-------------------------------------
+
+It is possible to use dependency injection when calling custom user functions,
+for example :ref:`.userFunc within TypoScript <t3tsref:cobj-user-properties>` or
+:ref:`in (legacy) hooks <hooks-general>`, usually via
+:php:`\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()`.
+
+This method :php:`callUserFunction()` internally uses the dependency-injection-aware
+helper :php:`GeneralUtility::makeInstance()`, which can recognize and inject
+classes/services that are marked public.
+
+..  attention::
+
+    The backend module :guilabel:`Admin Tools > Extensions > Configuration` is also
+    able to specify user functions for input options provided via an
+    :file:`ext_conf_template.txt` (see :ref:`extension-configuration`).
+
+    However, this backend module is executed in a special low-level context
+    that disables some functionality for failsafe-reasons. Specifically,
+    this prevents dependency injection from being used in this scenario.
+
+    If you need to utilize services and other classes inside user functions
+    that are called there, you need to perform custom :php:`GeneralUtility::makeInstance()`
+    calls inside your own user function method to initialize those needed classes/services.
+
 Dependency injection in a XCLASSed class
 ----------------------------------------
 


### PR DESCRIPTION
According to the slack thread:

https://typo3.slack.com/archives/C025BQLFA/p1708949302026419
https://typo3.slack.com/archives/C025BQLFA/p1708950531310449

there is an issue when using userfuncs and DI within the extension configuration.

I tried to put this as general statements. Feedback appreciated on whether any information here is imprecise or can be improved.

<img width="898" alt="Screenshot 2024-02-26 at 18 00 48" src="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/273326/f90006d3-c2a8-4832-a21d-b6fcf2df8133">

Releases: main, 12.4, 11.5