### PR TITLE
[TASK] Update "PHP Best Practices / Accessing the Database" chapter

### DIFF
--- a/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/AccessingTheDatabase.rst
+++ b/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/AccessingTheDatabase.rst
@@ -1,20 +1,18 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Coding guidelines; Database
-.. _cgl-database-access:
+..  include:: /Includes.rst.txt
+..  index:: pair: Coding guidelines; Database
+..  _cgl-database-access:
 
 ======================
 Accessing the Database
 ======================
 
-The TYPO3 database should always be accessed using the QueryBuilder of doctrine.
-The :php:`ConnectionPool` class can be used to create
-a :php:`QueryBuilder` instance:
+The TYPO3 database should always be accessed using the :php:`QueryBuilder` of
+Doctrine. The :ref:`ConnectionPool <database-connection-pool>` class should be
+injected via :ref:`constructor injection <Constructor-injection>` and can then
+be used to create a :ref:`QueryBuilder <database-query-builder>` instance:
 
-.. code-block:: php
+..  literalinclude:: _AccessingTheDatabase/_MyTableRepository.php
+    :language: php
+    :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
-   use TYPO3\CMS\Core\Database\ConnectionPool;
-   use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-
-   $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tablename');
-
-See the :ref:`Database Access API documentation <database>` for more details.
+See the :ref:`Database <database>` chapter for more details.

--- a/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/_AccessingTheDatabase/_MyTableRepository.php
+++ b/Documentation/CodingGuidelines/CglPhp/CodingBestPractices/_AccessingTheDatabase/_MyTableRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Domain\Repository;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+final class MyTableRepository
+{
+    private const TABLE_NAME = 'tx_myextension_domain_model_mytable';
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
+    public function findSomething()
+    {
+        // Get a query builder for a table
+        $queryBuilder = $this->connectionPool
+            ->getQueryBuilderForTable(self::TABLE_NAME);
+    }
+}


### PR DESCRIPTION
The best practise nowadays for getting the query builder is to use dependency injection for the ConnectionPool.

Releases: main, 12.4, 11.5