### PR TITLE
[TASK] Remove examples section in ModifyLoadedPageTsConfigEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
@@ -17,10 +17,6 @@ entries that can be overridden or added, based on the root line.
     and the new event, and TYPO3 v13 will stop calling the old event.
     See also :ref:`ModifyLoadedPageTsConfigEventv11v12`.
 
-Example
-=======
-
-..  include:: /_includes/EventsContributeNote.rst.txt
 
 API
 ===


### PR DESCRIPTION
The example is given in the migration section below, and the included hint in the examples section is misleading. Therefore, it is removed.

Releases: 12.4