### PR TITLE
[TASK] Introduce a Backend module API section

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendModules/Index.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/Index.rst
@@ -1,0 +1,19 @@
+..  include:: /Includes.rst.txt
+..  index:: ! Backend modules
+..  index:: Backend modules; API
+..  _backend-modules-api:
+..  _backend-modules:
+
+===================
+Backend modules API
+===================
+
+..  versionchanged:: 12.0
+    Registration of backend modules was changed with version 12. Read more:
+    :ref:`backend-modules-configuration <Backend module configuration>`.
+
+..  note:: This section is currently (Mai 2024) work in progress.
+
+This chapter describes the API that can be used to create custom backend modules
+in extensions. See the following chapter for a tutorial on :ref:`how to create
+custom backend modules <backend-modules-how-to>`.

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/Index.rst
@@ -1,8 +1,6 @@
 .. include:: /Includes.rst.txt
-.. index:: ! Backend modules
-.. index:: Backend modules; API
-.. _backend-modules-api:
-.. _backend-modules:
+.. index:: Backend modules; How to
+.. _backend-modules-how-to:
 
 ===============
 Backend modules


### PR DESCRIPTION
All we have until now is a mix of Tutorials and API in the extension section.

Releases: main, 12.4