### PR TITLE
[TASK] Display extension structure in a directory tree

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Persistence/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Persistence/Index.rst
@@ -8,6 +8,8 @@
 
 This folder can contain the following files:
 
+..  _extension-configuration-extbase-persistence-classes:
+
 :file:`Classes.php`
 ===================
 

--- a/Documentation/ExtensionArchitecture/FileStructure/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Index.rst
@@ -14,6 +14,105 @@ This chapter should also help you to find your way around in
 extensions and sitepackages that where automatically generated or
 that you downloaded as an example.
 
+The following folders and files can typically be found in a TYPO3 extension:
+
+..  directory-tree::
+    :level: 1
+    :show-file-icons: true
+
+    *   :ref:`Classes <extension-classes>`
+
+        *   ...
+
+    *   :ref:`Configuration <extension-configuration-files>`
+
+        *   :ref:`Backend <extension-configuration-backend>`
+
+            *   :ref:`AjaxRoutes.php <extension-configuration-backend-ajaxroutes>`
+            *   :ref:`Modules.php <extension-configuration-backend-modules>`
+            *   :ref:`Routes.php <extension-configuration-backend-routes>`
+
+        *   :ref:`Extbase <extension-configuration-extbase>`
+
+            *   :ref:`Persistence <extension-configuration-extbase-persistence>`
+
+                *   :ref:`Classes.php <extension-configuration-extbase-persistence-classes>`
+
+        *   :ref:`TCA <extension-configuration-tca>`
+
+            *   :ref:`Overrides <extension-configuration-tca-overrides>`
+
+                *   <tablename>.php
+                *   ...
+
+            *   <tablename>.php
+            *   ...
+
+        *   :ref:`TsConfig <extension-configuration-tsconfig>`
+
+            *   ...
+
+        *   :ref:`TypoScript <extension-configuration-typoscript>`
+
+            *   ...
+
+            *   constants.typoscript
+            *   setup.typoscript
+
+        *   :ref:`extension-configuration-Icons-php`
+        *   :ref:`extension-configuration-page_tsconfig`
+        *   :ref:`extension-configuration-services-yaml`
+        *   :ref:`extension-configuration-user_tsconfig`
+
+    *   :ref:`Documentation <extension-files-documentation>`
+
+        *   ...
+
+    *   :ref:`Resources <extension-files-Resources>`
+
+        *   :ref:`Private <extension-Resources-Private>`
+
+            *   :ref:`Language <extension-Resources-Private-Language>`
+
+                *   ...
+
+            *   Layouts
+
+                *   ...
+
+            *   Partials
+
+                *   ...
+
+            *   Templates
+
+                *   ...
+
+            *   ...
+
+        *   :ref:`Public <extension-Resources-Public>`
+
+            *   ...
+
+    *   :ref:`Tests <extension-files-tests>`
+
+        *   Functional
+
+            *   ...
+
+        *   Unit
+
+            *   ...
+
+        *   ...
+
+    *   :ref:`composer.json <files-composer-json>`
+    *   :ref:`ext_emconf.php <ext_emconf-php>`
+    *   :ref:`ext_localconf.php <ext-localconf-php>`
+    *   :ref:`ext_tables.php <ext-tables-php>`
+    *   :ref:`ext_tables.sql <ext_tables-sql>`
+
+
 .. _extension-files:
 
 Files
@@ -70,6 +169,7 @@ will create the correct structure for you.
 .. toctree::
    :titlesonly:
    :glob:
+   :hidden:
 
    *
    */Index

--- a/Documentation/ExtensionArchitecture/FileStructure/Tests/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Tests/Index.rst
@@ -1,6 +1,8 @@
 .. include:: /Includes.rst.txt
 .. index:: Path; EXT:{extkey}/Tests
 
+..  _extension-files-tests:
+
 =============
 :file:`Tests`
 =============


### PR DESCRIPTION
Needs to be backported manually

After: 

Expandable directory tree linking to the files or headlines describing file or folder:

![image](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/48202465/ba7d6d35-756c-40a0-80af-780d34ba452a)

![image](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/48202465/44915c34-3c82-4b77-97fe-a16b69174c6e)


Before:

The files can be kind of seen in the structure of the automatic menu:
![image](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/assets/48202465/eeba7d07-c879-41c9-84c9-462011eaab1d)


Releases: 12.4, 11.5