### PR TITLE
Fix utility class name used for debugging

### DIFF
--- a/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
@@ -132,7 +132,7 @@ Debug output
 ============
 
 During development it is allowed to use :php:`debug()` or
-:php:`DebugUtility::debug()` function calls to produce debug output.
+:php:`\TYPO3\CMS\Core\Utility\DebugUtility::debug()` function calls to produce debug output.
 However all debug statements must be removed (not only commented!)
 before pushing the code to the Git repository. Only very exceptionally
 is it allowed to even *think* of leaving a debug statement, if it is

--- a/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
@@ -132,7 +132,7 @@ Debug output
 ============
 
 During development it is allowed to use :php:`debug()` or
-:php:`GeneralUtility::debug()` function calls to produce debug output.
+:php:`DebugUtility::debug()` function calls to produce debug output.
 However all debug statements must be removed (not only commented!)
 before pushing the code to the Git repository. Only very exceptionally
 is it allowed to even *think* of leaving a debug statement, if it is


### PR DESCRIPTION
Probably a simple mixup, but the GeneralUtility doesn't have a debug() method. The DebugUtility does though.