### PR TITLE
[TASK] User composer names instead of extension keys

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -225,7 +225,7 @@ In the Fluid template the column positions can be accessed now via content mappi
 Reference implementations of backend layouts
 ============================================
 
-The extension :t3ext:`bootstrap_package` ships several
+The extension :composer:`bk2k/bootstrap-package` ships several
 `Backend layouts <https://github.com/benjaminkott/bootstrap_package/tree/1b00a01e362d2460af92f754ee10e507edb70568/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts>`__
 as well as an example configuration of how to include frontend templates for backend layouts (see its
 `setup.typoscript <https://github.com/benjaminkott/bootstrap_package/blob/1b00a01e362d2460af92f754ee10e507edb70568/Configuration/TypoScript/setup.typoscript#L99-L113>`__)
@@ -238,8 +238,8 @@ Extensions for backend layouts
 
 In many cases besides defining fixed backend layouts a more modular approach with the possibility of combining different
 backend layouts and frontend layouts may be feasible. The extension
-:t3ext:`container`
+:composer:`b13/container`
 integrates the grid layout concept also to regular content elements.
 
-The extension :t3ext:`content_defender` offers advanced options to
+The extension :composer:`ichhabrecht/content-defender` offers advanced options to
 the column positions i.e. allowed or disallowed content elements, a maximal number of content elements.

--- a/Documentation/ApiOverview/Backend/BackendModules/_AboutBlogExample.rst.txt
+++ b/Documentation/ApiOverview/Backend/BackendModules/_AboutBlogExample.rst.txt
@@ -1,3 +1,3 @@
 The following example is extracted from the example Extbase extension
-:t3ext:`blog_example`. See the complete source code at
+:composer:`t3docs/blog-example`. See the complete source code at
 `t3doc/blog-example (GitHub) <https://github.com/TYPO3-Documentation/blog_example>`__.

--- a/Documentation/ApiOverview/CommandControllers/ListCommands.rst
+++ b/Documentation/ApiOverview/CommandControllers/ListCommands.rst
@@ -15,7 +15,7 @@ on which system extensions are installed.
 Third party extensions can define :ref:`custom console
 commands <console-command-tutorial>`.
 
-The extension :t3ext:`typo3_console` ships many commands to execute TYPO3
+The extension :composer:`helhum/typo3-console` ships many commands to execute TYPO3
 actions, which otherwise would only be accessible via the TYPO3 backend.
 
 This page assumes that the code is run on a Composer based installation with

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -32,7 +32,7 @@ as is done for example in the *table* content element with the field `bodytext`.
 In these cases Fluid does not have to deal with these manipulations or transformation.
 
 You can find the example below in the TYPO3 Documentation Team extension
-:t3ext:`examples`.
+:composer:`t3docs/examples`.
 
 
 Prerequisites
@@ -240,7 +240,7 @@ Extended example: Extend tt_content and use data processing
 ===========================================================
 
 You can find the complete example in the  TYPO3 Documentation Team extension
-:t3ext:`examples`. The steps for
+:composer:`t3docs/examples`. The steps for
 creating a simple new content element as above need to be repeated. We use the
 key *examples_newcontentcsv* in this example.
 

--- a/Documentation/ApiOverview/ContentElements/CustomDataProcessing.rst
+++ b/Documentation/ApiOverview/ContentElements/CustomDataProcessing.rst
@@ -14,7 +14,7 @@ define a custom data processor by implementing
 :php:`\TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface`.
 
 You can find the example below in the TYPO3 Documentation Team extension
-:t3ext:`examples`.
+:composer:`t3docs/examples`.
 
 
 ..  index::

--- a/Documentation/ApiOverview/Fal/Administration/Permissions.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Permissions.rst
@@ -224,7 +224,7 @@ permissions are not enforced in any way by the TYPO3 Core. It is up to extension
 developers to create tools which make use of these permissions.
 
 As an example, you may want to take a look at extension
