### PR TITLE
[TASK] Remove TYPO3_CONF_VARS removed with TYPO3 12

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -521,23 +521,8 @@ the TYPO3 backend:
         :ref:`Configuration/user.tsconfig <extension-configuration-user_tsconfig>`
         instead.
 
-    Contains the default user TSconfig.
-
-    This variable should not be changed directly but by the following API function.
-    This makes your code less likely to break in the future.
-
-    ..  code-block:: php
-        :caption: my_sitepackage/ext_localconf.php
-
-        /**
-        * Adding the default User TSconfig
-        */
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig('
-            @import 'EXT:my_sitepackage/Configuration/TsConfig/User/default.tsconfig'
-        ');
-
-    Read more about
-    :ref:`Setting default User TSconfig <t3tsconfig:usersettingdefaultusertsconfig>`.
+        See also
+        :ref:`Setting default User TSconfig <t3tsconfig:usersettingdefaultusertsconfig>`.
 
 ..  _typo3ConfVars_be_defaultPageTSconfig:
 
@@ -550,27 +535,7 @@ the TYPO3 backend:
         This setting will be ignored with TYPO3 v14.0.
         Use :ref:`Configuration/page.tsconfig <extension-configuration-page_tsconfig>` instead.
 
-    Contains the default page TSconfig.
-
-    Never set this configuration variable directly. Use the following methods instead:
-
-    ..  versionadded:: 12.0
-        TSconfig stored in a file :file:`EXT:my_sitepackage/Configuration/page.tsconfig`
-        will be automatically loaded before the content of
-        :php:`$TYPO3_CONF_VARS[SYS][defaultPageTSconfig]`.
-
-    Page TSconfig stored in files like
-    :file:`EXT:my_sitepackage/Configuration/page.tsconfig` are loaded before
-    :php:`$TYPO3_CONF_VARS[SYS][defaultPageTSconfig]`.
-    This is done during build-time and therefore more performant than the legacy way of
-    loading default Page Tsconfig during runtime by setting
-    :php:`$TYPO3_CONF_VARS[SYS][defaultPageTSconfig]` or the API function
-    :php:`ExtensionManagementUtility::addPageTSConfig`. It is therefore highly recommended
-    to migrate to using files like :file:`EXT:my_sitepackage/Configuration/page.tsconfig`
-    instead of setting this global variable.
-
-    Read more about
-    :ref:`Setting the Page TSconfig globally <t3tsconfig:pagesettingdefaultpagetsconfig>`.
+        See also :ref:`Setting the page TSconfig globally <t3tsconfig:pagesettingdefaultpagetsconfig>`.
 
 ..  _typo3ConfVars_be_defaultPermissions:
 
@@ -683,31 +648,6 @@ the TYPO3 backend:
     Have also a look into the :ref:`security guidelines
     <security-global-typo3-options-fileDenyPattern>`.
 
-..  _typo3ConfVars_be_interfaces:
-
-..  confval:: interfaces
-    :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['interfaces']
-    :name: globals-typo3-conf-vars-be-interfaces
-
-    ..  versionchanged:: 12.0
-        This option was removed with TYPO3 v12.0.
-
-    If a TYPO3 project really relies on this feature, create an
-    :ref:`XCLASS <xclasses>` of :php:`\TYPO3\CMS\Backend\Controller\LoginController`,
-    where also a custom Fluid template may be used.
-
-..  _typo3ConfVars_be_explicitADmode:
-
-..  confval:: explicitADmode
-    :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']
-    :name: globals-typo3-conf-vars-be-explicitADmode
-
-    ..  versionchanged:: 12.0
-        The handling of :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode']` has been changed and
-        is now set using :php:`explicitAllow`. Extensions should not assume this global array
-        key is set anymore as of TYPO3 Core v12. Extensions that need to stay compatible with v11
-        and v12 should instead use: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] ?? 'explicitAllow'`.
-
 ..  _typo3ConfVars_be_flexformForceCDATA:
 
 ..  confval:: flexformForceCDATA
@@ -749,28 +689,6 @@ the TYPO3 backend:
     mode. Furthermore the fieldname is appended to the label of fields. Use
     this to debug the backend only!
 
-..  _typo3ConfVars_be_toolbarItems:
-
-..  confval:: toolbarItems
-    :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']
-    :name: globals-typo3-conf-vars-be-toolbarItems
-
-    ..  versionchanged:: 12.0
-        This configuration variable has been removed in TYPO3 version 12.0. Setting
-        it has no effect.
-
-    Starting with version 12.0 toolbar items implementing
-    :php:`\TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface` are automatically
-    registered by adding the tag :yaml:`backend.toolbar.item`, if :yaml:`autoconfigure`
-    is enabled in :file:`Services.yaml`.
-
-    ..  rubric:: Migration
-
-    Remove :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']` from your
-    :file:`ext_localconf.php` file. If :yaml:`autoconfigure` is not enabled in
-    your :file:`Configuration/Services.(yaml|php)`, add the tag
-    :yaml:`backend.toolbar.item` to your toolbar item class.
-
 ..  _typo3ConfVars_be_HTTP:
 
 ..  confval:: HTTP
