### PR TITLE
[Backport 12.4] [TASK] Add trailing commas to arguments, match and parameters (#4061)

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -67,7 +67,7 @@ return (new Config())
         'single_line_comment_style' => ['comment_types' => ['hash']],
         // @todo: Can be dropped once we enable @PER-CS2.0
         'single_line_empty_body' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
         'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
 

--- a/Build/Scripts/validateRstFiles.php
+++ b/Build/Scripts/validateRstFiles.php
@@ -78,7 +78,7 @@ class validateRstFiles
                     $this->messages['include']['title'],
                     $this->messages['reference']['title'],
                     $this->messages['index']['title'],
-                    $shortPath
+                    $shortPath,
                 );
                 if ($this->messages['include']['message']) {
                     printf($this->messages['include']['message'] . chr(10));

--- a/Documentation/ApiOverview/Assets/_MyClassWithAssetCollector.php
+++ b/Documentation/ApiOverview/Assets/_MyClassWithAssetCollector.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Page\AssetCollector;
 final class MyClass
 {
     public function __construct(
-        private readonly AssetCollector $assetCollector
+        private readonly AssetCollector $assetCollector,
     ) {}
 
     public function doSomething()

--- a/Documentation/ApiOverview/Assets/_MyClassWithPageRenderer.php
+++ b/Documentation/ApiOverview/Assets/_MyClassWithPageRenderer.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 final class MyClass
 {
     public function __construct(
-        private readonly PageRenderer $pageRenderer
+        private readonly PageRenderer $pageRenderer,
     ) {}
 
     public function doSomething()

--- a/Documentation/ApiOverview/Backend/JavaScript/ES6/_LoadES6V11Compatible.php
+++ b/Documentation/ApiOverview/Backend/JavaScript/ES6/_LoadES6V11Compatible.php
@@ -7,11 +7,11 @@ use TYPO3\CMS\Core\Information\Typo3Version;
 $typo3Version = new Typo3Version();
 if ($typo3Version->getMajorVersion() > 11) {
     $this->pageRenderer->loadJavaScriptModule(
-        '@vendor/my-extension/my-example.js'
+        '@vendor/my-extension/my-example.js',
     );
 } else {
     // keep RequireJs for TYPO3 below v12.0
     $this->pageRenderer->loadRequireJsModule(
-        'TYPO3/CMS/MyExtension/MyExample'
+        'TYPO3/CMS/MyExtension/MyExample',
     );
 }

--- a/Documentation/ApiOverview/Backend/JavaScript/ES6/_PageRendererJavaScriptLoading.php
+++ b/Documentation/ApiOverview/Backend/JavaScript/ES6/_PageRendererJavaScriptLoading.php
@@ -21,7 +21,7 @@ final class SomeClass
 
         // Load JavaScript via JavaScriptRenderer
         $this->pageRenderer->getJavaScriptRenderer()->addJavaScriptModuleInstruction(
-            JavaScriptModuleInstruction::create('@vendor/my-extension/example.js')
+            JavaScriptModuleInstruction::create('@vendor/my-extension/example.js'),
         );
     }
 }

--- a/Documentation/ApiOverview/Backend/_Ajax/_ExampleController2.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_ExampleController2.php
@@ -14,7 +14,7 @@ final class ExampleController
         $input = $request->getQueryParams()['input']
             ?? throw new \InvalidArgumentException(
                 'Please provide a number',
-                1580585107
+                1580585107,
             );
 
         $result = $input ** 2;

--- a/Documentation/ApiOverview/Backend/_Ajax/_ExampleController3.php
+++ b/Documentation/ApiOverview/Backend/_Ajax/_ExampleController3.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final class ExampleController
 {
     public function __construct(
-        private readonly ResponseFactoryInterface $responseFactory
+        private readonly ResponseFactoryInterface $responseFactory,
     ) {}
 
     public function doSomethingAction(ServerRequestInterface $request): ResponseInterface
@@ -19,7 +19,7 @@ final class ExampleController
         $input = $request->getQueryParams()['input']
             ?? throw new \InvalidArgumentException(
                 'Please provide a number',
-                1580585107
+                1580585107,
             );
 
         $result = $input ** 2;
@@ -27,7 +27,7 @@ final class ExampleController
         $response = $this->responseFactory->createResponse()
             ->withHeader('Content-Type', 'application/json; charset=utf-8');
         $response->getBody()->write(
-            json_encode(['result' => $result], JSON_THROW_ON_ERROR)
+            json_encode(['result' => $result], JSON_THROW_ON_ERROR),
         );
         return $response;
     }

--- a/Documentation/ApiOverview/Backend/_BackendRouting/_UriBuilderExample.php
+++ b/Documentation/ApiOverview/Backend/_BackendRouting/_UriBuilderExample.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 final class MyRouteController
 {
     public function __construct(
-        private readonly UriBuilder $uriBuilder
+        private readonly UriBuilder $uriBuilder,
     ) {}
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -21,7 +21,7 @@ final class MyRouteController
         // Using a route identifier
         $uri = $this->uriBuilder->buildUriFromRoute(
             'web_layout',
-            ['id' => 42]
+            ['id' => 42],
         );
 
         // Using a route path
@@ -33,7 +33,7 @@ final class MyRouteController
                         123 => 'edit',
                     ],
                 ],
-            ]
+            ],
         );
 
         // ... do some other stuff

--- a/Documentation/ApiOverview/Backend/_BroadcastChannels/_BackendControllerHook.php
+++ b/Documentation/ApiOverview/Backend/_BroadcastChannels/_BackendControllerHook.php
@@ -9,16 +9,16 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 final class BackendControllerHook
 {
     public function __construct(
-        private readonly PageRenderer $pageRenderer
+        private readonly PageRenderer $pageRenderer,
     ) {}
 
     public function registerClientSideEventHandler(): void
     {
         $this->pageRenderer->loadJavaScriptModule(
-            '@myvendor/my-extension/event-handler.js'
+            '@myvendor/my-extension/event-handler.js',
         );
         $this->pageRenderer->addInlineLanguageLabelFile(
-            'EXT:my_extension/Resources/Private/Language/locallang_slug_service.xlf'
+            'EXT:my_extension/Resources/Private/Language/locallang_slug_service.xlf',
         );
     }
 }

