### PR TITLE
[BUGFIX] Avoid TSFE constructor injection in DataHandler example

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -606,7 +606,7 @@ By default the following cache tags are flushed:
     updating a record if a record of any table placed on the page with UID 10
     (:php:`<table>.pid = 10`) is updated.
 
-Notice that you can also use the :php:`TypoScriptFrontendController::addCacheTags()`
+Notice that you can also use the :php:`TypoScriptFrontendController->addCacheTags()`
 method to register additional tags for the cache entry of the current page while
 it is rendered. This way you can implement an elaborate caching behavior which
 ensures that every record update in the TYPO3 backend (which is processed by the
@@ -617,24 +617,9 @@ Following the rules mentioned above you could register :ref:`cache tags <caching
 from within your :ref:`Extbase <extbase>` plugin (for example, controller or a
 custom ViewHelper):
 
-..  todo: Adjust example as TSFE cannot be injected anymore since TYPO3 v12
-
-..  code-block:: php
+..  literalinclude:: _SomeController.php
+    :language: php
     :caption: EXT:my_extension/Classes/Controller/SomeController.php
-
-    public function __construct(TypoScriptFrontendController $frontendController)
-    {
-        $this->frontendController = $frontendController;
-    }
-
-    public function showAction(ExampleModel $example): ResponseInterface
-    {
-        // ...
-
-        $this->frontendController->addCacheTags([
-            sprintf('tx_myextension_example_%d', $example->getUid()),
-        ]);
-    }
 
 Hook for cache post-processing
 ------------------------------

--- a/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
+++ b/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use MyVendor\MyExtension\Domain\Model\ExampleModel;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+final class SomeController extends ActionController
+{
+    public function showAction(ExampleModel $example): ResponseInterface
+    {
+        // ...
+
+        $this->getFrontendController()->addCacheTags([
+            sprintf('tx_myextension_example_%d', $example->getUid()),
+        ]);
+
+        // ...
+    }
+
+    private function getFrontendController(): TypoScriptFrontendController
+    {
+        return $GLOBALS['TSFE'];
+    }
+}


### PR DESCRIPTION
With TYPO3 v12 the TSFE cannot be injected via constructor as it holds state. Therefore, the global variable must be used in this example.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html
Releases: main, 12.4, 11.5