### PR TITLE
add example for Context dependency injection

### DIFF
--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -18,13 +18,27 @@ track of, for example, the current time, if a user is logged in and which
 workspace is currently accessed.
 
 The :php:`\TYPO3\CMS\Core\Context\Context` object can be retrieved via
-:ref:`dependency injection <DependencyInjection>`:
+:ref:`dependency injection <DependencyInjection>` in the injection method:
+
+..  literalinclude:: _MyControllerUsingDependencyInjection.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Controller/MyController.php
+
+This requires under some circumstances also an entry in the :file:`Services.yaml` file (:ref:`more in <ServicesYaml>`):
+
+..  literalinclude:: _MyControllerServices.yaml
+    :language: yaml
+    :caption: EXT:my_extension/Configuration/Services.yaml
+
+
+Alternatively the :php:`\TYPO3\CMS\Core\Context\Context` object can also be retrieved in the constructor:
 
 ..  literalinclude:: _MyController.php
     :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
-This information is separated in so-called
+
+Context information is separated in so-called
 ":ref:`aspects <context_api_aspects>`", each being responsible for a certain
 area.
 

--- a/Documentation/ApiOverview/Context/_MyController.php
+++ b/Documentation/ApiOverview/Context/_MyController.php
@@ -10,8 +10,5 @@ final class MyController
 {
     public function __construct(
         private readonly Context $context
-    )
-    {
-        $this->context = $context;
-    }
+    ) {}
 }

--- a/Documentation/ApiOverview/Context/_MyController.php
+++ b/Documentation/ApiOverview/Context/_MyController.php
@@ -8,11 +8,6 @@ use TYPO3\CMS\Core\Context\Context;
 
 final class MyController
 {
-    /**
-     * @var Context
-     */
-    protected Context $context;
-
     public function __construct(
         private readonly Context $context
     )

--- a/Documentation/ApiOverview/Context/_MyController.php
+++ b/Documentation/ApiOverview/Context/_MyController.php
@@ -9,6 +9,6 @@ use TYPO3\CMS\Core\Context\Context;
 final class MyController
 {
     public function __construct(
-        private readonly Context $context
+        private readonly Context $context,
     ) {}
 }

--- a/Documentation/ApiOverview/Context/_MyControllerServices.yaml
+++ b/Documentation/ApiOverview/Context/_MyControllerServices.yaml
@@ -5,4 +5,4 @@ services:
     public: false
   MyVendor\MyExtension\:
     resource: '../Classes/*'
-    exclude: '../Classes/Api/*'
+    exclude: '../Classes/FolderToExclude/*'

--- a/Documentation/ApiOverview/Context/_MyControllerServices.yaml
+++ b/Documentation/ApiOverview/Context/_MyControllerServices.yaml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+  MyVendor\MyExtension\:
+    resource: '../Classes/*'
+    exclude: '../Classes/Api/*'

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
@@ -16,7 +16,7 @@ final class MyController
     public function __construct() {}
 
     public function injectContext(
-        private readonly Context $context
+        Context $context
     )
     {
         $this->context = $context;

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
@@ -17,8 +17,7 @@ final class MyController
 
     public function injectContext(
         Context $context
-    )
-    {
+    ) {
         $this->context = $context;
     }
 }

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
@@ -8,9 +8,6 @@ use TYPO3\CMS\Core\Context\Context;
 
 final class MyController
 {
-    /**
-     * @var Context
-     */
     protected Context $context;
 
     public function __construct() {}

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
@@ -13,8 +13,7 @@ final class MyController
      */
     protected Context $context;
 
-    public function __construct()
-        {}
+    public function __construct() {}
 
     public function injectContext(
         private readonly Context $context

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDependencyInjection.php
@@ -13,7 +13,10 @@ final class MyController
      */
     protected Context $context;
 
-    public function __construct(
+    public function __construct()
+        {}
+
+    public function injectContext(
         private readonly Context $context
     )
     {


### PR DESCRIPTION
The current PHP example only shows a constructor for dependency injection. TYPO3 however recommends to use inject methods instead of the constructor on the later pages.
In some cases it is even necessary to make an entry in the Services.yaml file to get this working.