--- a/Documentation/ApiOverview/Backend/_ButtonComponents/_DropDownButton.php
+++ b/Documentation/ApiOverview/Backend/_ButtonComponents/_DropDownButton.php
@@ -40,12 +40,12 @@ final class MyBackendController
             ->addItem(
                 GeneralUtility::makeInstance(DropDownItem::class)
                     ->setLabel('Item')
-                    ->setHref('#')
+                    ->setHref('#'),
             );
         $buttonBar->addButton(
             $dropDownButton,
             ButtonBar::BUTTON_POSITION_RIGHT,
-            2
+            2,
         );
     }
 }

--- a/Documentation/ApiOverview/CachingFramework/Developer/_MyClass.php
+++ b/Documentation/ApiOverview/CachingFramework/Developer/_MyClass.php
@@ -7,7 +7,7 @@ use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 final class MyClass
 {
     public function __construct(
-        private readonly FrontendInterface $cache
+        private readonly FrontendInterface $cache,
     ) {}
 
     //...

--- a/Documentation/ApiOverview/CommandControllers/_Tutorial/_DoSomethingCommandViaAttribute.php
+++ b/Documentation/ApiOverview/CommandControllers/_Tutorial/_DoSomethingCommandViaAttribute.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(
     name: 'examples:dosomething',
     description: 'A command that does nothing and always succeeds.',
-    aliases: ['examples:dosomethingalias']
+    aliases: ['examples:dosomethingalias'],
 )]
 class DoSomethingCommand extends Command
 {

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
@@ -20,7 +20,7 @@ defined('TYPO3') or die();
         'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_description',
     ],
     'textmedia',
