### PR TITLE
[BUGFIX] Fix spelling errors, standardize brand names, fix event listener examples

### DIFF
--- a/Documentation/ApiOverview/Autoloading/Background.rst
+++ b/Documentation/ApiOverview/Autoloading/Background.rst
@@ -13,7 +13,7 @@ Integrating Composer class loader into TYPO3
 
 In our efforts to make TYPO3 faster and closer oriented
 to common PHP standard systems, we looked into the integration of the
-class loader that is used by all composer-based projects. We consider
+class loader that is used by all Composer-based projects. We consider
 this functionality a crucial feature for the future of TYPO3 on the
 base level, but also as a dramatic increase of the overall performance
 of every request inside TYPO3.
@@ -60,7 +60,7 @@ ensured.
 Understanding the Composer class loader
 =======================================
 
-Compared to the TYPO3 class loader, the composer class loader
+Compared to the TYPO3 class loader, the Composer class loader
 concept differs in the following major points:
 
 Caching on build stage
@@ -78,7 +78,7 @@ Using PSR-4 compatible prefix-based resolving
 ---------------------------------------------
 
 Instead of looking up every single class and caching the information
-away, composer works on a “prefix”-based resolution. As an example, the
+away, Composer works on a “prefix”-based resolution. As an example, the
 Composer class loader only needs to know that all PHP classes starting
 with :php:`TYPO3\CMS\Core` are located within :file:`EXT:core/Classes`. The
 rest is done by a simple resolution to include the necessary PHP class
@@ -91,7 +91,7 @@ package or distribution / project.
 Autoloading developer-specific data differently
 -----------------------------------------------
 
-The composer class loader checks the :file:`composer.json` for a development
+The Composer class loader checks the :file:`composer.json` for a development
 installation differently, including for example unit and functional tests
 separately to the rest of the installation. The static map with all
 namespaces are thus different when using Composer with `composer
@@ -119,14 +119,14 @@ the :file:`typo3_src` directory. The generated class information is available
 under :file:`typo3/contrib/vendor/composer/`. For TYPO3 installations that are
 set up with composer, the TYPO3 bootstrap checks
 :file:`Packages/Libraries/autoload.php` first which can be shipped with any
-composer-based project and include many more PHP Composer packages than
+Composer-based project and include many more PHP Composer packages than
 just TYPO3 extensions. To ensure maximum backwards-compatibility, the
 option to load from :file:`Packages/Library/autoload.php` instead of the shipped
 "required-core-packages-only" needs to be activated via an environment
 variable called :php:`TYPO3_COMPOSER_AUTOLOAD` which needs to be set on
 server-side level.
 
-If the composer-based logic is not used in some legacy cases (for
+If the Composer-based logic is not used in some legacy cases (for
 extensions etc), the usual TYPO3 class loader comes into play and does
 the same logic as before.
 

--- a/Documentation/ApiOverview/Autoloading/Index.rst
+++ b/Documentation/ApiOverview/Autoloading/Index.rst
@@ -166,7 +166,7 @@ Best practices
 
 ..  tip::
     PSR-4 is a standard that has been developed by the PHP Framework Interop
-    Group (FIG). PSR-4 is an advanced standard for autoloading php classes and
+    Group (FIG). PSR-4 is an advanced standard for autoloading PHP classes and
     replaces PSR-0. If you want to know more about the PHP FIG in general and
     PSR-4 in specific, please visit https://www.php-fig.org/psr/psr-4/.
 

--- a/Documentation/ApiOverview/Backend/EditLinks.rst
+++ b/Documentation/ApiOverview/Backend/EditLinks.rst
@@ -51,7 +51,7 @@ The examples above leads to the normal edit form for a page:
 Additional options for editing records
 ======================================
 
-When creating the link via php it is possible to add more options.
+When creating the link via PHP it is possible to add more options.
 
 You can specify as many tables and uids you like and you will get them all in
 one single form!
@@ -104,7 +104,7 @@ There is a backend viewhelper to display a "create new record" link:
 		<f:translate key="function_links_new_haiku"/>
 	</a>
 
-If you create the backend link via php it is possible to add more options like
+If you create the backend link via PHP it is possible to add more options like
 default values for certain fields.
 
 .. code-block:: php

--- a/Documentation/ApiOverview/Events/Concept/Index.rst
+++ b/Documentation/ApiOverview/Events/Concept/Index.rst
@@ -64,7 +64,7 @@ yet, then you should suggest emitting an event. Normally that is rather easily
 done by the author of the source you want to extend:
 
 *   For the TYPO3 Core create an issue on `forge.typo3.org`_.
-*   For a third-party extension create in issue in the according issue tracker
+*   For a third-party extension create an issue in the according issue tracker
     of that extension.
 
 ..  _forge.typo3.org: https://forge.typo3.org/projects/typo3cms-core/issues

--- a/Documentation/ApiOverview/Events/Events/Core/Imaging/_ModifyRecordOverlayIconIdentifierEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Imaging/_ModifyRecordOverlayIconIdentifierEvent/_MyEventListener.php
@@ -7,11 +7,11 @@ namespace Vendor\MyExtension\Imaging\EventListener;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Imaging\Event\ModifyRecordOverlayIconIdentifierEvent;
 
+#[AsEventListener(
+    identifier: 'my-extension/imaging/modify-record-overlay-icon-identifier',
+)]
 final readonly class MyEventListener
 {
-    #[AsEventListener(
-        identifier: 'my-extension/imaging/modify-record-overlay-icon-identifier',
-    )]
     public function __invoke(ModifyRecordOverlayIconIdentifierEvent $event): void
     {
         if ($event->getTable() === 'tx_myextension_domain_model_mytable') {

--- a/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/_AfterPackageActivationEvent/_MyEventListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Package\EventListener;
 
 use TYPO3\CMS\Core\Attribute\AsEventListener;

--- a/Documentation/ApiOverview/Events/Events/Core/Package/_PackageInitializationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/_PackageInitializationEvent/_MyEventListener.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Package\EventListener;
 
 use TYPO3\CMS\Core\Attribute\AsEventListener;

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCreatedEvent.rst
@@ -8,7 +8,7 @@ AfterFileCreatedEvent
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Resource\Event\AfterFileCreatedEvent`
-is fired before a file was created within a resource
+is fired after a file was created within a resource
 :ref:`storage <fal-architecture-components-storage>` /
 :ref:`driver <fal-architecture-components-drivers>`.
 The folder represents the "target folder".

