### PR TITLE
Fix various spelling errors, fix URL

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/Templating/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Templating/Index.rst
@@ -1,5 +1,5 @@
 .. include:: /Includes.rst.txt
-.. index:: 
+.. index::
    JavaScript (Backend); lit-html engine
    Templating
    pair: Templating; Client-side
@@ -155,7 +155,7 @@ This is rendered as:
 .. code-block:: html
 
    <my-element value="World">
-      <p>Hellow world!</p>
+      <p>Hello world!</p>
    </my-element>
 
 .. _web-components: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements

--- a/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Architecture/Index.rst
@@ -51,7 +51,7 @@ For performance reasons, it should be quick to calculate.
 Suppose a resource-intensive extension is added as a plugin on two different
 pages. The calculated content depends on the page on which it is inserted and
 if a user is logged in or not. So, the plugin creates at maximum four different
-ontent outputs, which can be cached in four different cache entries:
+content outputs, which can be cached in four different cache entries:
 
 *   page 1, no user logged in
 *   page 1, a user is logged in

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -48,7 +48,7 @@ It can be installed via Composer with:
    composer req typo3/cms-fluid-styled-content
 
 
-.. index:: Extension devolopment; Custom content element
+.. index:: Extension development; Custom content element
 .. _AddingCE-use-an-extension:
 
 Use an extension

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -135,7 +135,7 @@ With :php:`->select()` the list of fields to be selected is specified, and with
 :php:`->addSelect()` further elements can be added to an existing list.
 
 Mind that :php:`->select()` **replaces** any formerly registered list instead of
-appending it. Thus, it is not very usefule to call :php:`select()` twice in a
+appending it. Thus, it is not very useful to call :php:`select()` twice in a
 code flow or **after** an :php:`->addSelect()`. The methods :php:`->where()` and
 :php:`->andWhere()` share the same behavior: :php:`->where()` replaces all
 formerly registered constraints, :php:`->andWhere()` appends additional
@@ -850,7 +850,7 @@ add()
     :header: "Before", "After"
 
     ":php:`->add('select', $array)`", ":php:`->select(...$array)`"
-    ":php:`->add('where', $constraints)`", ":php:`->where(...$contraints)`"
+    ":php:`->add('where', $constraints)`", ":php:`->where(...$constraints)`"
     ":php:`->add('having', $havings)`", ":php:`->having(...$havings)`"
     ":php:`->add('orderBy', $orderBy)`", ":php:`->orderBy($orderByField, $orderByDirection)->addOrderBy($orderByField2)`"
     ":php:`->add('groupBy', $groupBy)`", ":php:`->groupBy($groupField)->addGroupBy($groupField2)`"

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileContentsSetEvent.rst
@@ -10,7 +10,7 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Core\Resource\Event\AfterFileContentsSetEvent`
 is fired after the contents of a file got set / replaced.
 
-*Example:* Listeners can analyze content for :abbr:`AI (Artifical Intelligence)`
+*Example:* Listeners can analyze content for :abbr:`AI (Artificial Intelligence)`
 purposes within extensions.
 
 Example

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
@@ -44,7 +44,7 @@ For the implementation we need the
 additional link errors and the
 :php:`\TYPO3\CMS\Core\DataHandling\SoftReference\SoftReferenceParserFactory` so
 we can automatically parse for links. These two classes have to be injected via
-:ref:`dependeny injection <Dependency-Injection>`:
+:ref:`dependency injection <Dependency-Injection>`:
 
 ..  include:: /CodeSnippets/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent/ExampleInject.rst.txt
 

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_DeletingFile.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_DeletingFile.php
@@ -26,7 +26,7 @@ final class MyClass
         if ($file->delete()) {
             // ... file was deleted successfully
         } else {
-            // ... an error occured
+            // ... an error occurred
         }
 
         // ... more logic

--- a/Documentation/ApiOverview/Fluid/Syntax.rst
+++ b/Documentation/ApiOverview/Fluid/Syntax.rst
@@ -124,7 +124,7 @@ There are 3 ways to import ViewHelper namespaces in TYPO3. In all three examples
       :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
 
       <html
-       xmlns:blog="http://typo3.org/ns/Myvendr/MyExtension/ViewHelpers"
+       xmlns:blog="http://typo3.org/ns/Myvendor/MyExtension/ViewHelpers"
        data-namespace-typo3-fluid="true">
 
       </html>

--- a/Documentation/ApiOverview/LockingApi/Index.rst
+++ b/Documentation/ApiOverview/LockingApi/Index.rst
@@ -297,7 +297,7 @@ If you do find better resources, feel free to make changes or add to this list!
   <https://stackoverflow.com/q/11837428/2444812>`__
 * `Wikipedia: Readers-writers problem <https://en.wikipedia.org/wiki/Readers%E2%80%93writers_problem>`__
 * `Wikipedia: Readers–writer lock <https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock>`__
