### PR TITLE
[BUGFIX] Correct highlighted line in FlexForm example

### DIFF
--- a/Documentation/CodeSnippets/Config/ExtensionDevelopment/Extbase.php
+++ b/Documentation/CodeSnippets/Config/ExtensionDevelopment/Extbase.php
@@ -322,7 +322,7 @@ return [
         'caption' => 'EXT:blog_example/Configuration/FlexForms/PluginSettings.xml',
         'sourceFile' => 'EXT:blog_example/Configuration/FlexForms/PluginSettings.xml',
         'targetFileName' => 'CodeSnippets/Extbase/Configuration/PluginSettings.rst.txt',
-        'emphasizeLines' => [10],
+        'emphasizeLines' => [8],
     ],
     [
         'action' => 'createPhpClassCodeSnippet',

--- a/Documentation/CodeSnippets/Extbase/Configuration/PluginSettings.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Configuration/PluginSettings.rst.txt
@@ -3,7 +3,7 @@
 
 .. code-block:: xml
    :caption: EXT:blog_example/Configuration/FlexForms/PluginSettings.xml
-   :emphasize-lines: 10
+   :emphasize-lines: 8
 
    <T3DataStructure>
        <sheets>
@@ -27,4 +27,3 @@
            </sDEF>
        </sheets>
    </T3DataStructure>
-   


### PR DESCRIPTION
The `<settings.postsPerPage>` should be highlighted instead `</label>`.

Releases: main, 12.4