### PR TITLE
[TASK] Remove hint to features.skipDefaultArguments

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -265,12 +265,6 @@ is an extension to the :ref:`regular plugin enhancer
 functionality to generate multiple variants, typically based on the available
 controller/action pairs.
 
-..  warning::
-    Do not enable the deprecated setting
-    :ref:`features.skipDefaultArguments <t3tsref:setup-plugin-features-skipDefaultArguments>`
-    in your Extbase plugin configuration as this will result in missing
-    parameters to be mapped - then no matching route configuration can be found.
-
 The Extbase plugin enhancer with the configuration below would now apply to the
 following URLs:
 


### PR DESCRIPTION
The option "features.skipDefaultArguments" was deprecated in TYPO3 v12 and removed in TYPO3 v13.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100622-ExtbaseFeatureToggles.html#skipdefaultarguments-1
Releases: main