-* Exlains shared / exclusive locks `IBM CICS Transaction Server: Exclusive locks and shared locks
+* Explains shared / exclusive locks `IBM CICS Transaction Server: Exclusive locks and shared locks
   <https://www.ibm.com/support/knowledgecenter/SSGMGV_3.2.0/com.ibm.cics.ts.applicationprogramming.doc/topics/dfhp39o.html>`__
 * `Oracle JE: Locks, Blocks and Deadlocks <https://docs.oracle.com/cd/E17277_02/html/TransactionGettingStarted/blocking_deadlocks.html>`__
 

--- a/Documentation/ApiOverview/PasswordHashing/Troubleshooting.rst
+++ b/Documentation/ApiOverview/PasswordHashing/Troubleshooting.rst
@@ -68,7 +68,7 @@ working algorithm.
 Manually disable argon2 in the :file:`config/system/settings.php`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This may be nessesary if access to the install tool is not possible.
+This may be necessary if access to the install tool is not possible.
 This can happen when the first installation was done on a system with argon2
 and the installation was then copied to a target system that doesn't support
 this encryption type.

--- a/Documentation/ApiOverview/Rte/InTheFrontend/Introduction.rst
+++ b/Documentation/ApiOverview/Rte/InTheFrontend/Introduction.rst
@@ -50,7 +50,7 @@ The optional features
    with existing data. This might require some considerations concerning
    multiple aspects.
 
-*  Links might be choosen out of the existing pages of the website, those
+*  Links might be chosen out of the existing pages of the website, those
    links can be added as internal instead of external links but require
    a visual and functional option to select from existing pages.
 

--- a/Documentation/ApiOverview/Rte/RenderingInTheFrontend/Index.rst
+++ b/Documentation/ApiOverview/Rte/RenderingInTheFrontend/Index.rst
@@ -35,7 +35,7 @@ of the form `t3://page?uid=51` that need to be processed. Usually those links sh
 be transformed already because the ViewHelper is using by default `lib.parseFunc_RTE`
 to parse the content.
 
-Nevertheless it's possible to define the parsing function explicitely and also to
+Nevertheless it's possible to define the parsing function explicitly and also to
 define a different parsing function:
 
 .. code-block:: xml

--- a/Documentation/ApiOverview/Seo/XmlSitemap.rst
+++ b/Documentation/ApiOverview/Seo/XmlSitemap.rst
@@ -277,7 +277,7 @@ sitemap:
 
 The :php:`loc` element is the URL of the page to be crawled by a search engine.
 The :php:`lastMod` element contains the date of the last update of the
-specific item. This value is a UNIX timestamp. In additiona, you can include
+specific item. This value is a UNIX timestamp. In addition, you can include
 :php:`changefreq` and :php:`priority` as keys in the array to give
 :ref:`search engines a hint <xmlsitemap-changefreq-priority>`.
 

--- a/Documentation/ApiOverview/Services/Introduction/Index.rst
+++ b/Documentation/ApiOverview/Services/Introduction/Index.rst
@@ -98,7 +98,7 @@ Reasons for using the Services API
    The abstract class :php:`\TYPO3\CMS\Core\Service\AbstractService` has been
    removed. See :ref:`services-developer-service-api-migration`.
 
-The :php:`AbstractService` has been removed and it is planed to also
+The :php:`AbstractService` has been removed and it is planned to also
 deprecate the other methods of the Service API in the future. The Service API
 should only be used for frontend and backend user :ref:`authentication
 <authentication>`.

--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -62,7 +62,7 @@ calling one (or both) of these two methods:
     $dataHandler->process_cmdmap();
 
 .. note::
-    Any error that might have occured during your DataHandler operations can be
+    Any error that might have occurred during your DataHandler operations can be
     accessed via its public property :php:`$dataHandler->errorLog`.
 
 Commands array
