### PR TITLE
[BUGFIX] Limit cs-fixer to folder "Documentation"

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,7 +8,7 @@ use PhpCsFixer\Finder;
 return (new Config())
     ->setFinder(
         (new Finder())
-            ->in(__DIR__)
+            ->in(__DIR__.'/Documentation')
     )
     ->setRiskyAllowed(true)
     ->setRules([


### PR DESCRIPTION
This greatly speeds up the fixer as it does not search in var and vendor directories then.

Releases: main, 12.4, 11.5