### PR TITLE
Update LanguageService.rst - fix typo

### DIFF
--- a/Documentation/ApiOverview/Localization/LocalizationApi/LanguageService.rst
+++ b/Documentation/ApiOverview/Localization/LocalizationApi/LanguageService.rst
@@ -22,7 +22,7 @@ In the frontend a :php:`LanguageService` can be accessed via the contentObject:
     use TYPO3\CMS\Core\Utility\GeneralUtility;
 
     class ExampleController {
-        proteced ServerRequestInterface $request;
+        protected ServerRequestInterface $request;
 
         public function __construct (
             private readonly LanguageServiceFactory $LanguageServiceFactory,


### PR DESCRIPTION
In the example code the was an missing "t" in "protected".