### PR TITLE
[TASK] Note about automatic nonce inclusion for inline scripts/styles

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -159,7 +159,12 @@ or styles are blocked by the browser.
 
 The nonce is applied automatically, when scripts or styles are defined with the
 TYPO3 API, like TypoScript (:typoscript:`page.includeJS`, etc.) or the
-:ref:`asset collector <assets>`.
+:ref:`asset collector <assets>`. This only refers to referenced files
+(via :html:`src` and :html:`href` attributes) and not inline scripts
+or stylesheets. For those, you should either use the PHP/Fluid approach
+as listed below, or use TypoScript only for passing DOM attributes
+and using external scripts to actually evaluate these attributes to control
+functionality.
 
 TYPO3 provides APIs to get the nonce for the current request:
 
@@ -188,6 +193,7 @@ is available, which provides the nonce in a Fluid template, for example:
 ..  code-block:: html
 
     <script nonce="{f:security.nonce()}">const inline = 'script';</script>
+    <f:asset.script useNonce="1">console.log('Something');</f:asset.script>
 
 
 .. _content-security-policy-reporting:

--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -161,7 +161,7 @@ The nonce is applied automatically, when scripts or styles are defined with the
 TYPO3 API, like TypoScript (:typoscript:`page.includeJS`, etc.) or the
 :ref:`asset collector <assets>`. This only refers to referenced files
 (via :html:`src` and :html:`href` attributes) and not inline scripts
-or stylesheets. For those, you should either use the PHP/Fluid approach
+or inline styles. For those, you should either use the PHP/Fluid approach
 as listed below, or use TypoScript only for passing DOM attributes
 and using external scripts to actually evaluate these attributes to control
 functionality.


### PR DESCRIPTION
As noted in https://forge.typo3.org/issues/100771#note-8 the documentation is missing a hint, that automatic nonce values are only added to referenced files, not actual inline javascript/css usage.

This PR tries to rephrase this a bit and also hint at the `<f:asset.script useNonce="1">` possibility.