### PR TITLE
[FEATURE] Add link to feature toggles in SYS section

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -796,6 +796,9 @@ features
 New features of TYPO3 that are activated on new installations but upgrading
 installations may still use the old behaviour.
 
+These settings are :ref:`feature toggles <feature-toggles>` and can be
+changed in the Backend module :guilabel:`Settings` in the section
+:guilabel:`Feature Toggles`, but not in :guilabel:`Configure Installation-Wide Options`.
 
 .. index::
    TYPO3_CONF_VARS SYS; features form.legacyUploadMimeTypes


### PR DESCRIPTION
Add link and description where these settins can be set in the backend because these settins are handled differently and cannot be changed in the BE module in "Configure Installation-Wide options" as the other settings.

Resolves: #4420