### PR TITLE
Fix import statement for hotkeys.js

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/_example.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/_example.js
@@ -1,4 +1,4 @@
-import {Hotkeys, ModifierKeys} from '@typo3/backend/hotkeys.js';
+import Hotkeys, {ModifierKeys} from '@typo3/backend/hotkeys.js';
 
 Hotkeys.register([Hotkeys.normalizedCtrlModifierKey, ModifierKeys.ALT, 'e'], keyboardEvent => {
   console.log('Triggered on Ctrl/Cmd+Alt+E');


### PR DESCRIPTION
As "Hotkeys" is the default export inside hotkeys.js, it must be outside the curly braces.