### PR TITLE
[TASK] Discard setup information for old translation server

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
@@ -23,8 +23,6 @@ Get in contact with the team in the TYPO3 Slack channel
 `#cig-crowdin-localization`_ with the following information:
 
 #.  Extension name
-#.  Information if your extension is already available on the previous
-    translation server
 #.  Your email address for an invitation to Crowdin, so you will get the correct
     role for your project.
 


### PR DESCRIPTION
The old translation server (Pootle) has passed away some time ago. So, this information is not needed anymore and can be discarded.

Releases: main, 12.4, 11.5