### PR TITLE
[TASK] Use references in DataHandler's data array section

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -417,7 +417,8 @@ Description of keywords in syntax:
 
     If you are creating new records, use a random string prefixed with `NEW`,
     for example, `NEW7342abc5e6d`. You can use static strings (`NEW1`, `NEW2`,
-    ...) or generate them using :php:`StringUtility::getUniqueId('NEW')`.
+    ...) or generate them using
+    :php:`\TYPO3\CMS\Core\Utility\StringUtility::getUniqueId('NEW')`.
 
 
 ..  confval:: fieldname
@@ -425,7 +426,8 @@ Description of keywords in syntax:
     :Data type: string
 
     Name of the database field you want to set a value for. The columns of the
-    table must be configured in :php:`$GLOBALS['TCA'][$table]['columns']`.
+    table must be configured in
+    :ref:`$GLOBALS['TCA'][$table]['columns'] <t3tca:columns>`.
 
 
 ..  confval:: value
@@ -434,8 +436,8 @@ Description of keywords in syntax:
 
     Value for "fieldname".
 
-    For fields of type `inline` this is a comma-separated list (CSV) of UIDs of
-    referenced records.
+    For fields of type :ref:`inline <t3tca:columns-inline>` this is a
+    comma-separated list of UIDs of referenced records.
 
 
 ..  note::


### PR DESCRIPTION
Additionally:
- Use FQCN for class name
- Remove "(CSV)" as this is mostly associated with the CSV file format, whereas a comma-separated list is meant (which is just 1,2,3 and not "1","2","3" like in CSV).

Releases: main, 12.4, 11.5