### PR TITLE
[TASK] Add section about parameter types in the DB/Connection chapter

### DIFF
--- a/Documentation/ApiOverview/Database/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/Connection/Index.rst
@@ -82,6 +82,50 @@ Another way is to inject the :php:`Connection` object directly via
         :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 
+.. _database-connection-parameter-types:
+
+Parameter types
+===============
+
+The parameter types are used in various places to bind values to types, for
+example, when using named parameters in the
+:ref:`query builder <database-query-builder>`:
+
+..  code-block:: php
+
+    // use TYPO3\CMS\Core\Database\Connection;
+
+    $queryBuilder->createNamedParameter(42, Connection::PARAM_INT);
+
+The following parameter types are available:
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_NULL`
+    Represents an SQL :sql:`NULL` data type.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_INT`
+    Represents an SQL :sql:`INTEGER` data type.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_STR`
+    Represents an SQL :sql:`CHAR` or `VARCHAR` data type.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_LOB`
+    Represents an SQL large object data type.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_BOOL`
+    Represents a boolean data type.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_INT_ARRAY`
+    Represents an array of integer values.
+
+:php:`\TYPO3\CMS\Core\Database\Connection::PARAM_STR_ARRAY`
+    Represents an array of string values.
+
+The default parameter type is :php:`Connection::PARAM_STR`, if this argument
+is omitted.
+
+Internally, these parameter types are mapped to the types Doctrine DBAL expects.
+
+
 .. _database-connection-insert:
 
 insert()
@@ -96,6 +140,7 @@ Example:
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
 with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 ..  versionadded:: 12.1
     This method supports the native database field declaration :sql:`json`,
@@ -119,6 +164,7 @@ Arguments of the :php:`insert()` method:
 
     Read :ref:`how to instantiate <database-connection-instantiation>` a
     connection with the connection pool.
+    See available :ref:`parameter types <database-connection-parameter-types>`.
 
 :php:`insert()` returns the number of affected rows. Guess what? That is the
 number `1` ... If something goes wrong, a :php:`\Doctrine\DBAL\Exception` is
@@ -142,6 +188,7 @@ This method insert multiple rows at once:
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
 with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Arguments of the :php:`bulkInsert()` method:
 
@@ -184,6 +231,7 @@ Create an :sql:`UPDATE` statement and execute it. The example from FAL's
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
 with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Arguments of the :php:`update()` method:
 
@@ -220,6 +268,7 @@ from :php:`BackendUtility`, to mark rows as no longer locked by a user:
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
 with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Arguments of the :php:`delete()` method:
 

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -45,6 +45,8 @@ context:
 ..  literalinclude:: _MyTableRepository.php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
