### PR TITLE
Fix incorrect path of namespace in constant reference

### DIFF
--- a/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/QueryBuilder/Index.rst
@@ -1072,7 +1072,7 @@ createNamedParameter()
 ..  versionchanged:: 13.0
     Doctrine DBAL v4 dropped the support for using the :php:`\PDO::PARAM_*`
     constants in favor of the enum types. Be aware of this and use
-    :php:`\TYPO3\CMS\Core\Database\Connection\::PARAM_*`, which can already be
+    :php:`\TYPO3\CMS\Core\Database\Connection::PARAM_*`, which can already be
     used in TYPO3 v12 and v11.
 
 This method creates a placeholder for a field value of a prepared statement.


### PR DESCRIPTION
Change the namespace path of the `PARAM_` constant from \TYPO3\CMS\Core\Database\Connection by removing an unnecessary/wrong backslash character.

Edit: this could also be backported to v11 and v12 documentation.