### PR TITLE
[BUGFIX] Resolve duplicate link anchors

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -3,7 +3,6 @@
    ! File; EXT:{extkey}/ext_conf_template.txt
    Extension development; Extension configuration
 .. _extension-options:
-.. _extension-configuration:
 
 ===============================================
 :file:`ext_conf_template.txt`


### PR DESCRIPTION
They cause warnings since the newest version of the render-guides

Releases: main, 12.4, 11.5