### PR TITLE
Fix code example for ArrayPaginator

### DIFF
--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -43,8 +43,8 @@ Code example for the :php:`ArrayPaginator`:
    $paginator = new ArrayPaginator($itemsToBePaginated, $currentPageNumber, $itemsPerPage);
    $paginator->getNumberOfPages(); // returns 3
    $paginator->getCurrentPageNumber(); // returns 3, basically just returns the input value
-   $paginator->getKeyOfFirstPaginatedItem(); // returns 5
-   $paginator->getKeyOfLastPaginatedItem(); // returns 5
+   $paginator->getKeyOfFirstPaginatedItem(); // returns 4
+   $paginator->getKeyOfLastPaginatedItem(); // returns 4
 
    // use TYPO3\CMS\Core\Pagination\SimplePagination;
 


### PR DESCRIPTION
The given example divides the items in three pages with a maximum of two items each, leaving one item ("pineapple") for the last page. The example is showing page 3, hence getKeyOfFirstPaginatedItem() and getKeyOfLastPaginatedItem() both return the key of the item "pineapple", which is 4. (as the key of "apple is 0, and so on)