@@ -443,8 +443,8 @@ Description of keywords in syntax:
    .. versionchanged:: 13.0.1/12.4.11/11.5.35
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 11.5.35, 12.4.11, and 13.0.1. The table
-   should not be extended and additional fields should be added to 
-   :sql:`sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__ 
+   should not be extended and additional fields should be added to
+   :sql:`sys_file_metadata`. See `security advisory TYPO3-CORE-SA-2024-006 <https://typo3.org/security/advisory/typo3-core-sa-2024-006>`__
    for more information.
 
 

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -242,12 +242,12 @@ Workspace-related API for backend modules
    passed by reference.
 
    .. todo: Find a better example
-            If looped (while), resultset is retrieved and looped completly, as there is
+            If looped (while), resultset is retrieved and looped completely, as there is
             no "break" which could leave unretrieved results. So the single retrieve
             statement after the loop do not make any sense, as resultset is at the end,
             and would return false instead of a row ....
             Next point is, that queryBuilder createNamedParameter does not make any
-            sense either, as it not assigned anyware or used?
+            sense either, as it not assigned anywhere or used?
 
    **Example:**
 

--- a/Documentation/CodeSnippets/Manual/Entity/Module.rst.txt
+++ b/Documentation/CodeSnippets/Manual/Entity/Module.rst.txt
@@ -3,7 +3,7 @@
 
 .. php:class:: Module
 
-   A standard backend nodule
+   A standard backend module
 
    .. php:method:: getRoutes()
 

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -14,7 +14,7 @@ Configuration
 features a short description for each topic and links to more information.
 
 
-We have categorized information about configuration into *configration
+We have categorized information about configuration into *configuration
 syntax* and *methods*. Configuration that can be changed in the backend
 is usually referred to as *Settings*. The :ref:`glossary` explains how we use
 these terms in this chapter.

--- a/Documentation/Configuration/Typo3ConfVars/HTTP.rst
+++ b/Documentation/Configuration/Typo3ConfVars/HTTP.rst
@@ -90,7 +90,7 @@ cert
 
    Set to a string to specify the path to a file containing a
    PEM formatted client side certificate. See
-   `Guzzle option cert <http//docs.guzzlephp.org/en/latest/request-options.html#cert>`__
+   `Guzzle option cert <https://docs.guzzlephp.org/en/latest/request-options.html#cert>`__
 
 .. index::
    TYPO3_CONF_VARS HTTP; connect_timeout

--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Index.rst
@@ -17,7 +17,7 @@ All resources that only get accessed by the web server
 (templates, language files, etc.) go to the folder :file:`Private/`.
 
 .. note::
-   Non–TYPO3 files such as third party JavaScript libaries are commonly stored
+   Non–TYPO3 files such as third party JavaScript libraries are commonly stored
    in this folder.
 
    TYPO3 is licensed under GPL version 2 or any later version. Any non–TYPO3

--- a/Documentation/ExtensionArchitecture/HowTo/CreateNewExtension.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/CreateNewExtension.rst
@@ -13,7 +13,7 @@ Creating a new extension
 First choose a unique `Composer name <https://getcomposer.org/doc/04-schema.md#name>`__
 for your extension. Additionally, an extension key is required.
 
-If you plan to ever publish your extension in the TYPO3 Extension Repositiory
+If you plan to ever publish your extension in the TYPO3 Extension Repository
 (TER), :ref:`register an extension key <extension-key>`.
 
 Kickstarting the extension

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
@@ -66,7 +66,7 @@ you can decide to introduce a new type and
 only extend that one type. This is, for example, commonly done when extending
 the model of :t3ext:`news`.
 
-If you are planing to publish your extension that extends another extensions
+If you are planning to publish your extension that extends another extensions
 model, research on `Packagist <https://packagist.org/>`__ and the
 `TER (TYPO3 extension repository) <https://extensions.typo3.org/>`__ for
 extensions that are already extending the model. If necessary, put them in

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/Index.rst
@@ -6,7 +6,7 @@
 Update your extension for new TYPO3 versions
 ============================================
 
-The following tool are helpfull when updating your extension:
+The following tool are helpful when updating your extension:
 
 ..  toctree::
     :titlesonly:

--- a/Documentation/ExtensionArchitecture/Tutorials/Kickstart/Index.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Kickstart/Index.rst
@@ -57,7 +57,7 @@ tutorials for common options:
                 The `Sitepackage Builder <https://www.sitepackagebuilder.com/>`__
                 can be used to conveniently create an extension containing the
                 sitepackage (theme) of a site. It can also be used to kickstart
-                an arbitary extension by removing unneeded files.
+                an arbitrary extension by removing unneeded files.
 
     ..  container:: col-md-6 pl-0 pr-3 py-3 m-0
 

