### PR TITLE
[TASK] Adjust addCacheTags() example

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
+++ b/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
@@ -15,15 +15,12 @@ final class SomeController extends ActionController
     {
         // ...
 
-        $this->getFrontendController()->addCacheTags([
+        /** @var TypoScriptFrontendController $frontendController */
+        $frontendController = $this->request->getAttribute('frontend.controller');
+        $frontendController->addCacheTags([
             sprintf('tx_myextension_example_%d', $example->getUid()),
         ]);
 
         // ...
-    }
-
-    private function getFrontendController(): TypoScriptFrontendController
-    {
-        return $GLOBALS['TSFE'];
     }
 }


### PR DESCRIPTION
The example is an Extbase controller, therefore the request object is available. We can use the "frontend.controller" attribute to get the TSFE object - and avoid the access of the global variable.

Releases: main, 12.4, 11.5