@@ -795,10 +713,6 @@ the TYPO3 backend:
                 ],
             ],
         ]
-
-    ..  versionchanged:: 12.3
-        The options :php:`strictTransportSecurity`, :php:`avoidMimeTypeSniffing`
-        and :php:`referrerPolicy` were added.
 
     ..  note::
         The `Strict-Transport-Security` is only active, if the option
@@ -851,8 +765,6 @@ the TYPO3 backend:
     :type: string
     :Default: default
 
-    ..  versionadded:: 12.0
-
     Defines the :ref:`password policy <password-policies>` in backend context.
 
 ..  _typo3ConfVars_be_stylesheets:
@@ -862,8 +774,6 @@ the TYPO3 backend:
     :name: globals-typo3-conf-vars-be-stylesheets
     :type: string
     :Default: default
-
-    ..  versionadded:: 12.3
 
     Load additional CSS files for the TYPO3 backend interface. This setting
     can be set per site or within an extension's :file:`ext_localconf.php`.
@@ -891,8 +801,6 @@ the TYPO3 backend:
     :name: globals-typo3-conf-vars-be-contentSecurityPolicyReportingUrl
     :type: string
     :Default: ''
-
-    ..  versionadded:: 12.3
 
     Configure the reporting HTTP endpoint of
     :ref:`Content Security Policy <content-security-policy>` violations in the

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -621,34 +621,6 @@ the TYPO3 frontend:
     :file:`EXT:core/Classes/TypoScript/IncludeTree/TreeBuilder.php`
 
 ..  index::
-    TYPO3_CONF_VARS FE; ContentObjects
-..  _typo3ConfVars_fe_ContentObjects:
-
-..  confval:: ContentObjects
-    :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']
-    :name: typo3-conf-vars-fe-ContentObjects
-    :type: array
-
-    ..  versionchanged:: 12.0
-        The global variable `$GLOBALS['TYPO3_CONF_VARS']['FE']['ContentObjects']` has
-        no effect anymore in TYPO3 v12.0 and above. It can be defined to achieve
-        backward compatibility with TYPO3 version 11 and below.
-
-    TypoScript content objects (`cObject`) like :typoscript:`TEXT` or
-    :typoscript:`HMENU` are registered as services:
-
-    ..  code-block:: yaml
-        :caption: EXT:my_extension/Configuration/Services.yaml
-
-        services:
-           # ...
-           MyCompany\MyPackage\ContentObject\CustomContentObject:
-             tags:
-               - name: frontend.contentobject
-                 identifier: 'MY_OBJ'
-
-
-..  index::
     TYPO3_CONF_VARS FE; typolinkBuilder
 ..  _typo3ConfVars_fe_typolinkBuilder:
 
@@ -723,11 +695,7 @@ the TYPO3 frontend:
 ..  _typo3ConfVars_fe_passwordPolicy:
 
 ..  confval:: passwordPolicy
-
-
-..  versionadded:: 12.0
-
-..  confval:: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordPolicy']
+    :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordPolicy']
     :name: typo3-conf-vars-fe-passwordPolicy
     :type: string
     :Default: default