--- a/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/MinimalExtension.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Kickstart/SitepackageBuilder/MinimalExtension.rst
@@ -62,7 +62,7 @@ Minimal extension - step-by-step
 4.  The namespace and PSR-4 autoloading
 
     TYPO3 features :ref:`PSR-4 autoloading <autoload>`. If a PHP class is
-    withing the correct namespace and path it will be available automatically.
+    within the correct namespace and path it will be available automatically.
 
     Now what is the correct namespace for your extension? Look for the
     keyword "autoload" in the :file:`composer.json` of your extension. You

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
@@ -149,7 +149,7 @@ The title of the field is displayed above the input field. The type is a (string
 input field. The other configuration values influence display (size of the input
 field) and or processing on saving ( :php:`'eval' => 'trim'` removes whitespace).
 
-You can find a complete list of available input types and their propererties in
+You can find a complete list of available input types and their properties in
 the :ref:`TCA Reference, chapter "Field types (config > type)" <t3tca:columns-types>`.
 
 The other text fields are defined in a similar manner.

--- a/Documentation/Images/Plantuml/FormEngine/FormEngineMainWorkflow.plantuml
+++ b/Documentation/Images/Plantuml/FormEngine/FormEngineMainWorkflow.plantuml
@@ -26,7 +26,7 @@ aFormDataGroup -> FormDataCompiler : Explode on error
 Controller -> FormDataCompiler : Give initialized data, call compile()
 FormDataCompiler -> aFormDataGroup : Compile single providers
 aFormDataGroup -> FormDataCompiler : Return updated data array
-FormDataCompiler -> Controller : Return full data arary
+FormDataCompiler -> Controller : Return full data array
 Controller -> NodeFactory : Receive full data array
 NodeFactory -> EntryContainer : Render self, sub containers
 EntryContainer -> NodeFactory : Return result with HTML, CSS, JS

--- a/Documentation/Security/GeneralGuidelines/Index.rst
+++ b/Documentation/Security/GeneralGuidelines/Index.rst
@@ -17,7 +17,7 @@ Secure passwords
 ================
 
 It is critical that every user is using secure passwords to
-authenticate themselfs at systems like TYPO3. Below are rules that
+authenticate themselves at systems like TYPO3. Below are rules that
 should be implemented in a password policy:
 
 #. Ensure that the passwords you use have a minimum length of 8 or more

--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -150,7 +150,7 @@ servers virtual host configuration. A typical example looks like this:
             deny all;
         }
 
-        # TYPO3 - Block access to libaries, source and temporary compiled data
+        # TYPO3 - Block access to libraries, source and temporary compiled data
         location ~ ^(?:vendor|typo3_src|typo3temp/var) {
             deny all;
         }

--- a/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
+++ b/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
@@ -89,7 +89,7 @@ The form looks like this:
       <f:form.textbox property="description" />
    </f:form>
 
-If the form is sent, the argument mapping for the user object recieves
+If the form is sent, the argument mapping for the user object receives
 this array:
 
 .. code-block:: none

--- a/Documentation/Testing/ProjectTesting.rst
+++ b/Documentation/Testing/ProjectTesting.rst
@@ -97,7 +97,7 @@ setups like these can be found in the `ddev documentation
 To execute acceptance tests in this installation you have to activate this file, usually it is now appended
 with the suffix `.inactive` and therefore not used when DDEV starts. To activate acceptance tests the file
 :file:`.ddev/docker-compose.chrome.yaml.inactive` has to be renamed to :file:`.ddev/docker-compose.chrome.yaml`.
-By default acceptance tests are disabled because they slow down other tests significantally.
+By default acceptance tests are disabled because they slow down other tests significantly.
 
 Next, after adding codeception as require-dev dependency in :file:`composer.json`, we need a
 basic :file:`Tests/codeception.yml` file:


### PR DESCRIPTION
Some small changes to ~30 files of the main documentation, nothing serious.

I have also noticed 3 spelling errors in the main image of the introduction at https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Introduction/Index.html (see: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/blob/51f04cd439fa3ff6989f2130b0e02c2431d9c467/Documentation/Introduction/Index.rst, https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/blob/main/Documentation/Images/Graphics/Typo3CmsStructure.png).

"Costomization" > "Customization", "Ingteraction" > "Interaction", "Database Sever" > "Database Server"

But I left those in as I don't know the specific font used. Also makes a good inside joke (3 typos for TYPO3). ;-)