### PR TITLE
[TASK] Update select field flexform example

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -189,16 +189,16 @@ Select field
             <renderType>selectSingle</renderType>
             <items>
                 <numIndex index="0">
-                    <numIndex index="label">
+                    <label>
                         LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.crdate
-                    </numIndex>
-                    <numIndex index="value">crdate</numIndex>
+                    </label>
+                    <value>crdate</value>
                 </numIndex>
                 <numIndex index="1">
-                    <numIndex index="label">
+                    <label>
                         LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.title
-                    </numIndex>
-                    <numIndex index="value">title</numIndex>
+                    </label>
+                    <value>title</value>
                 </numIndex>
             </items>
         </config>

--- a/Documentation/ApiOverview/FlexForms/T3datastructure/SheetReferences/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/T3datastructure/SheetReferences/Index.rst
@@ -52,10 +52,10 @@ Main Data Structure:
                         <type>check</type>
                         <items type="array">
                             <numIndex index="1" type="array">
-                                <numIndex index="0">
+                                <label>
                                     LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled
-                                </numIndex>
-                                <numIndex index="1">1</numIndex>
+                                </label>
+                                <value>1</value>
                             </numIndex>
                         </items>
                     </config>
@@ -69,10 +69,10 @@ Main Data Structure:
                         <type>check</type>
                         <items type="array">
                             <numIndex index="1" type="array">
-                                <numIndex index="0">
+                                <label>
                                     LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.enabled
-                                </numIndex>
-                                <numIndex index="1">1</numIndex>
+                                </label>
+                                <value>1</value>
                             </numIndex>
                         </items>
                     </config>


### PR DESCRIPTION
The deprecation RST suggest to migrate select field item data in FlexForm to `<label>` and `<value>` XML nodes. 
See https://review.typo3.org/c/Packages/TYPO3.CMS/+/77626/19/typo3/sysext/core/Documentation/Changelog/12.3/Deprecation-99739-IndexedArrayKeysForTCAItems.rst

The documentation should show  `<label>` and `<value>` for select items, since this is shorter and better to understand than the existing `<numIndex index="label">` notation.