### PR TITLE
[BUGFIX] Use proper #[Cascade(['value' => ''])] annotation

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Cascade.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Cascade.php
@@ -13,7 +13,7 @@ final class Blog extends AbstractEntity
     /**
      * @var ObjectStorage<Post>
      */
-    #[Cascade('remove')]
+    #[Cascade(['value' => 'remove'])]
     public $posts;
 
     /**

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Multiple.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_Multiple.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 class Post extends AbstractEntity
 {
     #[Lazy()]
-    #[Cascade('remove')]
+    #[Cascade(['value' => 'remove'])]
     /**
      * @var ObjectStorage<Comment>
      */


### PR DESCRIPTION
The annotation is currently improperly descriped. The right notation can be seen here:

https://forge.typo3.org/issues/96688

EXT:blog_example also makes correct use of the notation. I did not find other places for "#[Cascade".