### PR TITLE
[CI] Remove check for "important" admonition

### DIFF
--- a/Build/Scripts/validateRstFiles.php
+++ b/Build/Scripts/validateRstFiles.php
@@ -154,23 +154,6 @@ class validateRstFiles
                 $this->isError = true;
             }
         }
-
-        $checkForForbidden = [
-            [
-                'type' => 'include',
-                'regex' => '#\.\. *important::#m',
-                'title' => 'admonition warning forbidden',
-                'message' => 'use ".. attention" instead of ".. important"',
-            ],
-        ];
-
-        foreach ($checkForForbidden as $values) {
-            if (preg_match($values['regex'], $fileContent) > 0) {
-                $this->messages[$values['type']]['title'] = $values['title'];
-                $this->messages[$values['type']]['message'] = $values['message'];
-                $this->isError = true;
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Once upon a time, the "important" admonition was coloured green. This was bad as it looks like "everything is okay". But an "important" admonition is - well - important.

But the times have changed: Nowadays the admonitions only know two colours: orange and dark grey. Therefore, this check is now superfluous and can vanish.

Releases: main, 12.4