### PR TITLE
[TASK] Adjust hint that ELTS ran out for TYPO3 v8.7

### DIFF
--- a/Documentation/Includes.rst.txt
+++ b/Documentation/Includes.rst.txt
@@ -35,7 +35,8 @@
 
 .. attention::
    TYPO3 v8 has reached its end-of-life March 31st, 2020 and is not
-   maintained by the community anymore.
+   maintained by the community anymore. Looking for a stable version? Use the
+   version switch on the top left.
 
-   You can order Extended Long Term Support (ELTS) here:
-   `TYPO3 ELTS <https://typo3.com/services/extended-support-elts>`__.
+   There is no further ELTS support. It is recommended that you upgrade your
+   project and use a supported version of TYPO3.


### PR DESCRIPTION
The ELTS has reached end-of-life on March 31st, 2024.

Releases: 8.7