### PR TITLE
[BUGFIX] Add missing use statement in DataHandler example

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -384,7 +384,7 @@ of original record UIDs and UIDs of record copies as values.
 
     $cmd['tt_content'][1203]['copy'] = 400;  // Copies tt_content uid=1203 to first position in page uid=400
     $this->dataHandler->start([], $cmd);
-    $this->dataHandler->process_cmdmap()
+    $this->dataHandler->process_cmdmap();
 
     $uid = $this->dataHandler->copyMappingArray_merged['tt_content'][1203];
 

--- a/Documentation/ApiOverview/DataHandler/Database/_BasicUsage.php
+++ b/Documentation/ApiOverview/DataHandler/Database/_BasicUsage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\DataHandling;
 
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+
 final class MyClass
 {
     public function __construct(


### PR DESCRIPTION
Additionally, fix a missing semicolon in another example.

Releases: main, 12.4