### PR TITLE
[TASK] Add PropagateResponseException to ActionController section

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -187,7 +187,7 @@ plugin on the same page needs to be rendered. You would refactor your code so th
 :php:`downloadAction()` is not executed (e.g. via :html:`<f:form.action>`), but instead
 point to your middleware routing URI, let the middleware properly
 create output, and finally stop its processing by a concrete
-:php:`Psr\Http\Message\ResponseFactoryInterface` result object,
+:php:`\Psr\Http\Message\ResponseFactoryInterface` result object,
 as described in the Middleware chapters.
 
 If there are still reasons for you to utilize Extbase for this, you can use

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -176,28 +176,28 @@ come before and after that.
 
 In a download action, this would be unwanted content. To prevent that
 from happening, you have multiple options. While you might think placing
-an :php:`die()` or :php:`exit()` after your download action processing
+a :php:`die()` or :php:`exit()` after your download action processing
 is a good way, it is not very clean.
 
 The recommended way to deal with this, is to use a
-:ref:`PSR-15 Middleware <request-handling>` implementation. This is more performant,
+:ref:`PSR-15 middleware <request-handling>` implementation. This is more performant,
 because all other request workflows do not even need to be executed, because no other
 plugin on the same page needs to be rendered. You would refactor your code so that
 :php:`downloadAction()` is not executed (e.g. via :html:`<f:form.action>`), but instead
-point to your Middleware routing URI, let the Middleware properly
-create output, and finally stop it's processing by a concrete :php:`ResponseFactory` result object,
+point to your middleware routing URI, let the middleware properly
+create output, and finally stop its processing by a concrete :php:`ResponseFactory` result object,
 as described in the Middleware chapters.
 
-If there still are reasons for you to to utilize Extbase for this, you can use
+If there are still reasons for you to utilize Extbase for this, you can use
 a special method to stop the request workflow. In such a case a
-:php:`TYPO3\CMS\Core\Http\PropagateResponseException` can be thrown. This is automatically
+:php:`\TYPO3\CMS\Core\Http\PropagateResponseException` can be thrown. This is automatically
 caught by a PSR-15 middleware and the given PSR-7 response is then returned directly.
 
 Example:
 
 ..  literalinclude::  ../_FrontendPlugin/_PropagateResponseExceptionController.php
     :language: php
-    :caption: EXT:my_extension/Controller/MyController.php
+    :caption: EXT:my_extension/Classes/Controller/MyController.php
     :emphasize-lines: 21
 
 Also, if your controller needs to perform a redirect to a defined URI (internal or external),
@@ -205,7 +205,7 @@ you can return a specific :php:`responseFactory()` object:
 
 ..  literalinclude::  ../_FrontendPlugin/_ExternalRedirectController.php
     :language: php
-    :caption: EXT:my_extension/Controller/MyController.php
+    :caption: EXT:my_extension/Classes/Controller/MyController.php
     :emphasize-lines: 17-18
 
 ..  hint::

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -164,13 +164,14 @@ Stop further processing in a controller's action
 Sometimes you may want to use an Extbase controller action to
 return a specific output, and then stop the whole request flow.
 
-For example, a :php:`downloadAction()` might retrieve some binary data,
+For example, a :php:`downloadAction()` might provide some binary data,
 and should then stop.
 
 By default, Extbase actions need to return an object of type
-:php:`ResponseInterface` as described above. The actions are chained into the TYPO3 request
-flow (via the page renderer), so the returned object will be enriched by further processing
-of TYPO3: Most importantly, the usual layout of your website will be surrounded
+:php:`Psr\Http\Message\ResponseInterface` as described above. The actions
+are chained into the TYPO3 request flow (via the page renderer), so the
+returned object will be enriched by further processing of TYPO3. Most
+importantly, the usual layout of your website will be surrounded
 by your Extbase action's returned contents, and other plugin outputs may
 come before and after that.
 
@@ -185,7 +186,8 @@ because all other request workflows do not even need to be executed, because no 
 plugin on the same page needs to be rendered. You would refactor your code so that
 :php:`downloadAction()` is not executed (e.g. via :html:`<f:form.action>`), but instead
 point to your middleware routing URI, let the middleware properly
-create output, and finally stop its processing by a concrete :php:`ResponseFactory` result object,
+create output, and finally stop its processing by a concrete
+:php:`Psr\Http\Message\ResponseFactoryInterface` result object,
 as described in the Middleware chapters.
 
 If there are still reasons for you to utilize Extbase for this, you can use
@@ -201,7 +203,7 @@ Example:
     :emphasize-lines: 21
 
 Also, if your controller needs to perform a redirect to a defined URI (internal or external),
