### PR TITLE
Use LanguageServiceFactory instead of global LANG

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Php.rst
@@ -58,8 +58,9 @@ custom non-Extbase controllers, user functions, data processors etc.
 Localization in backend context
 -------------------------------
 
-In the backend context you can use the global variable :php:`$GLOBALS['LANG']`
-which contains the :ref:`LanguageService <LanguageService-api>`.
+In the backend context you should use the
+:ref:`LanguageServiceFactory <LanguageServiceFactory-api>`
+to create the required :ref:`LanguageService <LanguageService-api>`.
 
 ..  literalinclude:: _php/MyBackendClass.php
     :caption: EXT:my_extension/Classes/Backend/MyBackendClass.php

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_php/MyBackendClass.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Backend;
 
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 
 final class MyBackendClass
 {
+    private LanguageServiceFactory $languageServiceFactory;
+
+    public function __construct(LanguageServiceFactory $languageServiceFactory)
+    {
+        $this->languageServiceFactory = $languageServiceFactory;
+    }
+
     private function translateSomething(string $input): string
     {
         return $this->getLanguageService()->sL($input);
@@ -15,7 +24,13 @@ final class MyBackendClass
 
     private function getLanguageService(): LanguageService
     {
-        return $GLOBALS['LANG'];
+        return $this->languageServiceFactory
+            ->createFromUserPreferences($this->getBackendUserAuthentication());
+    }
+
+    private function getBackendUserAuthentication(): BackendUserAuthentication
+    {
+        return $GLOBALS['BE_USER'];
     }
 
     // ...


### PR DESCRIPTION
I have used constructor argument injection, so we can backport that issue to TYPO3 11 hopefully easy. If not, please remove that label from PR.
I have kept the attention note below, because it is still valid.