### PR TITLE
[TASK] #103496 - Use ISO 8601 format for date rendering

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -240,7 +240,8 @@ ddmmyy
    :type: text
    :Default: 'Y-m-d'
 
-   Format of Day-Month-Year - see PHP-function `date() <https://www.php.net/manual/en/function.date.php>`__
+   On how to format a date, see PHP function
+    `date() <https://www.php.net/manual/en/function.date.php>`__.
 
 .. index::
    TYPO3_CONF_VARS SYS; hhmm

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -230,11 +230,15 @@ devIPmask
 ddmmyy
 ======
 
+..  versionchanged:: 12.4.14/13.1.0
+    The default value has been changed from 'd-m-y' to 'Y-m-d' (ISO 8601) to
+    avoid unclear dates.
+
 .. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['ddmmyy']
 
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']
    :type: text
-   :Default: 'd-m-y'
+   :Default: 'Y-m-d'
 
    Format of Day-Month-Year - see PHP-function `date() <https://www.php.net/manual/en/function.date.php>`__
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/885
Releases: main, 12.4