--- a/Documentation/ApiOverview/Events/Events/Frontend/_EnhanceStdWrapEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Frontend/_EnhanceStdWrapEvent/_MyEventListener.php
@@ -10,11 +10,11 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsInitializedEvent
 use TYPO3\CMS\Frontend\ContentObject\Event\BeforeStdWrapFunctionsInitializedEvent;
 use TYPO3\CMS\Frontend\ContentObject\Event\EnhanceStdWrapEvent;
 
+#[AsEventListener(
+    identifier: 'my-extension/my-stdwrap-enhancement',
+)]
 final readonly class MyEventListener
 {
-    #[AsEventListener(
-        identifier: 'my-extension/my-stdwrap-enhancement',
-    )]
     public function __invoke(EnhanceStdWrapEvent $event): void
     {
         // listen to all events

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/_LogoutConfirmedEvent/_DeletePrivateKeyOnLogout.php
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/_LogoutConfirmedEvent/_DeletePrivateKeyOnLogout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\EventListener;
 
 use MyVendor\MyExtension\KeyPairHandling\KeyFileService;
@@ -26,7 +28,7 @@ final readonly class LogoutEventListener
         if ($this->keyFileService->deletePrivateKey($userAspect)) {
             $event->getController()->addFlashMessage('Your private key has been deleted. ', '', ContextualFeedbackSeverity::NOTICE);
         } else {
-            $event->getController()->addFlashMessage('Deletion of your private key failed. It will be deleted automatically withing 15 minutes by a scheduler task. ', '', ContextualFeedbackSeverity::WARNING);
+            $event->getController()->addFlashMessage('Deletion of your private key failed. It will be deleted automatically within 15 minutes by a scheduler task. ', '', ContextualFeedbackSeverity::WARNING);
         }
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
@@ -56,7 +56,7 @@ match, if it is an external link to an internal page.
 ..  include:: /CodeSnippets/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent/ParseFields.rst.txt
 
 If the URL found in the matching is external and contains the local domain name
-we add the an entry to the :php:`BrokenLinkRepository` and to the result set of
+we add an entry to the :php:`BrokenLinkRepository` and to the result set of
 :php:`BeforeRecordIsAnalyzedEvent`.
 
 ..  include:: /CodeSnippets/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent/AddToBrokenLinkRepository.rst.txt

--- a/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php
@@ -19,7 +19,7 @@ final readonly class MyEventListener
         // Remove wildcard host from list
         $hosts = array_filter($hosts, static fn($host) => $host['name'] !== '*');
 
-        // Ipdate changed hosts list
+        // Update changed hosts list
         $event->setHosts($hosts);
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Redirects/_SlugRedirectChangeItemCreatedEvent/_MyEventListener.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Redirects\RedirectUpdate\RedirectSourceCollection;
     identifier: 'my-extension/redirects/add-redirect-source',
     after: 'redirects-add-plain-slug-replacement-source',
 )]
