### PR TITLE
Correct version changed for registering TypeConverter

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -28,7 +28,7 @@ You can find the type converters provided by Extbase in the directory
 Custom type converters
 ======================
 
-..  versionchanged:: 13.0
+..  versionchanged:: 12.0
     A type converter has to be registered in your extension's
     :file:`Configuration/Services.yaml` file. The previous registration method
     via :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerTypeConverter()`


### PR DESCRIPTION
Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-94117-RegisterExtbaseTypeConvertersAsServices.html
Releases: main, 12.4