### PR TITLE
[BUGFIX] Correct some rendering warnings

### DIFF
--- a/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
+++ b/Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst
@@ -441,6 +441,7 @@ Description of keywords in syntax:
 
 .. caution::
    .. versionchanged:: 13.0.1/12.4.11/11.5.35
+
    Modifying the :sql:`sys_file` table using DataHandler is blocked since TYPO3
    version 11.5.35, 12.4.11, and 13.0.1. The table
    should not be extended and additional fields should be added to

--- a/Documentation/CodingGuidelines/CglPhp/FileStructure.rst
+++ b/Documentation/CodingGuidelines/CglPhp/FileStructure.rst
@@ -51,23 +51,23 @@ file. User files must have this copyright notice as well. Example:
 ..  code-block:: php
     :caption: EXT:some_extension/Classes/SomeClass.php
 
-   <?php
-   declare(strict_types = 1);
+    <?php
+    declare(strict_types = 1);
 
-   /*
-    * This file is part of the TYPO3 CMS project.
-    *
-    * It is free software; you can redistribute it and/or modify it under
-    * the terms of the GNU General Public License, either version 2
-    * of the License, or any later version.
-    *
-    * For the full copyright and license information, please read the
-    * LICENSE.txt file that was distributed with this source code.
-    *
-    * The TYPO3 project - inspiring people to share!
-    */
+    /*
+     * This file is part of the TYPO3 CMS project.
+     *
+     * It is free software; you can redistribute it and/or modify it under
+     * the terms of the GNU General Public License, either version 2
+     * of the License, or any later version.
+     *
+     * For the full copyright and license information, please read the
+     * LICENSE.txt file that was distributed with this source code.
+     *
+     * The TYPO3 project - inspiring people to share!
+     */
 
-    namespace Vendor\SomeExtension\SomeFolder;
+     namespace Vendor\SomeExtension\SomeFolder;
 
 The wording must not be changed/updated/extended, under any circumstances.
 

--- a/Documentation/CodingGuidelines/Introduction.rst
+++ b/Documentation/CodingGuidelines/Introduction.rst
@@ -68,7 +68,7 @@ Setup IDE / editor
 .. _cgl-editorconfig:
 
 .editorconfig
-~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 One method to set up your IDE / editor to adhere to specific Coding Guidelines,
 is to use an .editorconfig file. Read `EditorConfig.org <https://EditorConfig.org>`__


### PR DESCRIPTION
    ./Documentation/CodingGuidelines/Introduction.rst:71: WARNING: Title underline too short.
    ./Documentation/ApiOverview/Typo3CoreEngine/Database/Index.rst:444: WARNING: Explicit markup ends without a blank line; unexpected unindent.
    ./Documentation/CodingGuidelines/CglPhp/FileStructure.rst:51: ERROR: Error in "code-block" directive:

Releases: main, 12.4, 11.5