-    'after'
+    'after',
 );
 
 // Adds the content element icon to TCA typeicon_classes

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_ContentSecurityPolicies.php
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_ContentSecurityPolicies.php
@@ -22,7 +22,7 @@ return Map::fromEntries([
         new Mutation(
             MutationMode::Set,
             Directive::DefaultSrc,
-            SourceKeyword::self
+            SourceKeyword::self,
         ),
 
         // Extends the ancestor directive ('default-src'),
@@ -32,7 +32,7 @@ return Map::fromEntries([
             MutationMode::Extend,
             Directive::ImgSrc,
             SourceScheme::data,
-            new UriValue('https://*.typo3.org')
+            new UriValue('https://*.typo3.org'),
         ),
         // NOTICE: the following two instructions for `Directive::ImgSrc` are identical to the previous instruction,
         // `MutationMode::Extend` is a shortcut for `MutationMode::InheritOnce` and `MutationMode::Append`
@@ -46,7 +46,7 @@ return Map::fromEntries([
         new Mutation(
             MutationMode::Extend,
             Directive::ScriptSrc,
-            SourceKeyword::nonceProxy
+            SourceKeyword::nonceProxy,
         ),
 
         // Sets (overrides) the directive,
@@ -55,7 +55,7 @@ return Map::fromEntries([
         new Mutation(
             MutationMode::Set,
             Directive::WorkerSrc,
-            SourceScheme::blob
+            SourceScheme::blob,
         ),
     ),
 ]);

--- a/Documentation/ApiOverview/Context/_MyControllerUsingDateAspect.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingDateAspect.php
@@ -16,7 +16,7 @@ final class MyController
     {
         $currentTimestamp = $this->context->getPropertyFromAspect(
             'date',
-            'timestamp'
+            'timestamp',
         );
 
         // ... do something with $currentTimestamp

--- a/Documentation/ApiOverview/Context/_MyControllerUsingLanguageAspect.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingLanguageAspect.php
@@ -16,7 +16,7 @@ final class MyController
     {
         $fallbackChain = $this->context->getPropertyFromAspect(
             'language',
-            'fallbackChain'
+            'fallbackChain',
         );
 
         // ... do something with $fallbackChain

--- a/Documentation/ApiOverview/Context/_MyControllerUsingUserAspect.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingUserAspect.php
@@ -16,7 +16,7 @@ final class MyController
     {
         $userIsLoggedIn = $this->context->getPropertyFromAspect(
             'frontend.user',
-            'isLoggedIn'
+            'isLoggedIn',
         );
 
         // ... do something with $userIsLoggedIn

--- a/Documentation/ApiOverview/Context/_MyControllerUsingVisibilityAspect.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingVisibilityAspect.php
@@ -16,7 +16,7 @@ final class MyController
     {
         $showHiddenPages = $this->context->getPropertyFromAspect(
             'visibility',
-            'includeHiddenPages'
+            'includeHiddenPages',
         );
 
         // ... do something with $showHiddenPages

--- a/Documentation/ApiOverview/Context/_MyControllerUsingWorkspaceAspect.php
+++ b/Documentation/ApiOverview/Context/_MyControllerUsingWorkspaceAspect.php
@@ -16,7 +16,7 @@ final class MyController
     {
         $showHiddenPages = $this->context->getPropertyFromAspect(
             'workspace',
-            'id'
+            'id',
         );
 
         // ... do something with $showHiddenPages

--- a/Documentation/ApiOverview/Country/_MyClass.php
+++ b/Documentation/ApiOverview/Country/_MyClass.php
@@ -9,6 +9,6 @@ use TYPO3\CMS\Core\Country\CountryProvider;
 final class MyClass
 {
     public function __construct(
-        private readonly CountryProvider $countryProvider
+        private readonly CountryProvider $countryProvider,
     ) {}
 }

--- a/Documentation/ApiOverview/Country/_MyClassWithTranslation.php
+++ b/Documentation/ApiOverview/Country/_MyClassWithTranslation.php
@@ -12,7 +12,7 @@ final class MyClassWithTranslation
 {
     public function __construct(
         private readonly CountryProvider $countryProvider,
-        private readonly LanguageServiceFactory $languageServiceFactory
+        private readonly LanguageServiceFactory $languageServiceFactory,
     ) {}
 
     public function doSomething()

--- a/Documentation/ApiOverview/Database/BasicCrud/_MyDeleteRepository.php
+++ b/Documentation/ApiOverview/Database/BasicCrud/_MyDeleteRepository.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class MyDeleteRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function deleteSomeData()
@@ -17,7 +17,7 @@ final class MyDeleteRepository
         $this->connectionPool->getConnectionForTable('tt_content')
             ->delete(
                 'tt_content', // from
-                ['uid' => 4711]  // where
+                ['uid' => 4711],  // where
             );
     }
 }

--- a/Documentation/ApiOverview/Database/BasicCrud/_MyInsertRepository.php
+++ b/Documentation/ApiOverview/Database/BasicCrud/_MyInsertRepository.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class MyInsertRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function insertSomeData(): void
@@ -21,7 +21,7 @@ final class MyInsertRepository
                 [
                     'pid' => 42,
                     'bodytext' => 'ipsum',
-                ]
+                ],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/BasicCrud/_MyQueryBuilderSelectRepository.php
+++ b/Documentation/ApiOverview/Database/BasicCrud/_MyQueryBuilderSelectRepository.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 final class MyQueryBuilderSelectRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function selectSomeData(): array
@@ -36,13 +36,13 @@ final class MyQueryBuilderSelectRepository
                 $queryBuilder->expr()->or(
                     $queryBuilder->expr()->eq(
                         'bodytext',
-                        $queryBuilder->createNamedParameter('lorem')
+                        $queryBuilder->createNamedParameter('lorem'),
                     ),
                     $queryBuilder->expr()->eq(
                         'uid',
-                        $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
-                    )
-                )
+                        $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
+                    ),
+                ),
             )
             ->executeQuery()
             ->fetchAllAssociative();

--- a/Documentation/ApiOverview/Database/BasicCrud/_MySelectRepository.php
+++ b/Documentation/ApiOverview/Database/BasicCrud/_MySelectRepository.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class MySelectRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     /**
@@ -24,7 +24,7 @@ final class MySelectRepository
             ->select(
                 ['uid', 'pid', 'bodytext'], // fields to select
                 'tt_content',               // from
-                ['uid' => $uid]             // where
+                ['uid' => $uid],            // where
             )
             ->fetchAssociative();
     }

--- a/Documentation/ApiOverview/Database/BasicCrud/_MyUpdateRepository.php
+++ b/Documentation/ApiOverview/Database/BasicCrud/_MyUpdateRepository.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class MyUpdateRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function updateSomeData()
@@ -18,7 +18,7 @@ final class MyUpdateRepository
             ->update(
                 'tt_content',
                 [ 'bodytext' => 'ipsum' ], // set
-                [ 'bodytext' => 'lorem' ]  // where
+                [ 'bodytext' => 'lorem' ], // where
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyCacheRepository_truncate.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyCacheRepository_truncate.php
@@ -11,11 +11,11 @@ final class MyCacheRepository
     private const TABLE_NAME = 'cache_myextension';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function truncateSomething(
-        int $uid
+        int $uid,
     ): void {
         $this->connectionPool
             ->getConnectionForTable(self::TABLE_NAME)

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepositoryWithConnection.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepositoryWithConnection.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\Connection;
 final class MyTableRepository
 {
     public function __construct(
-        private readonly Connection $connection
+        private readonly Connection $connection,
     ) {}
 
     public function findSomething()

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepositoryWithConnectionPool.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepositoryWithConnectionPool.php
@@ -11,7 +11,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_domain_model_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function findSomething()

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_bulkinsert.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_bulkinsert.php
@@ -12,7 +12,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function bulkInsertSomething(
@@ -36,7 +36,7 @@ final class MyTableRepository
                 [
                     Connection::PARAM_INT,
                     Connection::PARAM_STR,
-                ]
+                ],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_count.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_count.php
@@ -11,7 +11,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function countSomething(
@@ -22,7 +22,7 @@ final class MyTableRepository
         return $connection->count(
             '*',
             self::TABLE_NAME,
-            ['some_value' => $something]
+            ['some_value' => $something],
         );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_delete.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_delete.php
@@ -12,18 +12,18 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function deleteSomething(
-        int $uid
+        int $uid,
     ): void {
         $this->connectionPool
             ->getConnectionForTable(self::TABLE_NAME)
             ->delete(
                 self::TABLE_NAME,
                 ['uid' => $uid],
-                [Connection::PARAM_INT]
+                [Connection::PARAM_INT],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_insert.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_insert.php
@@ -11,13 +11,13 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function insertSomething(
         int $pid,
         string $someString,
-        array $someData
+        array $someData,
     ): void {
         $this->connectionPool
             ->getConnectionForTable(self::TABLE_NAME)
@@ -27,7 +27,7 @@ final class MyTableRepository
                     'pid' => $pid,
                     'some_string' => $someString,
                     'json_field' => $someData,
-                ]
+                ],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_insert_types.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_insert_types.php
@@ -12,7 +12,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function insertSomething(
@@ -30,7 +30,7 @@ final class MyTableRepository
                 [
                     Connection::PARAM_INT,
                     Connection::PARAM_STR,
-                ]
+                ],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_lastinsertId.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_lastinsertId.php
@@ -11,18 +11,18 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function insertSomething(
-        array $someData
+        array $someData,
     ): int {
         $connection = $this->connectionPool
             ->getConnectionForTable(self::TABLE_NAME);
         $connection
             ->insert(
                 self::TABLE_NAME,
-                $someData
+                $someData,
             );
         return (int)$connection->lastInsertId(self::TABLE_NAME);
     }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_queryBuilder.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_queryBuilder.php
@@ -11,11 +11,11 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function useQueryBuilder(
-        array $someData
+        array $someData,
     ): void {
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
         foreach ($someData as $value) {
@@ -26,7 +26,7 @@ final class MyTableRepository
                 ->where(
                     $queryBuilder->expr()->eq(
                         'some_field',
-                        $queryBuilder->createNamedParameter($value)
+                        $queryBuilder->createNamedParameter($value),
                     ),
                 )
                 ->executeQuery()

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_select.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_select.php
@@ -12,7 +12,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function countSomething(
@@ -23,7 +23,7 @@ final class MyTableRepository
             ->select(
                 ['*'],
                 self::TABLE_NAME,
-                ['some_value' => $something]
+                ['some_value' => $something],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/Connection/_MyTableRepository_update.php
+++ b/Documentation/ApiOverview/Database/Connection/_MyTableRepository_update.php
@@ -12,13 +12,13 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function updateSomething(
         int $uid,
         string $someValue,
-        array $someData
+        array $someData,
     ): void {
         $this->connectionPool
             ->getConnectionForTable(self::TABLE_NAME)
@@ -29,7 +29,7 @@ final class MyTableRepository
                     'json_data' => $someData,
                 ],
                 ['uid' => $uid],
-                [Connection::PARAM_INT]
+                [Connection::PARAM_INT],
             );
     }
 }

--- a/Documentation/ApiOverview/Database/ConnectionPool/_MyTableRepository.php
+++ b/Documentation/ApiOverview/Database/ConnectionPool/_MyTableRepository.php
@@ -11,7 +11,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tx_myextension_domain_model_mytable';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function findSomething()

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/_MyTableRepository.php
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/_MyTableRepository.php
@@ -11,7 +11,7 @@ final class MyTableRepository
     private const TABLE_NAME = 'tt_content';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function findSomething()
@@ -25,12 +25,12 @@ final class MyTableRepository
                 // `bodytext` = 'lorem' AND `header` = 'dolor'
                 $queryBuilder->expr()->eq(
                     'bodytext',
-                    $queryBuilder->createNamedParameter('lorem')
+                    $queryBuilder->createNamedParameter('lorem'),
                 ),
                 $queryBuilder->expr()->eq(
                     'header',
-                    $queryBuilder->createNamedParameter('dolor')
-                )
+                    $queryBuilder->createNamedParameter('dolor'),
+                ),
             )
             ->executeQuery()
             ->fetchAllAssociative();

--- a/Documentation/ApiOverview/Database/QueryBuilder/_MyRepository.php
+++ b/Documentation/ApiOverview/Database/QueryBuilder/_MyRepository.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class MyRepository
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool
+        private readonly ConnectionPool $connectionPool,
     ) {}
 
     public function findSomething()

--- a/Documentation/ApiOverview/DependencyInjection/_ConstructorInjection.php
+++ b/Documentation/ApiOverview/DependencyInjection/_ConstructorInjection.php
@@ -9,6 +9,6 @@ use MyVendor\MyExtension\Repository\UserRepository;
 final class UserController
 {
     public function __construct(
-        private readonly UserRepository $userRepository
+        private readonly UserRepository $userRepository,
     ) {}
 }

--- a/Documentation/ApiOverview/DependencyInjection/_InterfaceInjection.php
+++ b/Documentation/ApiOverview/DependencyInjection/_InterfaceInjection.php
@@ -9,6 +9,6 @@ use MyVendor\MyExtension\Logger\LoggerInterface;
 final class UserController extends AbstractController
 {
     public function __construct(
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
     ) {}
 }

--- a/Documentation/ApiOverview/DependencyInjection/_MethodInjectionWithAbstract.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MethodInjectionWithAbstract.php
@@ -20,6 +20,6 @@ abstract class AbstractController
 final class UserController extends AbstractController
 {
     public function __construct(
-        private readonly UserRepository $userRepository
+        private readonly UserRepository $userRepository,
     ) {}
 }

--- a/Documentation/ApiOverview/DependencyInjection/_MyClass.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MyClass.php
@@ -9,7 +9,7 @@ use Psr\Clock\ClockInterface;
 final class MyClass
 {
     public function __construct(
-        private readonly ClockInterface $clock
+        private readonly ClockInterface $clock,
     ) {}
 
     // ...

--- a/Documentation/ApiOverview/DependencyInjection/_MyController.php
+++ b/Documentation/ApiOverview/DependencyInjection/_MyController.php
@@ -9,6 +9,6 @@ use MyVendor\MyExtension\Service\MyServiceInterface;
 class MyController
 {
     public function __construct(
-        private readonly MyServiceInterface $myService
+        private readonly MyServiceInterface $myService,
     ) {}
 }

--- a/Documentation/ApiOverview/DependencyInjection/_servicesInstallationWide.php
+++ b/Documentation/ApiOverview/DependencyInjection/_servicesInstallationWide.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (
     ContainerConfigurator $containerConfigurator,
-    ContainerBuilder $containerBuilder
+    ContainerBuilder $containerBuilder,
 ): void {
     $services = $containerConfigurator->services();
     $services->set(ClockInterface::class)

--- a/Documentation/ApiOverview/Events/EventDispatcher/_SomeClass2.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_SomeClass2.php
@@ -19,7 +19,7 @@ final class SomeClass
 
         /** @var DoingThisAndThatEvent $event */
         $event = $this->eventDispatcher->dispatch(
-            new DoingThisAndThatEvent('foo', 2)
+            new DoingThisAndThatEvent('foo', 2),
         );
         $someChangedValue = $event->getMutableProperty();
 

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_MyEventListener.php
@@ -14,8 +14,8 @@ final class MyEventListener
         $event->setAdditionalQueryParameters(
             array_replace_recursive(
                 $event->getAdditionalQueryParameters(),
-                ['myParam' => 'paramValue']
-            )
+                ['myParam' => 'paramValue'],
+            ),
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForContentEvent/_MyEventListener.php
@@ -25,8 +25,8 @@ final class MyEventListener
         $queryBuilder = $queryBuilder->andWhere(
             $queryBuilder->expr()->neq(
                 'some_field',
-                $queryBuilder->createNamedParameter(1, Connection::PARAM_INT)
-            )
+                $queryBuilder->createNamedParameter(1, Connection::PARAM_INT),
+            ),
         );
 
         // Set updated QueryBuilder to event

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
@@ -29,7 +29,7 @@ final class MyEventListener
                 'tx_my_control',
                 '<a href="/some/url" class="btn btn-default t3js-modal-trigger">'
                 . $iconFactory->getIcon('my-icon-identifier', Icon::SIZE_SMALL)->render()
-                . '</a>'
+                . '</a>',
             );
         }
     }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 final class MyEventListener
 {
     public function __construct(
-        private readonly IconFactory $iconFactory
+        private readonly IconFactory $iconFactory,
     ) {}
 
     public function __invoke(ModifyLinkExplanationEvent $event): void
@@ -22,8 +22,8 @@ final class MyEventListener
                 'icon',
                 $this->iconFactory->getIcon(
                     'my-custom-link-icon',
-                    Icon::SIZE_SMALL
-                )->render()
+                    Icon::SIZE_SMALL,
+                )->render(),
             );
         }
     }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_MyEventListener.php