-you can return a specific :php:`responseFactory()` object:
+you can return a specific object through the :php:`responseFactory`:
 
 ..  literalinclude::  ../_FrontendPlugin/_ExternalRedirectController.php
     :language: php

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -168,7 +168,7 @@ For example, a :php:`downloadAction()` might provide some binary data,
 and should then stop.
 
 By default, Extbase actions need to return an object of type
-:php:`Psr\Http\Message\ResponseInterface` as described above. The actions
+:php:`\Psr\Http\Message\ResponseInterface` as described above. The actions
 are chained into the TYPO3 request flow (via the page renderer), so the
 returned object will be enriched by further processing of TYPO3. Most
 importantly, the usual layout of your website will be surrounded

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
@@ -3,7 +3,6 @@
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
-// Example by: https://brot.krue.ml/extbase-controller-action-responses-in-typo3/
 final class MyController extends ActionController
 {
     public function downloadAction(): ResponseInterface

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
@@ -5,13 +5,14 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 final class MyController extends ActionController
 {
-    public function downloadAction(): ResponseInterface
+    public function redirectAction(): ResponseInterface
     {
         // ... do something (set $value, ...)
 
         $uri = $this->uriBuilder->uriFor('show', ['parameter' => $value]);
 
         // $uri could also be https://example.com/any/uri
+        // $this->resourceFactory is injected as part of the `ActionController` inheritance
         return $this->responseFactory->createResponse(307)
             ->withHeader('Location', $uri);
     }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
@@ -1,0 +1,20 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\PropagateResponseException;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+// Example by: https://brot.krue.ml/extbase-controller-action-responses-in-typo3/
+final class MyController extends ActionController
+{
+    public function downloadAction(): ResponseInterface
+    {
+        // ... do something (set $value, ...)
+
+        $uri = $this->uriBuilder->uriFor('show', ['parameter' => $value]);
+
+        // $uri could also be https://example.com/any/uri
+        return $this->responseFactory->createResponse(307)
+            ->withHeader('Location', $uri);
+    }
+}

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_ExternalRedirectController.php
@@ -1,7 +1,6 @@
 <?php
 
 use Psr\Http\Message\ResponseInterface;
-use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 // Example by: https://brot.krue.ml/extbase-controller-action-responses-in-typo3/

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_PropagateResponseExceptionController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_PropagateResponseExceptionController.php
@@ -1,0 +1,23 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\PropagateResponseException;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+// Example by: https://brot.krue.ml/extbase-controller-action-responses-in-typo3/
+final class MyController extends ActionController
+{
+    public function downloadAction(): ResponseInterface
+    {
+        // ... do something (set $filename, $filePath, ...)
+
+        $response = $this->responseFactory->createResponse()
+            ->withHeader('Cache-Control', 'private')
+            ->withHeader('Content-Disposition', sprintf('attachment; filename="%s"', $filename))
+            ->withHeader('Content-Length', (string)filesize($filePath))
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withBody($this->streamFactory->createStreamFromFile($filePath));
+
+        throw new PropagateResponseException($response, 200);
+    }
+}

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_PropagateResponseExceptionController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FrontendPlugin/_PropagateResponseExceptionController.php
@@ -4,7 +4,6 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\PropagateResponseException;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
-// Example by: https://brot.krue.ml/extbase-controller-action-responses-in-typo3/
 final class MyController extends ActionController
 {
     public function downloadAction(): ResponseInterface
@@ -12,9 +11,12 @@ final class MyController extends ActionController
         // ... do something (set $filename, $filePath, ...)
 
         $response = $this->responseFactory->createResponse()
+            // Must not be cached by a shared cache, such as a proxy server
             ->withHeader('Cache-Control', 'private')
+            // Should be downloaded with the given filename
             ->withHeader('Content-Disposition', sprintf('attachment; filename="%s"', $filename))
             ->withHeader('Content-Length', (string)filesize($filePath))
+            // It is a PDF file we provide as a download
             ->withHeader('Content-Type', 'application/pdf')
             ->withBody($this->streamFactory->createStreamFromFile($filePath));
 


### PR DESCRIPTION
Previously, the only CoreApi documentation dealing with PropagateResponseException was this:

https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/HowTo/RestRequests/Index.html

That however dealt more with external requests and wasn't really the best place to put it. Thanks to the great example on Chris' page (https://brot.krue.ml/extbase-controller-action-responses-in-typo3/) I think we should add this to the Extbase Controller section, which is done via this PR.

I'm not sure about where to put the example code, maybe this is better put somewhere else (where?).

Here are screenshots how it looks like rendered:

<img width="583" alt="Screenshot 2024-03-01 at 10 36 30" src="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/273326/5278c261-3068-445e-8ad3-a99cc4167be0">
<img width="590" alt="Screenshot 2024-03-01 at 10 36 38" src="https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/273326/0734cf84-dfd1-4806-a330-4cb17941310a">

Comments/rephrasing appreciated, this was a "quick shot".

Releases: main, 12.4, 11.5