### PR TITLE
[TASK] Mark event listeners as readonly

### DIFF
--- a/Documentation/ApiOverview/Events/EventDispatcher/_NullMailer.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_NullMailer.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent;
     identifier: 'my-extension/null-mailer',
     before: 'someIdentifier, anotherIdentifier',
 )]
-final class NullMailer
+final readonly class NullMailer
 {
     public function __invoke(AfterMailerInitializationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/EventDispatcher/_NullMailerRepeatable.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_NullMailerRepeatable.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Mail\Event\BeforeMailerSentMessageEvent;
     identifier: 'my-extension/null-mailer-sent-message',
     event: BeforeMailerSentMessageEvent::class,
 )]
-final class NullMailer
+final readonly class NullMailer
 {
     public function __invoke(
         AfterMailerInitializationEvent | BeforeMailerSentMessageEvent $event,

--- a/Documentation/ApiOverview/Events/EventDispatcher/_NullMailerRepeatable2.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_NullMailerRepeatable2.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent;
 use TYPO3\CMS\Core\Mail\Event\BeforeMailerSentMessageEvent;
 
-final class NullMailer
+final readonly class NullMailer
 {
     #[AsEventListener(
         identifier: 'my-extension/null-mailer-initialization',

--- a/Documentation/ApiOverview/Events/EventDispatcher/_ServicesOverrideBase.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_ServicesOverrideBase.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
     identifier: 'ext-some-extension/modify-hreflang',
     after: 'typo3-seo/hreflangGenerator',
 )]
-final class SeoEventListener
+final readonly class SeoEventListener
 {
     public function __invoke(ModifyHrefLangTagsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/EventDispatcher/_ServicesOverrideCustom.php
+++ b/Documentation/ApiOverview/Events/EventDispatcher/_ServicesOverrideCustom.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
     identifier: 'ext-some-extension/modify-hreflang',
     after: 'typo3-seo/hreflangGenerator',
 )]
-final class MySeoEventListener
+final readonly class MySeoEventListener
 {
     public function __invoke(ModifyHrefLangTagsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterBackendPageRenderEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterBackendPageRenderEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/after-backend-page-render',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterBackendPageRenderEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterPagePreviewUriGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterPagePreviewUriGeneratedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-preview-uri',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterPagePreviewUriGeneratedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterRecordSummaryForLocalizationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterRecordSummaryForLocalizationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/after-record-summary-for-localization',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterRecordSummaryForLocalizationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforeModuleCreationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforeModuleCreationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-module-icon',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeModuleCreationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforePagePreviewUriGeneratedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-parameters',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforePagePreviewUriGeneratedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforeSearchInDatabaseRecordProviderEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforeSearchInDatabaseRecordProviderEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/before-search-in-database-record-provider',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeSearchInDatabaseRecordProviderEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_IsContentUsedOnPageLayoutEvent/_ContentUsedOnPage.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_IsContentUsedOnPageLayoutEvent/_ContentUsedOnPage.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/view/content-used-on-page',
 )]
-final class ContentUsedOnPage
+final readonly class ContentUsedOnPage
 {
     public function __invoke(IsContentUsedOnPageLayoutEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_IsFileSelectableEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_IsFileSelectableEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-file-is-selectable',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(IsFileSelectableEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyAllowedItemsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyAllowedItemsEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/allowed-items',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyAllowedItemsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyButtonBarEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyButtonBarEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-button-bar',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyButtonBarEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/toolbar/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyClearCacheActionsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForContentEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Database\Connection;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-database-query-for-content',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyDatabaseQueryForContentEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForRecordListingEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyDatabaseQueryForRecordListingEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-database-query-for-record-list',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyDatabaseQueryForRecordListingEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyEditFormUserAccessEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyEditFormUserAccessEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-edit-form-user-access',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyEditFormUserAccessEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyGenericBackendMessagesEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyGenericBackendMessagesEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 #[AsEventListener(
     identifier: 'my-extension/backend/add-message',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyGenericBackendMessagesEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyImageManipulationPreviewUrlEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyImageManipulationPreviewUrlEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-imagemanipulation-previewurl',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyImageManipulationPreviewUrlEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
@@ -19,7 +19,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
     identifier: 'my-extension/backend/modify-controls',
     method: 'modifyControls',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function modifyEnabledControls(ModifyInlineElementEnabledControlsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Imaging\IconFactory;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-link-explanation',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __construct(
         private readonly IconFactory $iconFactory,

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkHandlersEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkHandlersEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/link-handlers',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyLinkHandlersEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyNewContentElementWizardItemsEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-wizard-items',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyNewContentElementWizardItemsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyPageLayoutContentEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-page-module-content',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyPageLayoutContentEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyQueryForLiveSearchEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyQueryForLiveSearchEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/modify-query-for-live-search-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyQueryForLiveSearchEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyRecordListTableActionsEvent/_MyEventListener.php
@@ -22,7 +22,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
     identifier: 'my-extension/recordlist/my-event-listener',
     method: 'modifyTableActions',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     private LoggerInterface $logger;
 

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 #[AsEventListener(
     identifier: 'my-extension/add-live-search-result-actions-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     private readonly LanguageService $languageService;
 

--- a/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 #[AsEventListener(
     identifier: 'my-extension/preview-rendering-example-ctype',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(PageContentPreviewRenderingEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_AfterUserLoggedInEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_AfterUserLoggedInEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Authentication\Event\AfterUserLoggedInEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-user-logged-in',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterUserLoggedInEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_BeforeRequestTokenProcessedEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Security\RequestToken;
 #[AsEventListener(
     identifier: 'my-extension/process-request-token-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeRequestTokenProcessedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/_LoginAttemptFailedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/_LoginAttemptFailedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Authentication\Event\LoginAttemptFailedEvent;
 #[AsEventListener(
     identifier: 'my-extension/login-attempt-failed',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(LoginAttemptFailedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_AfterFlexFormDataStructureIdentifierInitializedEvent/_FlexFormParsingModifyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_AfterFlexFormDataStructureIdentifierInitializedEvent/_FlexFormParsingModifyEventListener.php
@@ -26,7 +26,7 @@ use TYPO3\CMS\Core\Configuration\Event\BeforeFlexFormDataStructureParsedEvent;
     identifier: 'my-extension/modify-data-structure-identifier',
     method: 'modifyDataStructureIdentifier',
 )]
-final class FlexFormParsingModifyEventListener
+final readonly class FlexFormParsingModifyEventListener
 {
     public function setDataStructure(BeforeFlexFormDataStructureParsedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_BeforeTcaOverridesEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_BeforeTcaOverridesEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Configuration\Event\BeforeTcaOverridesEvent;
 #[AsEventListener(
     identifier: 'my-extension/before-tca-overrides',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeTcaOverridesEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Core/_BootCompletedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/_BootCompletedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Core\Event\BootCompletedEvent;
 #[AsEventListener(
     identifier: 'my-extension/boot-completed',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BootCompletedEvent $e): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/_BeforePageIsRetrievedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/_BeforePageIsRetrievedEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\Domain\Page;
 #[AsEventListener(
     identifier: 'my-extension/my-custom-page-resolver',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforePageIsRetrievedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/_RecordAccessGrantedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/_RecordAccessGrantedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Domain\Access\RecordAccessGrantedEvent;
 #[AsEventListener(
     identifier: 'my-extension/set-access-granted',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(RecordAccessGrantedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Imaging/_ModifyRecordOverlayIconIdentifierEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Imaging/_ModifyRecordOverlayIconIdentifierEvent/_MyEventListener.php
@@ -7,7 +7,7 @@ namespace Vendor\MyExtension\Imaging\EventListener;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Imaging\Event\ModifyRecordOverlayIconIdentifierEvent;
 
-final class MyEventListener
+final readonly class MyEventListener
 {
     #[AsEventListener(
         identifier: 'my-extension/imaging/modify-record-overlay-icon-identifier',

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_AfterLinkResolvedByStringRepresentationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_AfterLinkResolvedByStringRepresentationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\LinkHandling\Event\AfterLinkResolvedByStringRepresentationEve
 #[AsEventListener(
     identifier: 'my-extension/after-link-resolved-by-string-representation',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterLinkResolvedByStringRepresentationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_AfterTypoLinkDecodedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_AfterTypoLinkDecodedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\LinkHandling\Event\AfterTypoLinkDecodedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-typolink-decoded',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterTypoLinkDecodedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_BeforeTypoLinkEncodedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/_BeforeTypoLinkEncodedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\LinkHandling\Event\BeforeTypoLinkEncodedEvent;
 #[AsEventListener(
     identifier: 'my-extension/before-typolink-encoded',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeTypoLinkEncodedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerInitializationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerInitializationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Mail\Event\AfterMailerInitializationEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-mailer-initialization',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterMailerInitializationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Mail\Mailer;
 #[AsEventListener(
     identifier: 'my-extension/process-sent-message',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_BeforeMailerSentMessageEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_BeforeMailerSentMessageEvent/_MyEventListener.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Mail\Event\BeforeMailerSentMessageEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-message',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeMailerSentMessageEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_MyEventListener.php
@@ -8,7 +8,7 @@ use TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent;
 #[AsEventListener(
     identifier: 'my-extension/extension-activated',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterPackageActivationEvent $event)
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Package/_PackageInitializationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/_PackageInitializationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Package\Initialization\ImportExtensionDataOnPackageInitializa
     identifier: 'my-extension/package-initialization',
     after: ImportExtensionDataOnPackageInitialization::class,
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(PackageInitializationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/_EnrichPasswordValidationContextDataEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/_EnrichPasswordValidationContextDataEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Core\PasswordPolicy\Event\EnrichPasswordValidationContextDataEvent
 #[AsEventListener(
     identifier: 'my-extension/enrich-context-data-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(EnrichPasswordValidationContextDataEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterDefaultUploadFolderWasResolvedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterDefaultUploadFolderWasResolvedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Resource\Event\AfterDefaultUploadFolderWasResolvedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-default-upload-folder-was-resolved',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterDefaultUploadFolderWasResolvedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterFileCommandProcessedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterFileCommandProcessedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Resource\Event\AfterFileCommandProcessedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-file-command-processed',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterFileCommandProcessedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_AfterVideoPreviewFetchedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Resource\OnlineMedia\Event\AfterVideoPreviewFetchedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-video-preview-fetched',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterVideoPreviewFetchedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/_ModifyFileDumpEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/_ModifyFileDumpEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Resource\Event\ModifyFileDumpEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-file-dump',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyFileDumpEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/_PolicyMutatedEvent/_MyEventListener.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Core\Security\ContentSecurityPolicy\UriValue;
 #[AsEventListener(
     identifier: 'my-extension/mutate-policy',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(PolicyMutatedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_AfterTemplatesHaveBeenDeterminedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_AfterTemplatesHaveBeenDeterminedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\TypoScript\IncludeTree\Event\AfterTemplatesHaveBeenDetermined
 #[AsEventListener(
     identifier: 'my-extension/post-process-sys-templates',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterTemplatesHaveBeenDeterminedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_BeforeLoadedPageTsConfigEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_BeforeLoadedPageTsConfigEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\TypoScript\IncludeTree\Event\BeforeLoadedPageTsConfigEvent;
 #[AsEventListener(
     identifier: 'my-extension/global-pagetsconfig',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeLoadedPageTsConfigEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_BeforeLoadedUserTsConfigEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_BeforeLoadedUserTsConfigEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\TypoScript\IncludeTree\Event\BeforeLoadedUserTsConfigEvent;
 #[AsEventListener(
     identifier: 'my-extension/global-usertsconfig',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeLoadedUserTsConfigEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/_EvaluateModifierFunctionEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/_EvaluateModifierFunctionEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\TypoScript\AST\Event\EvaluateModifierFunctionEvent;
 #[AsEventListener(
     identifier: 'my-extension/evaluate-modifier-function',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(EvaluateModifierFunctionEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Extbase/Configuration/_BeforeFlexFormConfigurationOverrideEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Configuration/_BeforeFlexFormConfigurationOverrideEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Extbase\Event\Configuration\BeforeFlexFormConfigurationOverrideEve
 #[AsEventListener(
     identifier: 'my-extension/before-flexform-configuration-override',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeFlexFormConfigurationOverrideEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ModifyEditFileFormDataEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Filelist\Event\ModifyEditFileFormDataEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-edit-file-form-data',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyEditFileFormDataEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Filelist/_ProcessFileListActionsEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Filelist\Event\ProcessFileListActionsEvent;
 #[AsEventListener(
     identifier: 'my-extension/process-file-list',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ProcessFileListActionsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Form/_AfterFormDefinitionLoadedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Form/_AfterFormDefinitionLoadedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Form\Mvc\Persistence\Event\AfterFormDefinitionLoadedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-form-definition-loaded',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterFormDefinitionLoadedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
 #[AsEventListener(
     identifier: 'my-extension/content-modifier',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterCacheableContentIsGeneratedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterCachedPageIsPersistedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterCachedPageIsPersistedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\Event\AfterCachedPageIsPersistedEvent;
 #[AsEventListener(
     identifier: 'my-extension/content-modifier',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterCachedPageIsPersistedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterContentObjectRendererInitializedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterContentObjectRendererInitializedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterContentObjectRendererInitialized
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterContentObjectRendererInitializedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterGetDataResolvedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterGetDataResolvedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterGetDataResolvedEvent;
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterGetDataResolvedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterImageResourceResolvedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterImageResourceResolvedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterImageResourceResolvedEvent;
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterImageResourceResolvedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_AfterLinkIsGeneratedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\Event\AfterLinkIsGeneratedEvent;
 #[AsEventListener(
     identifier: 'my-extension/link-modifier',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterLinkIsGeneratedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_BeforeStdWrapContentStoredInCacheEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_BeforeStdWrapContentStoredInCacheEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\BeforeStdWrapContentStoredInCacheEven
 #[AsEventListener(
     identifier: 'my-extension/before-stdwrap-content-stored-in-cache',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeStdWrapContentStoredInCacheEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_EnhanceStdWrapEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_EnhanceStdWrapEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsInitializedEvent
 use TYPO3\CMS\Frontend\ContentObject\Event\BeforeStdWrapFunctionsInitializedEvent;
 use TYPO3\CMS\Frontend\ContentObject\Event\EnhanceStdWrapEvent;
 
-final class MyEventListener
+final readonly class MyEventListener
 {
     #[AsEventListener(
         identifier: 'my-extension/my-stdwrap-enhancement',

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyCacheLifetimeForPageEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyCacheLifetimeForPageEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Frontend\Event\ModifyCacheLifetimeForPageEvent;
 #[AsEventListener(
     identifier: 'my-extension/cache-timeout',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyCacheLifetimeForPageEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyHrefLangTagsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyHrefLangTagsEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent;
     identifier: 'my-extension/cache-timeout',
     after: 'typo3-seo/hreflangGenerator',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyHrefLangTagsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyImageSourceCollectionEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyImageSourceCollectionEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\ModifyImageSourceCollectionEvent;
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyImageSourceCollectionEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyPageLinkConfigurationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyPageLinkConfigurationEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\Event\ModifyPageLinkConfigurationEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-page-link-configuration',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyPageLinkConfigurationEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ModifyRecordsAfterFetchingContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ModifyRecordsAfterFetchingContentEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\ContentObject\Event\ModifyRecordsAfterFetchingContentEven
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyRecordsAfterFetchingContentEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Frontend/_ShouldUseCachedPageDataIfAvailableEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_ShouldUseCachedPageDataIfAvailableEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Frontend\Event\ShouldUseCachedPageDataIfAvailableEvent;
 #[AsEventListener(
     identifier: 'my-extension/avoid-cache-loading',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ShouldUseCachedPageDataIfAvailableEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Info/_ModifyInfoModuleContentEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Info\Controller\Event\ModifyInfoModuleContentEvent;
 #[AsEventListener(
     identifier: 'my-extension/content-to-info-module',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyInfoModuleContentEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
+++ b/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePackRemoteBaseUrlEvent/_CustomMirror.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Install\Service\Event\ModifyLanguagePackRemoteBaseUrlEvent;
 #[AsEventListener(
     identifier: 'my-extension/custom-mirror',
 )]
-final class CustomMirror
+final readonly class CustomMirror
 {
     private const EXTENSION_KEY = 'my_extension';
     private const MIRROR_URL = 'https://example.org/typo3-packages/';

--- a/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePacksEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Install/_ModifyLanguagePacksEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Install\Service\Event\ModifyLanguagePacksEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-language-packs',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyLanguagePacksEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/_ModifyValidatorTaskEmailEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Linkvalidator\Event\ModifyValidatorTaskEmailEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-validation-task-email',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyValidatorTaskEmailEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Lowlevel/_ModifyBlindedConfigurationOptionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Lowlevel/_ModifyBlindedConfigurationOptionsEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Lowlevel\Event\ModifyBlindedConfigurationOptionsEvent;
 #[AsEventListener(
     identifier: 'my-extension/blind-configuration-options',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyBlindedConfigurationOptionsEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_AfterAutoCreateRedirectHasBeenPersistedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_AfterAutoCreateRedirectHasBeenPersistedEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Redirects\RedirectUpdate\PlainSlugReplacementRedirectSource;
 #[AsEventListener(
     identifier: 'my-extension/after-auto-create-redirect-has-been-persisted',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterAutoCreateRedirectHasBeenPersistedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_BeforeRedirectMatchDomainEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_BeforeRedirectMatchDomainEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Redirects\Event\BeforeRedirectMatchDomainEvent;
 #[AsEventListener(
     identifier: 'my-extension/before-redirect-match-domain',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(BeforeRedirectMatchDomainEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Redirects\RedirectUpdate\PlainSlugReplacementRedirectSource;
 #[AsEventListener(
     identifier: 'my-extension/modify-auto-create-redirect-record-before-persisting',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(
         ModifyAutoCreateRedirectRecordBeforePersistingEvent $event,

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Redirects\Event\ModifyRedirectManagementControllerViewDataEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-redirect-management-controller-view-data',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyRedirectManagementControllerViewDataEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_RedirectWasHitEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Redirects\Event\RedirectWasHitEvent;
     identifier: 'my-extension/redirects/validate-hit-count',
     before: 'redirects-increment-hit-count',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(RedirectWasHitEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_MyEventListener.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Redirects\RedirectUpdate\RedirectSourceInterface;
     // not know if there is a PageType source for page type 0
     after: 'redirects-add-page-type-zero-source',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(
         SlugRedirectChangeItemCreatedEvent $event,

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
@@ -21,9 +21,9 @@ use TYPO3\CMS\Redirects\RedirectUpdate\RedirectSourceInterface;
     identifier: 'my-extension/custom-page-type-redirect',
     after: 'redirects-add-page-type-zero-source',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
-    protected array $customPageTypes = [1234, 169999];
+    private const CUSTOM_PAGE_TYPES = [1234, 169999];
 
     public function __invoke(
         SlugRedirectChangeItemCreatedEvent $event,
@@ -31,7 +31,7 @@ final class MyEventListener
         $changeItem = $event->getSlugRedirectChangeItem();
         $sources = $changeItem->getSourcesCollection()->all();
 
-        foreach ($this->customPageTypes as $pageType) {
+        foreach (self::CUSTOM_PAGE_TYPES as $pageType) {
             try {
                 $pageTypeSource = $this->createPageTypeSource(
                     $changeItem->getPageId(),

--- a/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/SEO/_ModifyUrlForCanonicalTagEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Seo\Exception\CanonicalGenerationDisabledException;
 #[AsEventListener(
     identifier: 'my-extension/modify-url-for-canonical-tag',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(ModifyUrlForCanonicalTagEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Setup/_AddJavaScriptModulesEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Setup/_AddJavaScriptModulesEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent;
 #[AsEventListener(
     identifier: 'my-extension/my-event-listener',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     // The name of JavaScript module to be loaded
     private const MODULE_NAME = 'TYPO3/CMS/MyExtension/CustomUserSettingsModule';

--- a/Documentation/ApiOverview/Events/Events/Workspaces/_AfterRecordPublishedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/_AfterRecordPublishedEvent/_MyEventListener.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Workspaces\Event\AfterRecordPublishedEvent;
 #[AsEventListener(
     identifier: 'my-extension/after-record-published',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterRecordPublishedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_MyEventListener.php
@@ -11,7 +11,7 @@ use TYPO3\CMS\Workspaces\Event\ModifyVersionDifferencesEvent;
 #[AsEventListener(
     identifier: 'my-extension/modify-version-differences',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __construct(private readonly DiffUtility $diffUtility)
     {


### PR DESCRIPTION
PHP 8.2 introduced readonly classes. Event listeners mostly hold no state, so we mark those classes in the examples as readonly as best practise.

Releases: main