### PR TITLE
[BUGFIX] Insert missing namespace import for Extbase\Annotation\Validate

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_CustomValidator/_ObjectValidatorUsage.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_CustomValidator/_ObjectValidatorUsage.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 use T3docs\BlogExample\Domain\Model\Blog;
 use T3docs\BlogExample\Exception\NoBlogAdminAccessException;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Annotation\Validate;
 
 class BlogController extends ActionController
 {

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_CustomValidator/_ObjectValidatorUsage.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_CustomValidator/_ObjectValidatorUsage.php
@@ -7,8 +7,8 @@ namespace T3docs\BlogExample\Controller;
 use Psr\Http\Message\ResponseInterface;
 use T3docs\BlogExample\Domain\Model\Blog;
 use T3docs\BlogExample\Exception\NoBlogAdminAccessException;
-use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Annotation\Validate;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 class BlogController extends ActionController
 {


### PR DESCRIPTION
The import statement was missing, so for anyone copy+pasting this example, the `@Validation` usage would throw an error.