### PR TITLE
Add documentation for fileExtensionToMimeType

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -1103,7 +1103,7 @@ FileInfo
 
 .. index::
    TYPO3_CONF_VARS SYS; FileInfo fileExtensionToMimeType
-.. _typo3ConfVars_sys_FileInfo_fileExtensionToMimeType:
+..  _typo3ConfVars_sys_FileInfo_fileExtensionToMimeType:
 
 fileExtensionToMimeType
 -----------------------

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -1108,7 +1108,7 @@ FileInfo
 fileExtensionToMimeType
 -----------------------
 
-.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType']
+..  confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType']
 
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']
     :type: array

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -1122,7 +1122,7 @@ fileExtensionToMimeType
 
     This is the default:
 
-    .. code-block:: php
+    ..  code-block:: php
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType'] = [
             'fileExtensionToMimeType' => [

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -1097,3 +1097,37 @@ routing
 
     ..  seealso::
         :ref:`message-bus-routing`
+
+FileInfo
+========
+
+.. index::
+   TYPO3_CONF_VARS SYS; FileInfo fileExtensionToMimeType
+.. _typo3ConfVars_sys_FileInfo_fileExtensionToMimeType:
+
+fileExtensionToMimeType
+-----------------------
+
+.. confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType']
+
+    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']
+    :type: array
+    :Default: see :file:`EXT:core/Configuration/DefaultConfiguration.php`
+
+    Static mapping for file extensions to mime types. In special cases the mime
+    type is not detected correctly. Override this array only for cases where the
+    automatic detection does not work correctly!
+
+    It is not possible to change this value in the Backend!
+
+    This is the default:
+
+    .. code-block:: php
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType'] = [
+            'fileExtensionToMimeType' => [
+                'svg' => 'image/svg+xml',
+                'youtube' => 'video/youtube',
+                'vimeo' => 'video/vimeo',
+            ],
+        ],


### PR DESCRIPTION
Documentation for $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['fileExtensionToMimeType'] is added.

Resolves: #3772