### PR TITLE
[TASK] Rework extbase model extension

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
@@ -156,17 +156,20 @@ Register the extended model
 ---------------------------
 
 The extended model needs to be registered for :ref:`Extbase persistence <extbase-Persistence>` in file
-:file:`Configuration/Extbase/Persistence/Classes.php`.
+:file:`Configuration/Extbase/Persistence/Classes.php` and :file:`ext_localconf.php`.
 
 ..  literalinclude:: _Classes.php
     :language: php
     :caption: EXT:my_extension/Configuration/Extbase/Persistence/Classes.php
 
+..  literalinclude:: _ext_localconf.php
+    :language: php
+    :caption: EXT:my_extension/ext_localconf.php
 
 ..  _extending-extbase-model_extend_original_repository:
 
-Extend the original repository
-------------------------------
+Extend the original repository (optional)
+-----------------------------------------
 
 Likewise extend the original repository:
 
@@ -182,7 +185,6 @@ If you have no need for additional repository methods you can leave the body of
 this class empty. However, for Extbase internal reasons you have to create this
 repository even if you need no additional functionality.
 
-
 ..  _extending-extbase-model_register_extended_repository:
 
 Register the extended repository
@@ -193,7 +195,7 @@ The extended repository needs to be registered with Extbase in your extensions
 Extbase to use your repository instead of the original one whenever the original
 repository is requested via Dependency Injection in a controller or service.
 
-..  literalinclude:: _ext_localconf.php
+..  literalinclude:: _ext_localconf_repository.php
     :language: php
     :caption: EXT:my_extension/ext_localconf.php
 

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/_ext_localconf_repository.php
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/_ext_localconf_repository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use MyVendor\MyExtension\Domain\Repository\MyExtendedRepository;
+use OriginalVendor\OriginalExtension\Domain\Repository\SomeRepository;
+
+defined('TYPO3') or die('Access denied.');
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][SomeRepository::class] = [
+    'className' => MyExtendedRepository::class,
+];


### PR DESCRIPTION
In most cases it's not necessary to extend the extbase repository at all. But the custom model needs to be registered as XCLASS for the original one. That's why there's now two `ext_localconf.php` demo files.

----

Maybe add something like "Optional: " to the steps 3, 6 and 7 to make it obvious that extending the model isn't necessary in most cases?

Maybe reorganize the order of the steps too? 3 could be moved down to 6 and maybe even put together under one headline with 6+7?

![image](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/1405149/df3b32c3-65e9-4700-ad06-e191421f6556)
