### PR TITLE
[BUGFIX] Do not reuse DataHandler

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/_BasicUsage.php
+++ b/Documentation/ApiOverview/DataHandler/Database/_BasicUsage.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace MyVendor\MyExtension\DataHandling;
 
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function basicUsage(): void
     {
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
         $cmd = [];
         $data = [];
-        $this->dataHandler->start($data, $cmd);
+        $dataHandler->start($data, $cmd);
 
         // ... do something more ...
     }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/Index.rst
@@ -62,8 +62,16 @@ the :php:`$data` and :php:`$cmd` arrays correctly prior to these chunks of code.
 The syntax for these two arrays is explained in the
 :ref:`DataHandler basics <datahandler-basics>` chapter.
 
-The :php:`DataHandler` class can be injected into the constructor via
-:ref:`dependency injection <DependencyInjection>`.
+..  warning::
+    A new :php:`DataHandler` object **should** be created using
+    :php:`GeneralUtility::makeInstance(DataHandler::class)` before each use.
+    It is a stateful service and has to be considered polluted after use. Do not
+    call :php:`DataHandler::start()` or :php:`DataHandler::process_datamap()`
+    multiple time on the same instance.
+
+    The :php:`DataHandler` class **must not** be injected into the constructor via
+    :ref:`dependency injection <DependencyInjection>`. This can cause unexpected
+    side effects.
 
 ..  _tcemain-submit-data:
 

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ClearCache.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ClearCache.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function clearCache(): void
     {
-        $this->dataHandler->start([], []);
-        $this->dataHandler->clear_cacheCmd('all');
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], []);
+        $dataHandler->clear_cacheCmd('all');
     }
 }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ErrorHandling.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ErrorHandling.php
@@ -6,21 +6,26 @@ namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
     public function __construct(
-        private readonly DataHandler $dataHandler,
         private readonly LoggerInterface $logger,
     ) {}
 
     public function handleError(): void
     {
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
         // ... previous call of DataHandler's process_datamap() or process_cmdmap()
 
-        if ($this->dataHandler->errorLog !== []) {
+        if ($dataHandler->errorLog !== []) {
             $this->logger->error('Error(s) while creating content element');
-            foreach ($this->dataHandler->errorLog as $log) {
+            foreach ($dataHandler->errorLog as $log) {
                 // handle error, for example, in a log
                 $this->logger->error($log);
             }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ExecuteCommands.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_ExecuteCommands.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function executeCommands(): void
     {
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
         // Prepare the cmd array
         $cmd = [
             // ... the cmd structure ...
@@ -21,9 +23,9 @@ final class MyClass
 
         // Registers the $cmd array inside the class and initialize the
         // class internally.
-        $this->dataHandler->start([], $cmd);
+        $dataHandler->start([], $cmd);
 
         // Execute the commands.
-        $this->dataHandler->process_cmdmap();
+        $dataHandler->process_cmdmap();
     }
 }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_SubmitComplexData.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_SubmitComplexData.php
@@ -6,13 +6,10 @@ namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function submitComplexData(): void
     {
         $data = [
@@ -28,10 +25,15 @@ final class MyClass
             ],
         ];
 
-        $this->dataHandler->reverseOrder = true;
-        $this->dataHandler->start($data, []);
-        $this->dataHandler->process_datamap();
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
+        $dataHandler->reverseOrder = true;
+        $dataHandler->start($data, []);
+        $dataHandler->process_datamap();
         BackendUtility::setUpdateSignal('updatePageTree');
-        $this->dataHandler->clear_cacheCmd('pages');
+        $dataHandler->clear_cacheCmd('pages');
     }
 }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_SubmitData.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_SubmitData.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function submitData(): void
     {
         // Prepare the data array
@@ -19,11 +16,16 @@ final class MyClass
             // ... the data ...
         ];
 
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
         // Register the $data array inside DataHandler and initialize the
         // class internally.
-        $this->dataHandler->start($data, []);
+        $dataHandler->start($data, []);
 
         // Submit data and have all records created/updated.
-        $this->dataHandler->process_datamap();
+        $dataHandler->process_datamap();
     }
 }

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/_UseAlternativeUser.php
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/_UseAlternativeUser.php
@@ -6,13 +6,10 @@ namespace MyVendor\MyExtension\Classes\DataHandling;
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
-    public function __construct(
-        private readonly DataHandler $dataHandler,
-    ) {}
-
     public function useAlternativeUser(BackendUserAuthentication $alternativeBackendUser): void
     {
         // Prepare the data array
@@ -25,8 +22,13 @@ final class MyClass
             // ... the cmd structure ...
         ];
 
-        $this->dataHandler->start($data, $cmd, $alternativeBackendUser);
-        $this->dataHandler->process_datamap();
-        $this->dataHandler->process_cmdmap();
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+
+        $dataHandler->start($data, $cmd, $alternativeBackendUser);
+        $dataHandler->process_datamap();
+        $dataHandler->process_cmdmap();
     }
 }

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_CreatingFileReference.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_CreatingFileReference.php
@@ -6,13 +6,12 @@ namespace MyVendor\MyExtension\Classes;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class MyClass
 {
     public function __construct(
-        private readonly DataHandler $dataHandler,
         private readonly ResourceFactory $resourceFactory,
     ) {}
 
@@ -37,13 +36,17 @@ final class MyClass
         $data['tt_content'][$contentElement['uid']] = [
             'assets' => $newId, // For multiple new references $newId is a comma-separated list
         ];
+        /** @var DataHandler $dataHandler */
+        // Do not inject or reuse the DataHander as it holds state!
+        // Do not use `new` as GeneralUtility::makeInstance handles dependencies
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
 
         // Process the DataHandler data
-        $this->dataHandler->start($data, []);
-        $this->dataHandler->process_datamap();
+        $dataHandler->start($data, []);
+        $dataHandler->process_datamap();
 
         // Error or success reporting
-        if ($this->dataHandler->errorLog === []) {
+        if ($dataHandler->errorLog === []) {
             // ... handle success
         } else {
             // ... handle errors


### PR DESCRIPTION
This is a follow up of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/4260 following discussions on Slack: https://typo3.slack.com/archives/C028JEPJL/p1716473533796529

Releases: main, 12.4, 11.5