@@ -21,7 +21,7 @@ final class MyEventListener
                     'CType' => 'my_element',
                 ],
             ],
-            ['after' => 'common_textpic']
+            ['after' => 'common_textpic'],
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_MyEventListener.php
@@ -28,7 +28,7 @@ final class MyEventListener
                 '<button>My Action</button>',
                 'myAction',
                 'secondary',
-                'move'
+                'move',
             );
         }
 

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
@@ -20,7 +20,7 @@ final class MyEventListener
     public function __construct(
         private readonly IconFactory $iconFactory,
         LanguageServiceFactory $languageServiceFactory,
-        private readonly UriBuilder $uriBuilder
+        private readonly UriBuilder $uriBuilder,
     ) {
         $this->languageService = $languageServiceFactory->createFromUserPreferences($GLOBALS['BE_USER']);
     }

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_MyEventListener.php
@@ -21,7 +21,7 @@ final class MyEventListener
         // Validate individual requirements/checks
         // ...
         $event->setRequestToken(
-            RequestToken::create('core/user-auth/' . strtolower($user->loginType))
+            RequestToken::create('core/user-auth/' . strtolower($user->loginType)),
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Mail\Mailer;
 final class MyEventListener
 {
     public function __construct(
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
     ) {}
 
     public function __invoke(AfterMailerSentMessageEvent $event): void

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ final class MyEventListener
     public function __invoke(AfterVideoPreviewFetchedEvent $event): void
     {
         $event->setPreviewImageFilename(
-            '/var/www/html/typo3temp/assets/online_media/new-preview-image.jpg'
+            '/var/www/html/typo3temp/assets/online_media/new-preview-image.jpg',
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
@@ -20,7 +20,7 @@ final class MyEventListener
         // Allow images from example.org
         $event->getCurrentPolicy()->extend(
             Directive::ImgSrc,
-            new UriValue('https://example.org/')
+            new UriValue('https://example.org/'),
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
@@ -17,7 +17,7 @@ final class MyEventListener
         $event->getController()->content = str_replace(
             'foo',
             'bar',
-            $event->getController()->content
+            $event->getController()->content,
         );
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_MyEventListener.php
@@ -12,7 +12,7 @@ final class MyEventListener
     {
         $linkResult = $event->getLinkResult()->withAttribute(
             'data-enable-lightbox',
-            'true'
+            'true',
         );
         $event->setLinkResult($linkResult);
     }

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_MyEventListener.php
@@ -20,7 +20,7 @@ final class MyEventListener
         }
 
         $fluidEmail->subject(
-            $linkAnalyzerResult->getTotalBrokenLinksCount() . ' new broken links'
+            $linkAnalyzerResult->getTotalBrokenLinksCount() . ' new broken links',
         );
 
         $fluidEmail->to(new Address('custom@mail.com'));

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Redirects\RedirectUpdate\PlainSlugReplacementRedirectSource;
 final class MyEventListener
 {
     public function __invoke(
-        ModifyAutoCreateRedirectRecordBeforePersistingEvent $event
+        ModifyAutoCreateRedirectRecordBeforePersistingEvent $event,
     ): void {
         // Only work on plain slug replacement redirect sources.
         if (!($event->getSource() instanceof PlainSlugReplacementRedirectSource)) {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_MyEventListener.php
@@ -20,15 +20,15 @@ final class MyEventListener
         ) {
             $matchedRedirect['disable_hitcount'] = true;
             $event->setMatchedRedirect(
-                $matchedRedirect
+                $matchedRedirect,
             );
 
             // Also add a custom response header
             $event->setResponse(
                 $event->getResponse()->withAddedHeader(
                     'X-My-Custom-Header',
-                    'Hit count increment skipped'
-                )
+                    'Hit count increment skipped',
+                ),
             );
         }
     }

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_MyEventListener.php
@@ -13,12 +13,12 @@ use TYPO3\CMS\Redirects\RedirectUpdate\RedirectSourceInterface;
 final class MyEventListener
 {
     public function __invoke(
-        SlugRedirectChangeItemCreatedEvent $event
+        SlugRedirectChangeItemCreatedEvent $event,
     ): void {
         $changeItem = $event->getSlugRedirectChangeItem();
         $sources = $changeItem->getSourcesCollection()->all();
         $pageTypeZeroSource = $this->getPageTypeZeroSource(
-            ...array_values($sources)
+            ...array_values($sources),
         );
         if ($pageTypeZeroSource === null) {
             // nothing we can do - no page type 0 source found
@@ -30,14 +30,14 @@ final class MyEventListener
         // 0 source, therefor it is safe to simply remove it by class check.
         $sources = array_filter(
             $sources,
-            static fn($source) => !($source instanceof PlainSlugReplacementRedirectSource)
+            static fn($source) => !($source instanceof PlainSlugReplacementRedirectSource),
         );
 
         // update sources
         $changeItem = $changeItem->withSourcesCollection(
             new RedirectSourceCollection(
-                ...array_values($sources)
-            )
+                ...array_values($sources),
+            ),
         );
 
         // update change item with updated sources
@@ -45,7 +45,7 @@ final class MyEventListener
     }
 
     private function getPageTypeZeroSource(
-        RedirectSourceInterface ...$sources
+        RedirectSourceInterface ...$sources,
     ): ?PageTypeSource {
         foreach ($sources as $source) {
             if ($source instanceof PageTypeSource

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_MyEventListener.php
@@ -20,7 +20,7 @@ final class MyEventListener
         // Remove plain slug replacement redirect source from sources
         $sources = array_filter(
             $sources,
-            fn($source) => !($source instanceof PlainSlugReplacementRedirectSource)
+            fn($source) => !($source instanceof PlainSlugReplacementRedirectSource),
         );
 
         // Add custom source implementation
@@ -28,7 +28,7 @@ final class MyEventListener
 
         // Replace sources collection
         $changeItem = $changeItem->withSourcesCollection(
-            new RedirectSourceCollection(...array_values($sources))
+            new RedirectSourceCollection(...array_values($sources)),
         );
 
         // Update changeItem in the event

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
@@ -21,7 +21,7 @@ final class MyEventListener
     protected array $customPageTypes = [ 1234, 169999 ];
 
     public function __invoke(
-        SlugRedirectChangeItemCreatedEvent $event
+        SlugRedirectChangeItemCreatedEvent $event,
     ): void {
         $changeItem = $event->getSlugRedirectChangeItem();
         $sources = $changeItem->getSourcesCollection()->all();
@@ -53,8 +53,8 @@ final class MyEventListener
         // update sources
         $changeItem = $changeItem->withSourcesCollection(
             new RedirectSourceCollection(
-                ...array_values($sources)
-            )
+                ...array_values($sources),
+            ),
         );
 
         // update change item with updated sources
@@ -63,7 +63,7 @@ final class MyEventListener
 
     private function isDuplicate(
         PageTypeSource $pageTypeSource,
-        RedirectSourceInterface ...$sources
+        RedirectSourceInterface ...$sources,
     ): bool {
         foreach ($sources as $existingSource) {
             if ($existingSource instanceof PageTypeSource
@@ -83,7 +83,7 @@ final class MyEventListener
         int $pageUid,
         int $pageType,
         Site $site,
-        SiteLanguage $siteLanguage
+        SiteLanguage $siteLanguage,
     ): ?PageTypeSource {
         if ($pageType === 0) {
             // pageType 0 is handled by \TYPO3\CMS\Redirects\EventListener\AddPageTypeZeroSource
@@ -99,7 +99,7 @@ final class MyEventListener
                     'type' => $pageType,
                 ],
                 '',
-                RouterInterface::ABSOLUTE_URL
+                RouterInterface::ABSOLUTE_URL,
             );
             return new PageTypeSource(
                 $uri->getHost() ?: '*',
@@ -115,10 +115,10 @@ final class MyEventListener
                     'The link to the page with ID "%d" and type "%d" could not be generated: %s',
                     $pageUid,
                     $pageType,
-                    $e->getMessage()
+                    $e->getMessage(),
                 ),
                 1675618235,
-                $e
+                $e,
             );
         }
     }

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_AddingFile.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_AddingFile.php
@@ -21,7 +21,7 @@ final class MyClass
         $newFile = $storage->addFile(
             '/tmp/temporary_file_name.ext',
             $storage->getRootLevelFolder(),
-            'final_file_name.ext'
+            'final_file_name.ext',
         );
 
         // ... more logic

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_AddingFileToSubFolder.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_AddingFileToSubFolder.php
@@ -21,7 +21,7 @@ final class MyClass
         $newFile = $storage->addFile(
             '/tmp/temporary_file_name.ext',
             $storage->getFolder('some/nested/folder'),
-            'final_file_name.ext'
+            'final_file_name.ext',
         );
 
         // ... more logic

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper.php
@@ -22,7 +22,7 @@ final class GravatarViewHelper extends AbstractTagBasedViewHelper
     {
         $this->tag->addAttribute(
             'src',
-            'https://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress'])
+            'https://www.gravatar.com/avatar/' . md5($this->arguments['emailAddress']),
         );
         return $this->tag->render();
     }

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarTagBasedViewHelper2.php
@@ -21,7 +21,7 @@ final class GravatarViewHelper extends AbstractTagBasedViewHelper
 
         $this->tag->addAttribute(
             'src',
-            'https://www.gravatar.com/avatar/' . md5($emailAddress)
+            'https://www.gravatar.com/avatar/' . md5($emailAddress),
         );
 
         return $this->tag->render();

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarViewHelper.php
@@ -23,7 +23,7 @@ final class GravatarViewHelper extends AbstractViewHelper
     public static function renderStatic(
         array $arguments,
         \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
+        RenderingContextInterface $renderingContext,
     ): string {
         // this is improved with the TagBasedViewHelper (see below)
         return sprintf('<img src="https://www.gravatar.com/avatar/%s" />', md5($arguments['emailAddress']));

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_GravatarWithContentElementsViewHelper.php
@@ -22,7 +22,7 @@ final class GravatarViewHelper extends AbstractViewHelper
     public static function renderStatic(
         array $arguments,
         \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
+        RenderingContextInterface $renderingContext,
     ): string {
         $emailAddress = $renderChildrenClosure();
 

--- a/Documentation/ApiOverview/Fluid/_CustomViewHelper/_StrtolowerViewHelper.php
+++ b/Documentation/ApiOverview/Fluid/_CustomViewHelper/_StrtolowerViewHelper.php
@@ -22,7 +22,7 @@ final class StrtolowerViewHelper extends AbstractViewHelper
     public static function renderStatic(
         array $arguments,
         \Closure $renderChildrenClosure,
-        RenderingContextInterface $renderingContext
+        RenderingContextInterface $renderingContext,
     ): string {
         return strtolower($arguments['string']);
     }
@@ -32,7 +32,7 @@ final class StrtolowerViewHelper extends AbstractViewHelper
         $closureName,
         &$initializationPhpCode,
         ViewHelperNode $node,
-        TemplateCompiler $compiler
+        TemplateCompiler $compiler,
     ): string {
         return 'strtolower(' . $argumentsName . '[\'string\'])';
     }

--- a/Documentation/ApiOverview/FormEngine/Rendering/_SomeController.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_SomeController.php
@@ -18,7 +18,7 @@ final class SomeController
         $javaScriptRenderer = $this->pageRenderer->getJavaScriptRenderer();
         $javaScriptRenderer->addJavaScriptModuleInstruction(
             JavaScriptModuleInstruction::create('@myvendor/my_extension/my-service.js')
-                ->invoke('someFunction')
+                ->invoke('someFunction'),
         );
         // ...
         return $this->pageRenderer->renderResponse();

--- a/Documentation/ApiOverview/FormProtection/_FormProtectionExample.php
+++ b/Documentation/ApiOverview/FormProtection/_FormProtectionExample.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
 final class FormProtectionExample
 {
     public function __construct(
-        private readonly FormProtectionFactory $formProtectionFactory
+        private readonly FormProtectionFactory $formProtectionFactory,
     ) {}
 
     public function handleRequest(ServerRequestInterface $request): ResponseInterface

--- a/Documentation/ApiOverview/Icon/_IconFactoryExample.php
+++ b/Documentation/ApiOverview/Icon/_IconFactoryExample.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 final class MyClass
 {
     public function __construct(
-        private readonly IconFactory $iconFactory
+        private readonly IconFactory $iconFactory,
     ) {}
 
     public function doSomething()
@@ -18,7 +18,7 @@ final class MyClass
         $icon = $this->iconFactory->getIcon(
             'tx-myext-action-preview',
             Icon::SIZE_SMALL,
-            'overlay-identifier'
+            'overlay-identifier',
         );
 
         // Do something with the icon, for example, assign it to the view

--- a/Documentation/ApiOverview/Localization/LocalizationApi/_LocaleExample.php
+++ b/Documentation/ApiOverview/Localization/LocalizationApi/_LocaleExample.php
@@ -10,14 +10,14 @@ use TYPO3\CMS\Core\Localization\Locale;
 final class LocaleExample
 {
     public function __construct(
-        private readonly LanguageServiceFactory $languageServiceFactory
+        private readonly LanguageServiceFactory $languageServiceFactory,
     ) {}
 
     public function doSomething()
     {
         $languageService = $this->languageServiceFactory->create(new Locale('de-CH'));
         $myTranslatedString = $languageService->sL(
-            'LLL:EXT:my_extension/Resources/Private/Language/myfile.xlf:my-label'
+            'LLL:EXT:my_extension/Resources/Private/Language/myfile.xlf:my-label',
         );
     }
 }

--- a/Documentation/ApiOverview/Logging/Writers/_MyClassWithConstructorInjection.php
+++ b/Documentation/ApiOverview/Logging/Writers/_MyClassWithConstructorInjection.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 final class MyClass
 {
     public function __construct(
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
     ) {}
 
     public function doSomething()

--- a/Documentation/ApiOverview/MessageBus/_DemoMessage.php
+++ b/Documentation/ApiOverview/MessageBus/_DemoMessage.php
@@ -7,6 +7,6 @@ namespace MyVendor\MyExtension\Queue\Message;
 final class DemoMessage
 {
     public function __construct(
-        public readonly string $content
+        public readonly string $content,
     ) {}
 }

--- a/Documentation/ApiOverview/MessageBus/_MyClass.php
+++ b/Documentation/ApiOverview/MessageBus/_MyClass.php
@@ -10,7 +10,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 final class MyClass
 {
     public function __construct(
-        private readonly MessageBusInterface $bus
+        private readonly MessageBusInterface $bus,
     ) {}
 
     public function doSomething(): void

--- a/Documentation/ApiOverview/PageTypes/_ext_localconf.php
+++ b/Documentation/ApiOverview/PageTypes/_ext_localconf.php
@@ -6,5 +6,5 @@ defined('TYPO3') or die();
 
 // Add custom doktype to the page tree toolbar
 ExtensionManagementUtility::addUserTSConfig(
-    "@import 'EXT:examples/Configuration/TsConfig/User/*.tsconfig'"
+    "@import 'EXT:examples/Configuration/TsConfig/User/*.tsconfig'",
 );

--- a/Documentation/ApiOverview/PageTypes/_ext_tables.php
+++ b/Documentation/ApiOverview/PageTypes/_ext_tables.php
@@ -14,5 +14,5 @@ $dokTypeRegistry->add(
     [
         'type' => 'web',
         'allowedTables' => '*',
-    ]
+    ],
 );

--- a/Documentation/ApiOverview/PageTypes/_pages.php
+++ b/Documentation/ApiOverview/PageTypes/_pages.php
@@ -17,7 +17,7 @@ defined('TYPO3') or die();
             'value' => $customPageDoktype,
             'icon'  => $customIconClass,
             'group' => 'special',
-        ]
+        ],
     );
     // Add the icon to the icon class configuration
     $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes'][$customPageDoktype] = $customIconClass;

--- a/Documentation/ApiOverview/Seo/_ExampleSetInController/_SomeController.php
+++ b/Documentation/ApiOverview/Seo/_ExampleSetInController/_SomeController.php
@@ -7,7 +7,7 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 final class SomeController extends ActionController
 {
     public function __construct(
-        private readonly MyOwnPageTitleProvider $titleProvider
+        private readonly MyOwnPageTitleProvider $titleProvider,
     ) {}
 
     public function someAction(): ResponseInterface

--- a/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
+++ b/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 final class WebsiteTitleProvider implements PageTitleProviderInterface
 {
     public function __construct(
-        private readonly SiteFinder $siteFinder
+        private readonly SiteFinder $siteFinder,
     ) {}
 
     public function getTitle(): string

--- a/Documentation/ApiOverview/Seo/_MetaTagApi/_ext_localconf_register_manager.php
+++ b/Documentation/ApiOverview/Seo/_MetaTagApi/_ext_localconf_register_manager.php
@@ -11,5 +11,5 @@ defined('TYPO3') or die();
 $metaTagManagerRegistry = GeneralUtility::makeInstance(MetaTagManagerRegistry::class);
 $metaTagManagerRegistry->registerManager(
     'custom',
-    CustomMetaTagManager::class
+    CustomMetaTagManager::class,
 );

--- a/Documentation/ApiOverview/Seo/_MetaTagApi/_ext_localconf_register_manager_open_graph.php
+++ b/Documentation/ApiOverview/Seo/_MetaTagApi/_ext_localconf_register_manager_open_graph.php
@@ -12,5 +12,5 @@ $metaTagManagerRegistry = GeneralUtility::makeInstance(MetaTagManagerRegistry::c
 $metaTagManagerRegistry->registerManager(
     'myOwnOpenGraphManager',
     MyOpenGraphMetaTagManager::class,
-    ['opengraph']
+    ['opengraph'],
 );

--- a/Documentation/ApiOverview/Services/Developer/_Implementing/_ext_localconf.php
+++ b/Documentation/ApiOverview/Services/Developer/_Implementing/_ext_localconf.php
@@ -28,5 +28,5 @@ ExtensionManagementUtility::addService(
         'exec' => '',
 
         'className' => Translator::class,
-    ]
+    ],
 );

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_MyErrorHandler.php
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_MyErrorHandler.php
@@ -25,7 +25,7 @@ final class ErrorHandler implements PageErrorHandlerInterface
     public function handlePageError(
         ServerRequestInterface $request,
         string $message,
-        array $reasons = []
+        array $reasons = [],
     ): ResponseInterface {
         return new HtmlResponse('<h1>Not found, sorry</h1>', $this->statusCode);
     }

--- a/Documentation/ApiOverview/SiteHandling/_extending-site-config.php
+++ b/Documentation/ApiOverview/SiteHandling/_extending-site-config.php
@@ -15,5 +15,5 @@ $GLOBALS['SiteConfiguration']['site']['columns']['myNewField'] = [
 $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'] = str_replace(
     'base,',
     'base, myNewField, ',
-    $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem']
+    $GLOBALS['SiteConfiguration']['site']['types']['0']['showitem'],
 );

--- a/Documentation/ApiOverview/SoftReferences/_MyController.php
+++ b/Documentation/ApiOverview/SoftReferences/_MyController.php
@@ -14,7 +14,7 @@ final class MyController
     {
         // Get the soft reference parser with the key "my_softref_key"
         $mySoftRefParser = $this->softReferenceParserFactory->getSoftReferenceParser(
-            'my_softref_key'
+            'my_softref_key',
         );
 
         // ... do something with $mySoftRefParser

--- a/Documentation/Configuration/UserSettingsConfiguration/_ext_tables.php
+++ b/Documentation/Configuration/UserSettingsConfiguration/_ext_tables.php
@@ -15,5 +15,5 @@ $GLOBALS['TYPO3_USER_SETTINGS']['columns']['tx_examples_mobile'] = [
 ];
 ExtensionManagementUtility::addFieldsToUserSettings(
     $lll . 'be_users.tx_examples_mobile,tx_examples_mobile',
-    'after:email'
+    'after:email',
 );

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Repository/_LanguageAspect.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Repository/_LanguageAspect.php
@@ -16,8 +16,8 @@ final class MyRepository extends Repository
             new LanguageAspect(
                 $languageId,
                 $contentId,
-                LanguageAspect::OVERLAYS_MIXED
-            )
+                LanguageAspect::OVERLAYS_MIXED,
+            ),
         );
         // query something
     }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ext_localconf.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ext_localconf.php
@@ -16,5 +16,5 @@ ExtensionUtility::configurePlugin(
     // all actions
     [PostController::class => 'show', CommentController::class => 'create'],
     // non-cacheable actions
-    [CommentController::class => 'create']
+    [CommentController::class => 'create'],
 );

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ext_localconf_rss.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ext_localconf_rss.php
@@ -11,5 +11,5 @@ defined('TYPO3') or die();
 ExtensionUtility::configurePlugin(
     'BlogExample',
     'PostListRss',
-    [PostController::class => 'displayRssList']
+    [PostController::class => 'displayRssList'],
 );

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_tt_content.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_tt_content.php
@@ -9,6 +9,6 @@ defined('TYPO3') or die();
         // arbitrary, but unique plugin name (not visible in the backend)
         'PostSingle',
         // plugin title, as visible in the drop-down in the backend, use "LLL:" for localization
-        'Single Post (BlogExample)'
+        'Single Post (BlogExample)',
     );
 })();

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyClass.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyClass.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 final class MyClass
 {
     public function __construct(
-        private readonly UriBuilder $uriBuilder
+        private readonly UriBuilder $uriBuilder,
     ) {}
 
     public function doSomething()
@@ -30,7 +30,7 @@ final class MyClass
                 ],
                 'MyController',
                 'myextension',
-                'myplugin'
+                'myplugin',
             );
 
         // do something with $url
@@ -43,7 +43,7 @@ final class MyClass
 
         // We have to provide an Extbase request object
         return new Request(
-            $request->withAttribute('extbase', new ExtbaseRequestParameters())
+            $request->withAttribute('extbase', new ExtbaseRequestParameters()),
         );
     }
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyController.php
@@ -21,7 +21,7 @@ final class MyController extends ActionController
                 ],
                 'MyController',
                 'myextension',