-:t3ext:`fal_securedownload`
+:composer:`beechit/fal-securedownload`
 which also makes use of the "Is publicly available?" property of
 :ref:`File storages <fal-administration-storages>`.
 

--- a/Documentation/ApiOverview/FlexForms/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Index.rst
@@ -115,7 +115,7 @@ Steps to perform (extension developer)
         );
 
 
-    If you are using a content element with a custom CType (recommend, both with and without 
+    If you are using a content element with a custom CType (recommend, both with and without
     Extbase), the example
     looks like this:
 
@@ -552,8 +552,8 @@ Credits
 =======
 
 Some of the examples were taken from the extensions
-:t3ext:`news` (by Georg Ringer)
-and :t3ext:`bootstrap_package`
+:composer:`georgringer/news` (by Georg Ringer)
+and :composer:`bk2k/bootstrap-package`
 (by Benjamin Kott).
 
 Further enhancements by the TYPO3 community are welcome!

--- a/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
@@ -205,7 +205,7 @@ Example
 =======
 
 Below is the structure of a basic FlexForm from the example extension
-:t3ext:`styleguide`:
+:composer:`typo3/cms-styleguide`:
 
 ..  include:: /CodeSnippets/FlexForms/Simple.rst.txt
 

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -52,7 +52,8 @@ The TYPO3 Core ships two icon providers which can be used straight away:
 ..  versionchanged:: 12.0
     The :php:`\TYPO3\CMS\Core\Imaging\IconProvider\FontawesomeIconProvider`
     was removed from the Core in 12.0. You can use the polyfill extension from
-    :t3ext:`fontawesome_provider` which is also compatible with TYPO3 v11 LTS.
+    :composer:`friendsoftypo3/fontawesome-provider` which is also compatible
+    with TYPO3 v11 LTS.
 
 If you need a custom icon provider, you can add your own by writing a
 class which implements the

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -266,7 +266,7 @@ Examples
 ========
 
 Examples of the usage of the logger can be found in the extension
-:t3ext:`examples`. in file
+:composer:`t3docs/examples`. in file
 :file:`/Classes/Controller/ModuleController.php`
 
 

--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -53,7 +53,7 @@ The following option is available:
         that module.
 
     ..  tip::
-        There is the third-party extension :t3ext:`logs` available for viewing
+        There is the third-party extension :composer:`co-stack/logs` available for viewing
         such records in the TYPO3 backend.
 
     Example of a :sql:`CREATE TABLE` statement for :php:`logTable`:
@@ -286,4 +286,4 @@ Examples
 ========
 
 Working examples of the usage of different Log writers can be found in the
-extension :t3ext:`examples`.
+extension :composer:`t3docs/examples`.

--- a/Documentation/ApiOverview/PasswordPolicies/Index.rst
+++ b/Documentation/ApiOverview/PasswordPolicies/Index.rst
@@ -193,7 +193,7 @@ Please refer to :php:`\TYPO3\CMS\Core\PasswordPolicy\Validator\CorePasswordValid
 for a detailed implementation example.
 
 ..  tip::
-    The third-party extension :t3ext:`add_pwd_policy` provides additional
+    The third-party extension :composer:`derhansen/add_pwd_policy` provides additional
     password validators. It can also be used as a resource for writing your
     own password validator.
 

--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -183,7 +183,7 @@ The configuration looks like this:
 :yaml:`routePath` defines the static keyword and the placeholders.
 
 ..  note::
-    For people coming from :t3ext:`realurl` in previous TYPO3 versions: The
+    For people coming from :composer:`dmitryd/typo3-realurl` in previous TYPO3 versions: The
     :yaml:`routePath` can be loosely compared to some as "postVarSets".
 
 .. index:: Routing; Plugin Enhancer

--- a/Documentation/ApiOverview/Seo/PageTitleApi.rst
+++ b/Documentation/ApiOverview/Seo/PageTitleApi.rst
@@ -103,7 +103,7 @@ the providers later in the order are ignored.
 
 Therefore our custom provider should be loaded before `record`, the
 default provider which always returns a value. If the system extension
-:t3ext:`seo` is loaded the default :guilabel:`SEO Title` has a particular format,
+:composer:`typo3/cms-seo` is loaded the default :guilabel:`SEO Title` has a particular format,
 you can change this by loading your custom provider before `seo`.
 
 .. index:: PageTitle; Priority

--- a/Documentation/ApiOverview/SiteHandling/SiteSets.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSets.rst
@@ -301,7 +301,6 @@ Example: Using a set within a site package
 ==========================================
 
 You can see an example of using a sets within a site package in the extension
-:t3ext:`site-package`,
 `t3docs/site-package (Source on GitHub) <https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage-Code>`__.
 
 The site package example extension has the following file structure:
@@ -396,7 +395,7 @@ Example: Providing a site set in an extension
 Non site-package extensions can also provide site sets. These can be used by
 sites or site sets to include dependant TypoScript and settings.
 
-The example extension :t3ext:`blog_example` offers one main site set and several
+The example extension :composer:`t3docs/blog-example` offers one main site set and several
 site sets for special use-cases. It has the following file structure:
 
 ..  directory-tree::

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -88,7 +88,7 @@ The syntax is as follows and is commonly located in an extension's
 
 In this example, we declare that the :code:`\TYPO3\CMS\Backend\Controller\NewRecordController` class
 will be overridden by the :code:`\T3docs\Examples\Xclass\NewRecordController`
-class, the latter being part of the :t3ext:`examples` extension.
+class, the latter being part of the :composer:`t3docs/examples` extension.
 
 When XCLASSing a class that does not use namespaces, use that class name
 in the declaration.

--- a/Documentation/ExtensionArchitecture/Extbase/Examples/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Examples/Index.rst
@@ -17,7 +17,7 @@ Example extensions
 Tea example
 -----------
 
-The extension :t3ext:`tea`, is based on Extbase and Fluid. The
+The extension :composer:`ttn/tea`, is based on Extbase and Fluid. The
 extension features a range of best practices in relation to automated code checks,
 unit/functional/acceptance testing and continuous integration.
 
@@ -26,11 +26,11 @@ You can also use this extension to manage your collection of delicious teas.
 Blog example
 ------------
 
-The extension :t3ext:`blog_example` contains working examples of all the features documented in the :ref:`Extbase Reference <extbase_reference>` manual.
+The extension :composer:`t3docs/blog-example` contains working examples of all the features documented in the :ref:`Extbase Reference <extbase_reference>` manual.
 
 This extension should not be used as a base for building your own extension or used to blog in a live environment.
 
-If you want to set up a blog, take a look at the :t3ext:`blog` extension or combine :t3ext:`news` with a comment extension of your choice.
+If you want to set up a blog, take a look at the :composer:`t3docs/blog-example` extension or combine :composer:`georgringer/news` with a comment extension of your choice.
 
 Real-world examples
 ===================
@@ -38,12 +38,12 @@ Real-world examples
 Backend user module
 -------------------
 
-In the TYPO3 Core, the system extension :t3ext:`beuser` has backend modules
+In the TYPO3 Core, the system extension :composer:`typo3/cms-beuser` has backend modules
 based on Extbase. It can therefore be used as a guide on how to develop
 backend modules with Extbase.
 
 News
 ----
 
-:t3ext:`news` implements a versatile news system based on Extbase & Fluid
+:composer:`georgringer/news` implements a versatile news system based on Extbase & Fluid
 and uses the latest technologies provided by the Core.

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model.rst
@@ -447,7 +447,7 @@ the :php:`uid` of the translated record is kept in the :php:`_localizedUid`.
 +----------------------------------------------------------+-------------------------+---------------------------+
 
 ..  hint::
-    In case your project uses :t3ext:`workspaces` there is yet another
+    In case your project uses :composer:`typo3/cms-workspaces` there is yet another
     additional property, :php:`_versionedUid`. Refer to the
     :doc:`Workspaces documentation <ext_workspaces:Index>` for details on
     workspace overlays.

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Repository.rst
@@ -68,7 +68,7 @@ Custom find methods can be implemented. They can be used for complex queries.
 
 **Example:**
 
-The :php:`PostRepository` of the :t3ext:`blog` example extension implements
+The :php:`PostRepository` of the :composer:`t3docs/blog-example` example extension implements
 several custom find methods, two of them are shown below:
 
 ..  include:: /CodeSnippets/Extbase/Domain/CustomMethods.rst.txt

--- a/Documentation/ExtensionArchitecture/FileStructure/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Index.rst
@@ -163,7 +163,7 @@ stick to this and the other Coding Guidelines, the system helps in various ways.
 PHP classes into the :file:`Classes/` folder and using appropriate namespaces for the classes,
 the system will be able to autoload these files.
 
-Extension kickstarters like the :t3ext:`extension_builder`
+Extension kickstarters like the :composer:`friendsoftypo3/extension-builder`
 will create the correct structure for you.
 
 .. toctree::

--- a/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/CreateNewDistribution.rst
@@ -16,7 +16,7 @@ Concept of distributions
 
 The distributions are full TYPO3 CMS websites that only need to be unpacked.
 They offer a simple and quick introduction to the use of the TYPO3 CMS. The
-best known distribution is the :t3ext:`introduction`.
+best known distribution is the :composer:`typo3/cms-introduction`.
 Distributions are easiest to install via the :ref:`Extension Manager <extension-manager>` (EM)
 under "Get preconfigured distribution".
 
@@ -98,7 +98,7 @@ Note that you should *not* put your website configuration
 (TypoScript files, JavaScript, CSS, logos, etc.) in :file:`fileadmin/`,
 which is intended for editors only, but in a separate extension.
 In the case of the Introduction Package, the configuration is located in the
-:t3ext:`bootstrap_package`
+:composer:`bk2k/bootstrap-package`
 extension, and the Introduction Package depends on it. In this way,
 the Introduction Package provides only the database dump and asset files which
 results in only content-related files being in :file:`fileadmin/`,

--- a/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
@@ -48,6 +48,6 @@ from scratch, the TYPO3 community provides tools to support you:
 
 -  A `Sample Manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`_
    is available to be immediately copied into your own extension.
--  The :t3ext:`extension_builder`
+-  The :composer:`friendsoftypo3/extension-builder`
    optionally generates a documentation skeleton together with the extension
    skeleton.

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
@@ -64,7 +64,7 @@ as original model.
 If the model has different :ref:`Record types <extbase-persistance-record-types>`
 you can decide to introduce a new type and
 only extend that one type. This is, for example, commonly done when extending
-the model of :t3ext:`news`.
+the model of :composer:`georgringer/news`.
 
 If you are planning to publish your extension that extends another extensions
 model, research on `Packagist <https://packagist.org/>`__ and the

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Index.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Index.rst
@@ -11,7 +11,7 @@
 Tea in a nutshell
 =================
 
-The example extension :t3ext:`tea` was created as an example of best practises
+The example extension :composer:`ttn/tea` was created as an example of best practises
 on automatic code checks.
 
 ..  hint::

--- a/Documentation/Testing/UnitTesting/Running.rst
+++ b/Documentation/Testing/UnitTesting/Running.rst
@@ -111,8 +111,8 @@ GitHub Actions or Gitlab CI.
 Run the unit tests with runTests.sh
 ===================================
 
-If you are using a :file:`runTests.sh` like the one used by the :t3ext:`blog_example`
-you can run the tests with:
+If you are using a :file:`runTests.sh` like the one used by the
+:composer:`t3docs/blog-example` you can run the tests with:
 
 ..  code-block:: bash
 


### PR DESCRIPTION
This makes it easier for Composer users to install the extension.

Releases: main, 12.4