### PR TITLE
Avoid deprecated/removed setUpBackendUserFromFixture()

### DIFF
--- a/Documentation/Testing/WritingFunctional.rst
+++ b/Documentation/Testing/WritingFunctional.rst
@@ -142,7 +142,8 @@ call :php:`parent::setUp()` before doing own stuff. An example can be found in
         {
             parent::setUp();
 
-            $this->setUpBackendUserFromFixture(1);
+            $this->importCSVDataSet(__DIR__ . '/Fixtures/be_users.csv');
+            $this->setUpBackendUser(1);
             Bootstrap::initializeLanguageObject();
 
             $this->importCSVDataSet(ORIGINAL_ROOT . 'typo3/sysext/backend/Tests/Functional/Domain/Repository/Localization/Fixtures/DefaultPagesAndContent.csv');


### PR DESCRIPTION
This was deprecated and removed with TYPO3 Testing Framework 8.x

See https://github.com/TYPO3/testing-framework/commit/147b4b60a4ab42ca8730bd0bad453d7576e33691