### PR TITLE
[TASK] Adjust meta tag introduction

### DIFF
--- a/Documentation/ApiOverview/Seo/MetaTagApi.rst
+++ b/Documentation/ApiOverview/Seo/MetaTagApi.rst
@@ -6,7 +6,8 @@
 MetaTag API
 ============
 
-In order to have the possibility to set metatags in a flexible (but regulated way), a new MetaTag API is introduced.
+The MetaTag API is available for setting meta tags in a flexible (but
+controlled) way.
 
 .. note::
 

--- a/Documentation/ApiOverview/Seo/MetaTagApi.rst
+++ b/Documentation/ApiOverview/Seo/MetaTagApi.rst
@@ -6,8 +6,7 @@
 MetaTag API
 ============
 
-The MetaTag API is available for setting meta tags in a flexible (but
-controlled) way.
+The MetaTag API is available for setting meta tags in a flexible way.
 
 .. note::
 


### PR DESCRIPTION
The MetaTag API is available since TYPO3 v9. Time to not write that a "new MetaTag API is introduced".

Releases: main, 12.4, 11.5