### PR TITLE
[TASK] Improve documentation on accessing site settings

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -145,6 +145,8 @@ or even fetching all settings:
 
     $siteSettings->getAll();
 
+See :ref:`<sitehandling-inTypoScript>` for other means of accessing the site settings.
+
 API
 ---
 

--- a/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
@@ -27,6 +27,8 @@ via
     :ref:`data <t3tsref:data-type-gettext>` function in
     :ref:`TypoScript <t3tsref:start>`
 *   constants in :ref:`TypoScript <t3tsref:start>` or :ref:`page TSconfig <t3tsconfig:pagetsconfig>`
+*   as variables (for example, :fluid:`{site.configuration.settings.mySettingKey}`) in Fluid templates
+    using the :typoscript:`SiteProcessor data processor`, see :ref:`<sitehandling-inTypoScript`.
 
 For instance, settings can be used in custom frontend code to deliver features
 which might vary per site for extensions. An example may be to configure

--- a/Documentation/ApiOverview/SiteHandling/UseSiteInTypoScript.rst
+++ b/Documentation/ApiOverview/SiteHandling/UseSiteInTypoScript.rst
@@ -80,3 +80,17 @@ In the Fluid template the properties of the site entity can be accessed with:
 
    <p>{site.rootPageId}</p>
    <p>{site.configuration.someCustomConfiguration}</p>
+
+Specific :ref:`sitehandling-settings` can be accessed via:
+
+.. code-block:: html
+
+   <p>{site.configuration.settings.mySettingKey}</p>
+   <p>{site.settings.all.mySettingKey}</p>
+
+..  todo: We do not have a Fluid StandaloneView documentation yet?
+
+In a Fluid :php:`StandaloneView` you can use the PHP API to access the
+site settings (see :ref:`sitehandling-site-object`), then assign that object
+to your Fluid standalone template, and finally access it through the same
+notation as above.


### PR DESCRIPTION
Through Slack, Tobias Gaertner asked on how to access the site settings in v12 properly:

https://typo3.slack.com/archives/C025BQLFA/p1714662002068369

I think the current documentation is lacking some cross-linking and more specifics and made a quick PR about this. I'd value more feedback on this.

The "site.settings.all.xxx" notation is something we use in all our projects, but I see it is currently not documented. Unsure if this is "official API", but I find that clearer to use because "site.settings" rathern than "site.configuration.settings" comes more naturally to our integrators.

Also I found that we do not seem to have a Fluid Standalone Documentation yet to point to? If this is really missing and I didn't just oversee it, I can create an issue for it and try to improve it.

(Still in vacation mode, but wanted to get this "into the system").

Releases: main, 12.4