-final class MyEventListener
+final readonly class MyEventListener
 {
     public function __invoke(SlugRedirectChangeItemCreatedEvent $event): void
     {

--- a/Documentation/ApiOverview/FlashMessages/FlashMessagesApi.rst
+++ b/Documentation/ApiOverview/FlashMessages/FlashMessagesApi.rst
@@ -70,7 +70,7 @@ In backend modules you can then make that message appear on top of the
 module after a page refresh or the rendering of the next page request
 or render it on your own where ever you want.
 
-In this example the :php:`FlashMessageService` (:php:`TYPO3\CMS\Core\Messaging\FlashMessageService`) 
+In this example the :php:`FlashMessageService` (:php:`TYPO3\CMS\Core\Messaging\FlashMessageService`)
 is used to add a flash message at the bottom right of a module:
 
 .. code-block:: php
@@ -128,5 +128,5 @@ as top-right notifications, instead of inline:
     $notificationQueue->enqueue($flashMessage);
 
 The recommended way to show flash messages is to use the Fluid ViewHelper :html:`<f:flashMessages />`.
-This ViewHelper works in any context because it use the :php:`FlashMessageRendererResolver` class
+This ViewHelper works in any context because it uses the :php:`FlashMessageRendererResolver` class
 to find the correct renderer for the current context.

--- a/Documentation/ApiOverview/FlashMessages/NotificationApi.rst
+++ b/Documentation/ApiOverview/FlashMessages/NotificationApi.rst
@@ -14,8 +14,8 @@ JavaScript-based flash messages (Notification API)
 ..  attention::
     The notification API is designed for TYPO3 backend purposes only.
 
-The TYPO3 Core provides a JavaScript-based API  called :js:`Notification` to
-trigger flash messages that appear on the upper right corner of the TYPO3
+The TYPO3 Core provides a JavaScript-based API called :js:`Notification` to
+trigger flash messages that appear in the bottom right corner of the TYPO3
 backend. To use the notification API, load the
 :js:`TYPO3/CMS/Backend/Notification` module and use one of its methods:
 

--- a/Documentation/ApiOverview/Fluid/AdditionalAttributes.rst
+++ b/Documentation/ApiOverview/Fluid/AdditionalAttributes.rst
@@ -10,7 +10,7 @@ can get passed the property :html:`additionalAttributes`.
 
 A tag-based Fluid ViewHelper generally supports most attributes that are
 also available in HTML. There are, for example, the attributes `class` and
-`id`, which exists in all tag-based ViewHelpers.
+`id`, which exist in all tag-based ViewHelpers.
 
 Sometimes attributes are needed that are not provided by the
 ViewHelper. A common example are data attributes.
@@ -21,7 +21,7 @@ ViewHelper. A common example are data attributes.
     <f:form.textbox additionalAttributes="{data-anything: 'some info', data-something: some.variable}" />
 
 
-The property `additionalAttributes` are especially helpful if only a
+The property `additionalAttributes` is especially helpful if only a
 few of these additional attributes are needed. Otherwise, it is often
 reasonable to write an own ViewHelper which extends the corresponding
 ViewHelper.

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -302,7 +302,7 @@ Set the Fluid paths with TypoScript using :ref:`t3tsref:cobj-fluidtemplate`
    </f:section>
 
    <f:section name="Main">
-      <f:render partial="Jumbotron" />
+       <f:render partial="Jumbotron" />
        <div class="container">
          <div class="row">
            <div class="col-md-4">

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -256,7 +256,7 @@ Register the control in :file:`Configuration/TCA/Overrides/pages.php`:
     :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
 
-Add the php class for rendering the control in
+Add the PHP class for rendering the control in
 :file:`Classes/FormEngine/FieldControl/ImportDataControl.php`:
 
 ..  literalinclude:: _ImportDataControl.php

--- a/Documentation/ApiOverview/SiteHandling/Basics.rst
+++ b/Documentation/ApiOverview/SiteHandling/Basics.rst
@@ -29,7 +29,7 @@ missing configuration and can also serve as a starting point for all further
 actions.
 
 Most parts of the site configuration can be edited via the graphical interface
-in the backend module :guilabel:`Site`.
+in the backend module :guilabel:`Sites`.
 
 ..  include:: /Images/AutomaticScreenshots/SiteHandling/SiteHandlingSiteModule.rst.txt
 

--- a/Documentation/ApiOverview/SiteHandling/CreateNew.rst
+++ b/Documentation/ApiOverview/SiteHandling/CreateNew.rst
@@ -68,7 +68,7 @@ language IDs between sites in sync, 2. is a quick start to set up a new site.
 
 ..  include:: /Images/AutomaticScreenshots/SiteHandling/SiteHandlingCreateNewSite-3.rst.txt
 
-Check and correct all other settings as they will automatically used for
+Check and correct all other settings as they will be automatically used for
 features like the locale or displaying language flags in the backend.
 
 That is all that is required for a new site.

--- a/Documentation/ApiOverview/SiteHandling/SiteSets.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSets.rst
@@ -228,7 +228,7 @@ Defining the site set with a fluid_styled_content dependency
 ------------------------------------------------------------
 
 As our example site package only contains one site set the name of that set
-is the same like the composer name of the site package.
+is the same as the Composer name of the site package.
 
 The site package depends on
 :ref:`EXT:fluid_styled_content <typo3/cms-fluid-styled-content:start>`.

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -36,10 +36,10 @@ about how to do this.
 How does it work?
 =================
 
-In general every class instance in the Core and in extensions that stick to
+In general every class instance in the Core and in extensions that sticks to
 the recommended :ref:`coding guidelines <cgl>` is created with the API call
 :code:`\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()`.
-The methods takes care of singletons and also searches for existing XCLASSes.
+This method takes care of singletons and also searches for existing XCLASSes.
 If there is an XCLASS registered for the specific class that should be instantiated,
 an instance of that XCLASS is returned instead of an instance of the original class.
 
@@ -136,5 +136,5 @@ marked as public and protected but not private or static ones. Read more about
 `visibility and inheritance at php.net <https://www.php.net/manual/en/language.oop5.visibility.php>`__
 
 ..  seealso::
-    `How to use constructor dependency injection in a XCLASSed TYPO3 class 
+    `How to use constructor dependency injection in a XCLASSed TYPO3 class
     <https://www.derhansen.de/2021/06/how-to-use-constructor-injection-with-typo3-xclass.html>`__

--- a/Documentation/CodingGuidelines/CodingBestPractices/Singletons.rst
+++ b/Documentation/CodingGuidelines/CodingBestPractices/Singletons.rst
@@ -6,7 +6,7 @@
 Singletons
 ==========
 
-TYPO3 supports the singleton patterns for classes. Singletons are
+TYPO3 supports the singleton pattern for classes. Singletons are
 instantiated only once per request regardless of the number of
 calls to :php:`GeneralUtility::makeInstance()`. To use a singleton
 pattern, a class must implement the :php:`SingletonInterface`:

--- a/Documentation/Configuration/ConfigurationFiles.rst
+++ b/Documentation/Configuration/ConfigurationFiles.rst
@@ -91,7 +91,7 @@ could be shared with multiple TYPO3 installations.
 
 TYPO3 v12 has a strong support for Composer and TYPO3's own code base has
 progressed since 2012, when TYPO3 v6.0 was released. TYPO3 Core itself now
-only consists of extensions which are available as native composer packages.
+only consists of extensions which are available as native Composer packages.
 The concept of global extensions has been phased out over the past versions.
 
 Instead, TYPO3 installations now distinguish between "dependencies" such as

--- a/Documentation/Configuration/ConfigurationOverview.rst
+++ b/Documentation/Configuration/ConfigurationOverview.rst
@@ -261,7 +261,7 @@ YAML
 Some system extensions use YAML for configuration:
 
 * :ref:`Site <sitehandling>` configuration is stored in :file:`<project-root>/config/sites/<identifier>/config.yaml`.
-  It can be configured in the backend module "Site" or changed directly in
+  It can be configured in the backend module "Sites" or changed directly in
   the configuration file.
 
 * :ref:`routing` is also defined in the file :file:`<project-root>/config/sites/<identifier>/config.yaml`.

--- a/Documentation/Configuration/Yaml/YamlSyntax.rst
+++ b/Documentation/Configuration/Yaml/YamlSyntax.rst
@@ -19,7 +19,7 @@ the **TYPO3 specific information**:
 
 
 The :ref:`TYPO3 coding guidelines for YAML <cgl-yaml>` define some basic rules to
-be used in the TYPO3 Core  and extensions. Additionally, yaml has general syntax rules.
+be used in the TYPO3 Core  and extensions. Additionally, YAML has general syntax rules.
 
 These are recommendations that should be followed for TYPO3. We pointed out where things
 might break badly if not followed, by using MUST.

--- a/Documentation/ExtensionArchitecture/Concepts/Introduction.rst
+++ b/Documentation/ExtensionArchitecture/Concepts/Introduction.rst
@@ -102,7 +102,7 @@ are located in directory :file:`typo3/sysext`.
 Core
   As its name implies, this extension is crucial to the working of TYPO3 CMS.
   It defines the main database tables (BE users, BE groups, pages and all the
-  "sys\_*" tables. It also contains the default global configuration
+  "sys\_*" tables). It also contains the default global configuration
   (in :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`). Last
   but not least, it delivers a huge number of base PHP classes, far too many
   to describe here.

--- a/Documentation/ExtensionArchitecture/Concepts/SystemAndLocalExtensions.rst
+++ b/Documentation/ExtensionArchitecture/Concepts/SystemAndLocalExtensions.rst
@@ -46,7 +46,7 @@ or manually inserted in this directory.
 System Extensions
 =================
 
-System extensions have the composer type `typo3-cms-framework`:
+System extensions have the Composer type `typo3-cms-framework`:
 
 ..  code-block:: json
     :caption: EXT:core/composer.json`

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
@@ -14,8 +14,8 @@ configuration of different types.
 
 Some of the sub directories in here have reserved names with special meanings.
 
-All files in this directory and in the sub directories :file:`TCA` and :
-file:`Backend` are automatically included during the TYPO3 bootstrap.
+All files in this directory and in the sub directories :file:`TCA` and
+:file:`Backend` are automatically included during the TYPO3 bootstrap.
 
 The following files and folders are commonly found in the :file:`Configuration`
 folder:

--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
@@ -46,7 +46,7 @@ the servers web root.
 Alternatives: :file:`Resources/Public/Icons/Extension.png`,
 :file:`Resources/Public/Icons/Extension.gif`
 
-These file names are reserved for th extension icon, which will be displayed
+These file names are reserved for the extension icon, which will be displayed
 in the extension manager.
 
 It must be in format SVG (preferred), PNG or GIF and should have at least 16x16
@@ -65,7 +65,7 @@ Resources/Public/Css
 .. index:: Path; EXT:{extkey}/Resources/Public/Images
 
 Resources/Public/Images
-  Any images used by the extension.
+  Any image used by the extension.
 
 .. index::
    Path; EXT:{extkey}/Resources/Public/JavaScript

--- a/Documentation/ExtensionArchitecture/FileStructure/Tests/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Tests/Index.rst
@@ -7,7 +7,7 @@
 :file:`Tests`
 =============
 
-This folder contains all automatic Tests to test the extension.
+This folder contains all automatic tests to test the extension.
 
 Read more about :ref:`automatic testing <testing>`
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendGUI.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/BackendGUI.rst
@@ -48,7 +48,7 @@ Navigation frame
   when you move from the :guilabel:`Web > Page` module to the
   :guilabel:`Web > List` module, the same page stays selected in the page tree.
 
-Docheader
+DocHeader
   This part is always located above the Content area. It will generally
   contain a drop-down menu called the "Function menu", which allows to
   navigate into the various functions offered by the module. When editing

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/Tutorials.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/Tutorials.rst
@@ -17,12 +17,12 @@ module is based on a regular TYPO3 installation. Extbase is not used.
 
 In this video dependency injection is achieved via `Constructor Promotion <https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion>`__.
 
-Additionally `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>` 
+Additionally `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>`
 are used in the example.
 
-These features are available starting with PHP 8.0. With TYPO3 v11.5 it 
-is still possible to use PHP 7.4. So either require php 8.0 and 
-above in your :file:`composer.json` or use a normal constructor 
+These features are available starting with PHP 8.0. With TYPO3 v11.5 it
+is still possible to use PHP 7.4. So either require PHP 8.0 and
+above in your :file:`composer.json` or use a normal constructor
 for the dependency injection and refrain from using named arguments.
 
 Tutorial - Backend Module Registration - Part 2

--- a/Documentation/ExtensionArchitecture/HowTo/ExtensionManagement.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtensionManagement.rst
@@ -6,7 +6,7 @@
 Extension management
 ====================
 
-.. todo: Mention composer here
+.. todo: Mention Composer here
 
 Extensions are managed from the Extension Manager inside TYPO3 by
 "admin" users. The module is located at :guilabel:`Admin Tools > Extensions`
@@ -95,7 +95,7 @@ containing the data structure for each extension. These include the properties:
  - :Key:
          composerManifest
    :Description:
-         A large array containing the composer manifest. (the
+         A large array containing the Composer manifest. (the
          :file:`composer.json` of the extension, if it exists)
 
  - :Key:

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/ExtensionScanner.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/ExtensionScanner.rst
@@ -24,7 +24,7 @@ This document has been written to explain the design goals of the scanner, to po
 and can't do. The document should help extension and project developers to get the best out of the tool,
 and it should help Core developers to add Core patches which use the scanner.
 
-This module has been featured on the TYPO3 youtube channel:
+This module has been featured on the TYPO3 YouTube channel:
 
 .. youtube:: UdIYDZgBrQU
 
@@ -70,11 +70,11 @@ Goals and non goals
 
 * Core developers should be able to easily register and maintain matchers for new deprecations or breaking patches.
 
-* Implementation within the TYPO3 Core backend has been primary goal. While it might be possible, integration
+* Implementation within the TYPO3 Core backend has been the primary goal. While it might be possible, integration
   into IDEs like PhpStorm has not been a design goal. Also, matcher configuration is bound to the Core version,
   e.g. tests concerning v12 are not intended to be executed on v11.
 
-* Some of reST files that document a breaking change or deprecated API can be used to scan extensions.
+* Some of the reST files that document a breaking change or deprecated API can be used to scan extensions.
   If those find no matches, the reST documentation files are tagged with a "no match" label telling integrators
   and project developers that they do not need to concern themselves with that particular change.
 

--- a/Documentation/ExtensionArchitecture/Index.rst
+++ b/Documentation/ExtensionArchitecture/Index.rst
@@ -20,7 +20,7 @@ Extension development
          .. container:: card-body
 
             Learn about the concept of extensions
-            in TYPO3, the difference between system extension and local
+            in TYPO3, the difference between system extensions and local
             extensions. Learn about Extbase as an MVC basis for extension
             development.
 
@@ -34,11 +34,11 @@ Extension development
 
          .. container:: card-body
 
-            Lists reserved file and directory names within and extension. Also
+            Lists reserved file and directory names within an extension. Also
             lists file names that are used in a certain way by convention.
 
             This chapter should also help you to find your way around in
-            extensions and sitepackages that where automatically generated or
+            extensions and sitepackages that were automatically generated or
             that you downloaded as an example.
 
    .. container:: col-md-6 pl-0 pr-3 py-3 m-0

--- a/Documentation/ExtensionArchitecture/Tutorials/Kickstart/Make/Index.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Kickstart/Make/Index.rst
@@ -113,7 +113,7 @@ Call the CLI script on the console:
 `May we create a ext_emconf.php for you? (yes/no) [no]:`
     Mandatory for extensions supporting TYPO3 v10. Starting with v11:
     If your extension should be installable in legacy TYPO3 installations
-    choose `yes`. This is not necessary for local extensions in composer-based
+    choose `yes`. This is not necessary for local extensions in Composer-based
     installations.
 
 4.  Have a look at the result
@@ -137,7 +137,7 @@ the following files:
 5. Install the extension
 ========================
 
-On composer-based installations the extension is not installed yet.
+On Composer-based installations the extension is not installed yet.
 It will not be displayed in the :guilabel:`Extension Manager` in the backend.
 
 To install it, open the main :file:`composer.json` of your **project** (not the
@@ -158,7 +158,7 @@ one in the created extension) and add the extension directory as new repository:
         "...": "..."
     }
 
-Then require the extension on composer-based systems, using the composer
+Then require the extension on Composer-based systems, using the composer
 name defined in the prompt of the script:
 
 ..  tabs::

--- a/Documentation/Security/GuidelinesAdministrators/FurtherActions.rst
+++ b/Documentation/Security/GuidelinesAdministrators/FurtherActions.rst
@@ -35,7 +35,7 @@ Due to the fact that TYPO3 is a PHP application, secure PHP settings
 are also important, of course. PHP settings, such as `open_basedir`,
 `disable_functions` often improve the security of your system and should be considered.
 
-In use cases where you rely on outbound connections and your php comes without support
+In use cases where you rely on outbound connections and your PHP comes without support
 for curl it might be required to set `allow_url_fopen` to true.
 
 Note that disallowing remote connections (e.g. by blocking outgoing traffic on a firewall in

--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -115,7 +115,7 @@ servers virtual host configuration. A typical example looks like this:
             deny all;
         }
 
-        # TYPO3 - Block access to composer files
+        # TYPO3 - Block access to Composer files
         location ~* composer\.(?:json|lock) {
             deny all;
         }

--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -64,20 +64,20 @@ running on the host system. Executing the basic Core unit test suite boils down 
 
     # Initial core clone
     git clone git@github.com:typo3/typo3.git && cd typo3
-    # Install composer dependencies
+    # Install Composer dependencies
     Build/Scripts/runTests.sh -s composerInstall
     # Run unit tests
     Build/Scripts/runTests.sh
 
 That's it. You just executed the entire unit test suite.
-Now that we have examined the initial Core clone and a composer install process, we will then look at the
+Now that we have examined the initial Core clone and a Composer install process, we will then look at the
 different ways we can apply the :file:`runTests.sh` or other scenarios.
 
 
 Overview
 ========
 
-So what just happened? We cloned a Core, composer installed dependencies and executed Core
+So what just happened? We cloned a Core, Composer installed dependencies and executed Core
 unit tests. Let's have a look at some more details: :file:`runTests.sh` is a shell script that figures out
 which test suite with which options a user wants to execute, does some error handling for broken
 combinations, writes the file `Build/testing-docker/local/.env` according to its findings and then executes a
@@ -193,7 +193,7 @@ tests, but there is more:
     # Execute the cgl fixer
     Build/Scripts/runTests.sh -s cglGit
 
-    # Verbose runTests.sh output. Shows main steps and composer commands for debugging
+    # Verbose runTests.sh output. Shows main steps and Composer commands for debugging
     Build/Scripts/runTests.sh -v
 
 As shown there are various combinations available. Just go ahead, read the help output and play around.

--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -64,7 +64,7 @@ Testing enetcache
 =================
 
 The extension `enetcache <https://github.com/lolli42/enetcache>`_ is a small extension that helps
-with frontend plugin based caches. It has been available as composer package and a TER extension for quite
+with frontend plugin based caches. It has been available as Composer package and a TER extension for quite
 some time and is loosely maintained to keep up with current Core versions.
 
 The following is based on the current (May, 2023) main branch of enetcache,
@@ -99,8 +99,8 @@ Starting point
 As outlined in the general strategy, we need to extend the existing :file:`composer.json` file by
 adding some root composer.json specific things. This does not harm the functionality of the existing
 composer.json properties if the extension is a project dependency and not used as root composer.json:
-Root properties are ignored in composer if the file is not used as root project file, see the
-notes "root-only" of the `composer documentation <https://getcomposer.org/doc/04-schema.md>`_ for details.
+Root properties are ignored in Composer if the file is not used as root project file, see the
+notes "root-only" of the `Composer documentation <https://getcomposer.org/doc/04-schema.md>`_ for details.
 
 This is how the composer.json file looks before we add a test setup:
 
@@ -782,13 +782,13 @@ Now we want all of this automatically checked using Github Actions. As before, w
 .. code-block:: yaml
 
     name: tests
-    
+
     on:
       push:
       pull_request:
       schedule:
         - cron:  '42 5 * * *'
-    
+
     jobs:
       testsuite:
         name: all tests
@@ -802,43 +802,43 @@ Now we want all of this automatically checked using Github Actions. As before, w
         steps:
           - name: Checkout
             uses: actions/checkout@v3
-    
+
           - name: Install dependencies
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerUpdate
-    
+
           - name: Composer validate
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s composerValidate
-    
+
           - name: Lint PHP
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
-    
+
           - name: CGL
             run: Build/Scripts/runTests.sh -n -p ${{ matrix.php }} -s cgl
-    
+
           - name: phpstan
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s phpstan -e "--error-format=github"
-    
+
           - name: Unit Tests
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s unit
-    
+
           - name: Functional Tests with mariadb and mysqli
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -a mysqli -s functional
-    
+
           - name: Functional Tests with mariadb and pdo_mysql
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mariadb -a pdo_mysql -s functional
-    
+
           - name: Functional Tests with mysql and mysqli
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mysql -a mysqli -s functional
-    
+
           - name: Functional Tests with mysql and pdo_mysql
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d mysql -a pdo_mysql -s functional
-    
+
           - name: Functional Tests with postgres
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d postgres -s functional
-    
+
           - name: Functional Tests with sqlite
             run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -d sqlite -s functional
-    
+
           - name: Build CSS
             run: Build/Scripts/runTests.sh -s buildCss
 

--- a/Documentation/Testing/Faq.rst
+++ b/Documentation/Testing/Faq.rst
@@ -18,7 +18,7 @@ Why do you docker everything?
 
 Executing tests in a containerized environment like docker has significant advantages over
 local execution. It takes away all the demanding setup needs of additional services like
-selenium, various database systems, different php versions in parallel on the same system and
+selenium, various database systems, different PHP versions in parallel on the same system and
 so on. It also creates a well defined environment that is identical for everyone: Extension
 authors rely on the same system dependencies as the Core does, local test execution is identical
 to what the continuous integration system bamboo does. All dependencies and setup details are open

--- a/Documentation/Testing/History.rst
+++ b/Documentation/Testing/History.rst
@@ -130,8 +130,8 @@ ten thousand tests in place it is rather seldom that a test fails on one machine
 on another. And if that happens, the root cause is often a detail down below in PHP itself that has not been
 perfectly aligned during test bootstrap - for instance a missing locale or some detail php.ini setting.
 
-Second, the test execution was changed to use a composer based setup instead of cloning things on
-its own. This was at TYPO3 v6.2 times when composer was first introduced in TYPO3 world - testing was
+Second, the test execution was changed to use a Composer based setup instead of cloning things on
+its own. This was at TYPO3 v6.2 times when Composer was first introduced in TYPO3 world - testing was
 one of the first usages. In this process we were able to ditch the TYPO3 specific extension based
 flavor of phpunit and switched to the native version instead. This turned out to be a wise decision
 since TYPO3 Core  testing now no longer relied on development of a third party TER extension but could


### PR DESCRIPTION
- fix spelling errors
- standardize spelling of "YouTube", "PHP", "Composer", "YAML" outside of commands
- add missing "declare(strict_types=1);" for a few event listener examples
- move "AsEventListener" attribute before class declaration for a few event listener examples