+See available :ref:`parameter types <database-connection-parameter-types>`.
+
 ..  warning::
     It is of crucial importance to quote values correctly to not introduce SQL
     injection attack vectors into your application. See the :ref:`according
@@ -75,6 +77,8 @@ Example to find :sql:`tt_content` records:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // WHERE
     //     (`tt_content`.`CType` = 'list')
     //     AND (
@@ -88,17 +92,18 @@ Example to find :sql:`tt_content` records:
         $queryBuilder->expr()->or(
             $queryBuilder->expr()->eq(
                 'list_type',
-                $queryBuilder->createNamedParameter('example_pi1')
+                $queryBuilder->createNamedParameter('example_pi1', Connection::PARAM_STR)
             ),
             $queryBuilder->expr()->eq(
                 'list_type',
-                $queryBuilder->createNamedParameter('example_pi2')
+                $queryBuilder->createNamedParameter('example_pi2', Connection::PARAM_STR)
             )
         )
     )
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 
 Comparisons
@@ -218,6 +223,7 @@ Examples:
         )
     )
 
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Aggregate Functions
 ===================
@@ -290,6 +296,7 @@ database level. The following examples give a better idea of what is possible:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 The call to :php:`$queryBuilder->expr()-trim()` can be one of the following:
 
@@ -324,3 +331,4 @@ with an optional alias :php:`->length(string $fieldName, string $alias = null)`:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/_MyTableRepository.php
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/_MyTableRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Domain\Repository;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 final class MyTableRepository
@@ -25,11 +26,11 @@ final class MyTableRepository
                 // `bodytext` = 'lorem' AND `header` = 'dolor'
                 $queryBuilder->expr()->eq(
                     'bodytext',
-                    $queryBuilder->createNamedParameter('lorem'),
+                    $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR),
                 ),
                 $queryBuilder->expr()->eq(
                     'header',
-                    $queryBuilder->createNamedParameter('dolor'),
+                    $queryBuilder->createNamedParameter('dolor', Connection::PARAM_STR),
                 ),
             )
             ->executeQuery()

--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -160,12 +160,14 @@ code flow of a :sql:`SELECT` query looks like this:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $result = $queryBuilder
         ->select('uid', 'header', 'bodytext')
         ->from('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->executeQuery();
 
@@ -176,6 +178,7 @@ code flow of a :sql:`SELECT` query looks like this:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 ..  _database-query-builder-select-restrictions:
 
@@ -199,6 +202,8 @@ Create a :sql:`COUNT` query, a typical usage:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // SELECT COUNT(`uid`) FROM `tt_content` WHERE (`bodytext` = 'lorem')
     //     AND ((`tt_content`.`deleted` = 0) AND (`tt_content`.`hidden` = 0)
     //     AND (`tt_content`.`starttime` <= 1669885410)
@@ -208,13 +213,14 @@ Create a :sql:`COUNT` query, a typical usage:
         ->count('uid')
         ->from('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->executeQuery()
         ->fetchOne();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Remarks:
 
@@ -262,17 +268,20 @@ data is to be deleted. Classic usage:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // DELETE FROM `tt_content` WHERE `bodytext` = 'lorem'
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $affectedRows = $queryBuilder
         ->delete('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->executeStatement();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Remarks:
 
@@ -310,18 +319,21 @@ Create an :sql:`UPDATE` query. Typical usage:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
-     // UPDATE `tt_content` SET `bodytext` = 'dolor' WHERE `bodytext` = 'lorem'
+    // use TYPO3\CMS\Core\Database\Connection;
+
+    // UPDATE `tt_content` SET `bodytext` = 'dolor' WHERE `bodytext` = 'lorem'
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder
         ->update('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->set('bodytext', 'dolor')
         ->executeStatement();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 :php:`->update()` requires the table to update as the first argument and a table
 alias (for example, :sql:`t`) as optional second argument. The table alias can
@@ -330,18 +342,21 @@ then be used in :php:`->set()` and :php:`->where()` expressions:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // UPDATE `tt_content` `t` SET `t`.`bodytext` = 'dolor' WHERE `t`.`bodytext` = 'lorem'
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder
         ->update('tt_content', 't')
         ->where(
-            $queryBuilder->expr()->eq('t.bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('t.bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->set('t.bodytext', 'dolor')
         ->executeStatement();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 :php:`->set()` requires a field name as the first argument and automatically
 quotes it internally. The second mandatory argument is the value to set a field
@@ -356,18 +371,21 @@ be used:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // UPDATE `tt_content` SET `bodytext` = `header` WHERE `bodytext` = 'lorem'
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder
         ->update('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR))
         )
         ->set('bodytext', $queryBuilder->quoteIdentifier('header'), false)
         ->executeStatement();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Remarks:
 
@@ -489,8 +507,8 @@ is converted to a string on :php:`->executeQuery()` or
         ->select('uid', 'header', 'bodytext')
         ->from('tt_content')
         ->where(
-            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem')),
-            $queryBuilder->expr()->eq('header', $queryBuilder->createNamedParameter('a name'))
+            $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR)),
+            $queryBuilder->expr()->eq('header', $queryBuilder->createNamedParameter('a name', Connection::PARAM_STR))
         )
         ->orWhere(
             $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('dolor')),
@@ -503,6 +521,7 @@ is converted to a string on :php:`->executeQuery()` or
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Note the parenthesis of the above example: :php:`->andWhere()` encapsulates both
 :php:`->where()` and :php:`->orWhere()` with an additional restriction.
@@ -512,15 +531,18 @@ Argument unpacking can become handy with these methods:
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     $whereExpressions = [
-        $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem')),
-        $queryBuilder->expr()->eq('header', $queryBuilder->createNamedParameter('a name'))
+        $queryBuilder->expr()->eq('bodytext', $queryBuilder->createNamedParameter('lorem', Connection::PARAM_STR)),
+        $queryBuilder->expr()->eq('header', $queryBuilder->createNamedParameter('a name', Connection::PARAM_STR))
     ];
     if ($needsAdditionalExpression) {
         $whereExpressions[] = $someAdditionalExpression;
     }
     $queryBuilder->where(...$whereExpressions);
 
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Remarks:
 
@@ -598,6 +620,7 @@ of the table on the right, and the join restriction as fourth argument:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Notes to the example above:
 
@@ -689,6 +712,7 @@ uses the alias of the first join target as left side:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Further remarks:
 
@@ -1026,6 +1050,7 @@ parts and :sql:`JOIN` expressions:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Remarks:
 
@@ -1067,13 +1092,14 @@ statement from SQL injections:
         ->where(
             $queryBuilder->expr()->eq(
                 'bodytext',
-                $queryBuilder->createNamedParameter($searchWord)
+                $queryBuilder->createNamedParameter($searchWord, Connection::PARAM_STR)
             )
         )
         ->executeQuery();
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 The above example shows the importance of using :php:`->createNamedParameter()`:
 The search word ``kl'aus`` is "tainted" and would break the query if not
@@ -1153,6 +1179,7 @@ Use integer, integer array:
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 Rules
 -----
@@ -1189,6 +1216,8 @@ Rules
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // DO
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
     $queryBuilder->getRestrictions()->removeAll();
@@ -1198,7 +1227,7 @@ Rules
         ->where(
             $queryBuilder->expr()->eq(
                 'bodytext',
-                $queryBuilder->createNamedParameter($searchWord)
+                $queryBuilder->createNamedParameter($searchWord, Connection::PARAM_STR)
             )
         )
 
@@ -1216,6 +1245,7 @@ Rules
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 .. _database-query-builder-quote-identifier:
 
@@ -1292,6 +1322,8 @@ Helper method to quote `%` characters within a search string. This is helpful in
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
+    // use TYPO3\CMS\Core\Database\Connection;
+
     // SELECT `uid` FROM `tt_content` WHERE (`bodytext` LIKE '%kl\\%aus%')
     $searchWord = 'kl%aus';
     $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tt_content');
@@ -1301,12 +1333,13 @@ Helper method to quote `%` characters within a search string. This is helpful in
         ->where(
             $queryBuilder->expr()->like(
                 'bodytext',
-                $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($searchWord) . '%')
+                $queryBuilder->createNamedParameter('%' . $queryBuilder->escapeLikeWildcards($searchWord) . '%', Connection::PARAM_STR)
             )
         );
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
 a query builder with the connection pool.
+See available :ref:`parameter types <database-connection-parameter-types>`.
 
 ..  warning::
     Even when using :php:`->escapeLikeWildcards()` the value must be


### PR DESCRIPTION
An overview of all available parameter types was missing. This change now adds all available types.

In the examples, the `Connection::PARAM_STR` has been added to raise awareness, although this is the default type and can be omitted. Links to the list of parameter types are also introduced for convenience of the reader.

Before TYPO3 v13, the `\PDO::PARAM_*` constants could also be used, but with TYPO3 v13 using Doctrine DBAL v4 this is not possible anymore as Doctrine DBAL expected a custom enum now. When using the `Connection::PARAM_*` constants, projects and extensions don't have to care about this detail on upgrade.

Releases: main, 12.4, 11.5