@@ -759,8 +727,6 @@ the TYPO3 frontend:
     :name: typo3-conf-vars-fe-contentSecurityPolicyReportingUrl
     :type: string
     :Default: ''
-
-    ..  versionadded:: 12.3
 
     Configure the reporting HTTP endpoint of
     :ref:`Content Security Policy <content-security-policy>` violations in the

--- a/Documentation/Configuration/Typo3ConfVars/Index.rst
+++ b/Documentation/Configuration/Typo3ConfVars/Index.rst
@@ -58,8 +58,6 @@ This file overrides default settings from
 :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`.
 
 ..  note::
-    ..  versionchanged:: 12.1
-
     The :file:`settings.php` file can be read-only. In this case, the
     sections in the Install Tool that would write to this file inform a
     system maintainer that it is write-protected. All input fields are disabled

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -83,11 +83,6 @@ configurations.
    :type: text
    :Default: 'http'
 
-    ..  versionadded:: 12.0
-       The setting :php:`defaultScheme` was added in TYPO3 v12 to make it possible to
-       configure the default URI scheme when links are created by the Core.
-       Previously, :php:`'http'` was always used.
-
    Set the default URI scheme. This is used within links if no scheme is given.
    One can set this to :php:`'https'` if this should be used by default.
 
@@ -318,11 +313,6 @@ configurations.
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']
     :type: bool
     :Default: true
-
-    ..  versionchanged:: 12.0
-        Before TYPO3 v12 the default value for new installations was always set to :php:`false`.
-        However, because almost every file system now supports UTF-8 the new default value
-        is set to :php:`true`.
 
     If set to :php:`true`, then TYPO3 uses UTF-8 to store file names. This allows for accented
     latin letters as well as any other non-latin characters like Cyrillic and
@@ -659,8 +649,6 @@ configurations.
 
     ..  _typo3ConfVars_sys_features_security.frontend.enforceContentSecurityPolicy:
 
-    ..  versionadded:: 12.3
-
     ..  confval:: security.frontend.enforceContentSecurityPolicy
         :name: globals-typo3-conf-vars-sys-features-security-frontend-enforceContentSecurityPolicy
         :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.frontend.enforceContentSecurityPolicy']
@@ -671,8 +659,6 @@ configurations.
         is applied in frontend scope.
 
     ..  _typo3ConfVars_sys_features_security.frontend.allowInsecureSiteResolutionByQueryParameters:
-
-    ..  versionadded:: 12.4.4/11.5.30
 
     ..  confval:: security.frontend.allowInsecureSiteResolutionByQueryParameters
         :name: globals-typo3-conf-vars-sys-features-security-frontend-allowInsecureSiteResolutionByQueryParameters
@@ -763,11 +749,6 @@ configurations.
         :type: bool
         :Default: true
 
-        ..  versionadded:: 12.0
-            Before TYPO3 v12.0 all translations are taken into account when parsing XLF
-            files. As of TYPO3 v12.0, only approved translations are available by
-            default.
-
         The attribute :xml:`approved` of the :ref:`XLIFF <xliff>` standard is
         respected by TYPO3 since version 12.0 when parsing XLF files. This attribute
         can either have the value :xml:`yes` or :xml:`no` and indicates whether the
@@ -798,8 +779,6 @@ configurations.
     :name: globals-typo3-conf-vars-sys-passwordPolicies
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['passwordPolicies']
     :type: array
-
-    ..  versionadded:: 12.0
 
     Defines the available :ref:`password policies <password-policies>`. Each
     policy must have a unique identifier (the identifier `default` is reserved
@@ -841,8 +820,6 @@ configurations.
         :name: globals-typo3-conf-vars-sys-messenger-routing
         :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['messenger']['routing']
         :type: array
-
-        ..  versionadded:: 12.2
 
         The configuration of the routing for the
         :ref:`messenger component <message-bus>`. By default, TYPO3 uses a


### PR DESCRIPTION
* Remove versionadded hints for new TYPO3_CONF_VARS in TYPO3 v12