### PR TITLE
[TASK] Add a warning note about `_assets` not containing symlinks

### DIFF
--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -163,6 +163,8 @@ directory :file:`_assets/`.
     :bash:`composer dumpautoload` and the :file:`Resources/Public/` folder for
     that extension is symlinked to :file:`_assets/`.
 
+..  todo:: This may be fixed/addressed with this issue: https://review.typo3.org/c/Packages/TYPO3.CMS/+/84383
+
 ..  warning::
     The :file:`_assets/` directory is not meant to be manually changed. Also, it
     is important for local development that all subdirectories are symlinks

--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -167,7 +167,7 @@ directory :file:`_assets/`.
 
 ..  warning::
     The :file:`_assets/` directory is not meant to be manually changed. Also, it
-    is important for local development that all subdirectories are symlinks
+    is important for local development that all its subdirectories are symlinks
     to the specific Composer packages. Do not synchronize this directory
     from a production instance back to your development instance (only the other
     way round). Thus, the whole :file:`_assets/` directory should always be removable and

--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -164,19 +164,19 @@ directory :file:`_assets/`.
     that extension is symlinked to :file:`_assets/`.
 
 ..  warning::
-    The :file:`_assets/` directory is not meant be manually changed. Also, it
+    The :file:`_assets/` directory is not meant to be manually changed. Also, it
     is important for local development that all subdirectories are symlinks
     to the specific Composer packages. Do not synchronize this directory
     from a production instance back to your development instance (only the other
     way round). Thus, the whole :file:`_assets/` directory should always be removable and
     can be re-created with proper contents via :bash:`composer dumpautoload`.
-    This will create symlinks for all installed Composer packages containing public
+    This will create symlinks for all installed TYPO3 Composer packages containing public
     assets.
 
     If the :file:`_assets/` directory would not contain symlinks, any Composer update
     would never refer to updated versions of any JavaScript and CSS assets
-    (including TYPO3 CMS Backend), leading to incompatible code
-    being loaded and causing errors in both Backend and Frontend.
+    (including TYPO3 backend system extension), leading to incompatible code
+    being loaded and causing errors in both backend and frontend.
 
 ..  seealso::
 

--- a/Documentation/ApiOverview/DirectoryStructure/Index.rst
+++ b/Documentation/ApiOverview/DirectoryStructure/Index.rst
@@ -163,6 +163,21 @@ directory :file:`_assets/`.
     :bash:`composer dumpautoload` and the :file:`Resources/Public/` folder for
     that extension is symlinked to :file:`_assets/`.
 
+..  warning::
+    The :file:`_assets/` directory is not meant be manually changed. Also, it
+    is important for local development that all subdirectories are symlinks
+    to the specific Composer packages. Do not synchronize this directory
+    from a production instance back to your development instance (only the other
+    way round). Thus, the whole :file:`_assets/` directory should always be removable and
+    can be re-created with proper contents via :bash:`composer dumpautoload`.
+    This will create symlinks for all installed Composer packages containing public
+    assets.
+
+    If the :file:`_assets/` directory would not contain symlinks, any Composer update
+    would never refer to updated versions of any JavaScript and CSS assets
+    (including TYPO3 CMS Backend), leading to incompatible code
+    being loaded and causing errors in both Backend and Frontend.
+
 ..  seealso::
 
     -   :ref:`<t3upgrade:migrate-public-assets>`


### PR DESCRIPTION
This came up in a debugging session. I don't really like that there is now a plethora of boxes (Note, Tip, Warning, See Also) in this section, but I couldn't come up with a better idea. Open to suggestions! :-)

Note - https://review.typo3.org/c/Packages/TYPO3.CMS/+/84383 is an issue dealing with improving this situation within the Core.

Releases: main, 12.4