### PR TITLE
[TASK] Drop mentioning of signals in Xclasses chapter

### DIFF
--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -1,30 +1,29 @@
-.. include:: /Includes.rst.txt
-.. index::
-   ! XCLASS
-   Extending Classes
-   Overwriting Methods
-.. _xclasses:
+..  include:: /Includes.rst.txt
+..  index::
+    ! XCLASS
+    Extending Classes
+    Overwriting Methods
+..  _xclasses:
 
 ============================
 XCLASSes (Extending Classes)
 ============================
 
 
-.. _xclasses-intro:
+..  _xclasses-intro:
 
 Introduction
 ============
 
 XCLASSing is a mechanism in TYPO3 to extend classes or overwrite methods from the Core or extensions
 with one's own code. This enables a developer to easily change a given functionality,
-if other options like :ref:`hooks <hooks>`, signals, :ref:`events <EventDispatcher>`
+if other options like :ref:`events <EventDispatcher>` or :ref:`hooks <hooks>`,
 or the dependency injection mechanisms do not work or do not exist.
 
-.. warning::
-
-   Using XCLASSes is risky: Your XCLASS may break if the underlying
-   code is changed. Preferably use events or hooks to extend class functionality.
-   For other limitations see :ref:`XClass limitations <xclasses-limitations>`
+..  warning::
+    Using XCLASSes is risky: Your XCLASS may break if the underlying
+    code is changed. Preferably use events or hooks to extend class functionality.
+    For other limitations see :ref:`XClass limitations <xclasses-limitations>`
 
 If you need a hook or event that does not exist, feel free to submit
 a feature request and - even better - a patch. Consult the
@@ -32,7 +31,7 @@ a feature request and - even better - a patch. Consult the
 about how to do this.
 
 
-.. _xclasses-mechanism:
+..  _xclasses-mechanism:
 
 How does it work?
 =================
@@ -45,33 +44,33 @@ If there is an XCLASS registered for the specific class that should be instantia
 an instance of that XCLASS is returned instead of an instance of the original class.
 
 
-.. index::
-   single: XCLASS; limitations
+..  index::
+    single: XCLASS; limitations
 
-.. _xclasses-limitations:
+..  _xclasses-limitations:
 
 Limitations
 ===========
 
-- Using XCLASSes is risky: neither the Core, nor extensions authors
-  can guarantee that XCLASSes will not break if the underlying code changes
-  (for example during upgrades). Be aware that your XCLASS can easily break
-  and has to be maintained and fixed if the underlying code changes.
-  If possible, you should use a hook instead of an XCLASS.
+-   Using XCLASSes is risky: neither the Core, nor extensions authors
+    can guarantee that XCLASSes will not break if the underlying code changes
+    (for example during upgrades). Be aware that your XCLASS can easily break
+    and has to be maintained and fixed if the underlying code changes.
+    If possible, you should use a hook instead of an XCLASS.
 
-- XCLASSes do **not** work for static classes, static methods, abstract classes or final classes.
+-   XCLASSes do **not** work for static classes, static methods, abstract classes or final classes.
 
-- There can be **only one** XCLASS per base class, but an XCLASS can be XCLASSed again.
-  Be aware that such a construct is even more risky and definitely not advisable.
+-   There can be **only one** XCLASS per base class, but an XCLASS can be XCLASSed again.
+    Be aware that such a construct is even more risky and definitely not advisable.
 
-- A small number of Core classes are required very early during bootstrap
-  before configuration and other things are loaded. XCLASSing those classes will fail if they are singletons
-  or might have unexpected side-effects.
+-   A small number of Core classes are required very early during bootstrap
+    before configuration and other things are loaded. XCLASSing those classes will fail if they are singletons
+    or might have unexpected side-effects.
 
-.. index::
-   single: XCLASS; declaration
+..  index::
+    single: XCLASS; declaration
 
-.. _xclasses-declaration:
+..  _xclasses-declaration:
 
 Declaration
 ===========
@@ -94,7 +93,7 @@ When XCLASSing a class that does not use namespaces, use that class name
 in the declaration.
 
 
-.. _xclasses-coding:
+..  _xclasses-coding:
 
 Coding practices
 ================
@@ -103,36 +102,35 @@ The recommended way of writing an XCLASS is to **extend** the original class and
 overwrite only the methods where a change is needed. This lowers the chances of the
 XCLASS breaking after a code update.
 
-.. tip::
-
-   You're even safer if you can do your changes before or after the parent method
-   and call the latter with :code:`parent::`.
+..  tip::
+    You are even safer if you can do your changes before or after the parent method
+    and call the latter with :code:`parent::`.
 
 The example below extends the new record wizard screen. It first calls the original
 method and then adds its own content:
 
-.. code-block:: php
-   :caption: EXT:some_extension/Classes/Xclass/NewRecordController.php
+..  code-block:: php
+    :caption: EXT:my_extension/Classes/Xclass/NewRecordController.php
 
-   class NewRecordController extends \TYPO3\CMS\Backend\Controller\NewRecordController
-   {
-       protected function renderNewRecordControls(ServerRequestInterface $request): void
-       {
-           parent::renderNewRecordControls($request);
-           $ll = 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf'
-           $label = $GLOBALS['LANG']->sL($ll . ':help');
-           $text = $GLOBALS['LANG']->sL($ll . ':make_choice');
-           $str = '<div><h2 class="uppercase" >' .  htmlspecialchars($label)
-               . '</h2>' . $text . '</div>';
-           $this->code .= $str;
-       }
-   }
+    class NewRecordController extends \TYPO3\CMS\Backend\Controller\NewRecordController
+    {
+        protected function renderNewRecordControls(ServerRequestInterface $request): void
+        {
+            parent::renderNewRecordControls($request);
+            $ll = 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf'
+            $label = $GLOBALS['LANG']->sL($ll . ':help');
+            $text = $GLOBALS['LANG']->sL($ll . ':make_choice');
+            $str = '<div><h2 class="uppercase" >' .  htmlspecialchars($label)
+                . '</h2>' . $text . '</div>';
+            $this->code .= $str;
+        }
+    }
 
 The result can be seen here:
 
-.. include:: /Images/AutomaticScreenshots/Examples/Xclasses/XclassNewElementWizard.rst.txt
+..  include:: /Images/AutomaticScreenshots/Examples/Xclasses/XclassNewElementWizard.rst.txt
 
-The object oriented rules of PHP 7 such as rules about visibility apply here.
-As you are extending the original Class you can overload or call methods
+The object-oriented rules of PHP, such as rules about visibility, apply here.
+As you are extending the original class you can overload or call methods
 marked as public and protected but not private or static ones. Read more about
 `visibility and inheritance at php.net <https://www.php.net/manual/en/language.oop5.visibility.php>`__


### PR DESCRIPTION
Mainly:
- First mention events, then hooks.
- Adjust indentation
- Use my_extension instead of some_extension

Releases: main, 12.4, 11.5