### PR TITLE
add a solution for error cases with dependency injection

### DIFF
--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -476,13 +476,17 @@ autoconfigure
     available from the Symfony container and marked as shared
     (:yaml:`shared: true`).
 
-Model exclusion
+.. _dependency-injection-exclusion:
+
+Classpath Exclusion
     The path exclusion :yaml:`exclude: '../Classes/Domain/Model/*'` excludes
     your models from the dependency injection container, which means you cannot inject them
     nor inject dependencies into them. Models are not services and therefore
     should not require dependency injection. Also, these objects are created by
     the Extbase persistence layer, which does not support the DI container.
-
+    There are other possible error cases with classes called from outside of an extension
+    or too early during the boot process. It can be necessary to exclude several classes at once with
+    :yaml:`exclude: '../Classes/{Model,Middleware,UserFunc,Api}/*'`  
 
 .. _DependencyInjectionArguments:
 

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -485,7 +485,7 @@ Classpath Exclusion
     should not require dependency injection. Also, these objects are created by
     the Extbase persistence layer, which does not support the DI container.
     There are other possible error cases with classes called from outside of an extension
-    or too early during the boot process. It can be necessary to exclude several classes at once with
+    or getting utilized early during the boot process. Then it can be necessary to exclude several classes at once with
     :yaml:`exclude: '../Classes/{Model,Middleware,UserFunc,Api}/*'`  
 
 .. _DependencyInjectionArguments:

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -485,8 +485,10 @@ Classpath Exclusion
     should not require dependency injection. Also, these objects are created by
     the Extbase persistence layer, which does not support the DI container.
     There are other possible error cases with classes called from outside of an extension
-    or getting utilized early during the boot process. Then it can be necessary to exclude several classes at once with
-    :yaml:`exclude: '../Classes/{Model,Middleware,UserFunc,Api}/*'`  
+    or getting utilized early during the boot process or in complex initialization orders. 
+    Then it can be a solution to exclude several classes at once with
+    :yaml:`exclude: '../Classes/{ClassFolder1,ClassFolder2,ClassFolder3,ClassFolder4}/*'` 
+    if your classes have contructors which are not based on injectable classes.
 
 .. _DependencyInjectionArguments:
 


### PR DESCRIPTION
Many days of trial and error can be saved by a simple classpath exclusion.