### PR TITLE
[TASK] Streamline event listener examples to be readonly

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_MyEventListener.php
@@ -13,7 +13,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-page-tree-items',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(AfterPageTreeItemsPreparedEvent $event): void
     {

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
@@ -19,12 +19,12 @@ use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 )]
 final readonly class MyEventListener
 {
-    private readonly LanguageService $languageService;
+    private LanguageService $languageService;
 
     public function __construct(
-        private readonly IconFactory $iconFactory,
+        private IconFactory $iconFactory,
         LanguageServiceFactory $languageServiceFactory,
-        private readonly UriBuilder $uriBuilder,
+        private UriBuilder $uriBuilder,
     ) {
         $this->languageService = $languageServiceFactory->createFromUserPreferences($GLOBALS['BE_USER']);
     }

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/_AfterMailerSentMessageEvent/_MyEventListener.php
@@ -15,7 +15,7 @@ use TYPO3\CMS\Core\Mail\Mailer;
 final readonly class MyEventListener
 {
     public function __construct(
-        private readonly LoggerInterface $logger,
+        private LoggerInterface $logger,
     ) {}
 
     public function __invoke(AfterMailerSentMessageEvent $event): void

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/_LogoutConfirmedEvent/_DeletePrivateKeyOnLogout.php
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/_LogoutConfirmedEvent/_DeletePrivateKeyOnLogout.php
@@ -12,11 +12,11 @@ use TYPO3\CMS\FrontendLogin\Event\LogoutConfirmedEvent;
 #[AsEventListener(
     identifier: 'my-extension/delete-private-key-on-logout',
 )]
-final class LogoutEventListener
+final readonly class LogoutEventListener
 {
     public function __construct(
-        private readonly KeyFileService $keyFileService,
-        private readonly Context $context,
+        private KeyFileService $keyFileService,
+        private Context $context,
     ) {}
 
     public function __invoke(LogoutConfirmedEvent $event): void

--- a/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/_ModifyVersionDifferencesEvent/_MyEventListener.php
@@ -13,8 +13,9 @@ use TYPO3\CMS\Workspaces\Event\ModifyVersionDifferencesEvent;
 )]
 final readonly class MyEventListener
 {
-    public function __construct(private readonly DiffUtility $diffUtility)
-    {
+    public function __construct(
+        private DiffUtility $diffUtility,
+    ) {
         $this->diffUtility->stripTags = false;
     }
 


### PR DESCRIPTION
Most of the event listener classes are marked as readonly already. Some aren't, they are now. Additionally, remove "readonly" from properties as this is for readonly classes not necessary.

Releases: main