### PR TITLE
[TASK] Use "-" instead of "_" in page type icon name

### DIFF
--- a/Documentation/ApiOverview/PageTypes/_Icons.php
+++ b/Documentation/ApiOverview/PageTypes/_Icons.php
@@ -3,7 +3,7 @@
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 
 return [
-    'tx_examples-archive-page' => [
+    'tx-examples-archive-page' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:examples/Resources/Public/Images/ArchivePage.svg',
     ],

--- a/Documentation/ApiOverview/PageTypes/_pages.php
+++ b/Documentation/ApiOverview/PageTypes/_pages.php
@@ -6,7 +6,7 @@ defined('TYPO3') or die();
 (function () {
     // SAME as registered in ext_tables.php
     $customPageDoktype = 116;
-    $customIconClass = 'tx_examples-archive-page';
+    $customIconClass = 'tx-examples-archive-page';
 
     // Add the new doktype to the page type selector
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(


### PR DESCRIPTION
So that the naming is consistent the other examples:
- Documentation/ApiOverview/Icon/Index.rst
- Documentation/ApiOverview/Icon/_Icons.php

Those use "tx-myext-...icon" and not "tx_myext-...icon".

Related: #3898