-                'myplugin'
+                'myplugin',
             );
 
         // do something with $url

--- a/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 final class MyClass
 {
     public function __construct(
-        private readonly ExtensionConfiguration $extensionConfiguration
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {}
 
     public function doSomething()

--- a/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass2.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ExtConfTemplate/_MyClass2.php
@@ -9,7 +9,7 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 final class MyClass
 {
     public function __construct(
-        private readonly ExtensionConfiguration $extensionConfiguration
+        private readonly ExtensionConfiguration $extensionConfiguration,
     ) {}
 
     public function doSomething()

--- a/Documentation/ExtensionArchitecture/FileStructure/_ext_localconf_user_tsconfig.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ext_localconf_user_tsconfig.php
@@ -7,5 +7,5 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 defined('TYPO3') or die();
 
 ExtensionManagementUtility::addUserTSConfig(
-    '@import "EXT:my_extension/Configuration/defaultUser.tsconfig"'
+    '@import "EXT:my_extension/Configuration/defaultUser.tsconfig"',
 );

--- a/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_allowonstandardpages.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_allowonstandardpages.php
@@ -12,6 +12,6 @@ $versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
 
 if ($versionInformation->getMajorVersion() < 12) {
     ExtensionManagementUtility::allowTableOnStandardPages(
-        'tx_myextension_domain_model_mymodel'
+        'tx_myextension_domain_model_mymodel',
     );
 }

--- a/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_registerModule.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_registerModule.php
@@ -23,6 +23,6 @@ if ($versionInformation->getMajorVersion() < 12) {
             'access' => 'user,group',
             'icon'   => 'EXT:my_extension/ext_icon.svg',
             'labels' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_statistics.xlf',
-        ]
+        ],
     );
 }

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/_fe_users.php
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/_fe_users.php
@@ -7,6 +7,6 @@ call_user_func(static function () {
         'fe_users',
         'tx_myextension_options, tx_myextension_special',
         '',
-        'after:password'
+        'after:password',
     );
 });

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUserFunction.php
@@ -17,22 +17,22 @@ final class MyUserFunction
     ) {}
 
     private function getLanguageService(
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): LanguageService {
         return $this->languageServiceFactory->createFromSiteLanguage(
             $request->getAttribute('language')
-            ?? $request->getAttribute('site')->getDefaultLanguage()
+            ?? $request->getAttribute('site')->getDefaultLanguage(),
         );
     }
 
     public function main(
         string $content,
         array $conf,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): string {
         $this->languageService = $this->getLanguageService($request);
         return $this->languageService->sL(
-            'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:something'
+            'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:something',
         );
     }
 }

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyUtility.php
@@ -12,14 +12,14 @@ final class MyUtility
     private static function translateSomething(string $lll): string
     {
         $languageServiceFactory = GeneralUtility::makeInstance(
-            LanguageServiceFactory::class
+            LanguageServiceFactory::class,
         );
         // As we are in a static context we cannot get the current request in
         // another way this usually points to general flaws in your software-design
         $request = $GLOBALS['TYPO3_REQUEST'];
         $languageService = $languageServiceFactory->createFromSiteLanguage(
             $request->getAttribute('language')
-            ?? $request->getAttribute('site')->getDefaultLanguage()
+            ?? $request->getAttribute('site')->getDefaultLanguage(),
         );
         return $languageService->sL($lll);
     }


### PR DESCRIPTION
Trailing commas are already added to arrays - now they are also necessary for other multiline parts. This makes copy/pasting easier and diffs smaller.

Releases: main, 12.4