### PR TITLE
[TASK] Set a more suitable group identifier

### DIFF
--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content.php
@@ -15,7 +15,7 @@ defined('TYPO3') or die();
         // icon identifier
         'icon' => 'content-text',
         // group
-        'group' => 'common',
+        'group' => 'default',
         // description
         'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_description',
     ],


### PR DESCRIPTION
Contrary to the specification of the tab identifier "common" in the configuration of the New Content Element Wizard, the group must be named "default" in order to actually be listed among the default elements in the CType Select field. Otherwise, a new select item group with the name "common" is created in the element list.

This has been tested and applies to all versions from TYPO3 12 onwards.