### PR TITLE
[BUGFIX] Use inline literal for SQL part in restriction builder chapter

### DIFF
--- a/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/RestrictionBuilder/Index.rst
@@ -142,7 +142,7 @@ Restrictions
 
 :php:`\TYPO3\CMS\Core\Database\Query\Restriction\StartTimeRestriction` (default)
     Evaluates :php:`['ctrl']['enablecolumns']['starttime']`, typically adds
-    something like :sql:`AND (`tt_content`.`starttime` <= 1475580240)`.
+    something like ``AND (`tt_content`.`starttime` <= 1475580240)``.
 
 :php:`\TYPO3\CMS\Core\Database\Query\Restriction\EndTimeRestriction` (default)
     Evaluates :php:`['ctrl']['enablecolumns']['endtime']`.


### PR DESCRIPTION
The SQL part is not displayed correctly as it contains a backtick. Using the inline literal syntax the snippet is displayed correctly now.

Releases: main, 12.4, 11.5