### PR TITLE
fix crowdin translation path

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -96,7 +96,7 @@ located in the extension root directory.
 
     files:
       - source: /Resources/Private/Language/
-        translation: /%original_path%/%two_letters_code%.%original_file_name%
+        translation: /Resources/Private/Language/%two_letters_code%.%original_file_name%
         ignore:
           - /Resources/Private/Language/de.*
 


### PR DESCRIPTION
The current documentation leads to a wrong download path into /master/Resources/Resources/Private/Language/filename.xlf .

But it must be here:

/Resources/Resources/Private/Language/filename.xlf .