### PR TITLE
[TASK] Deprecate GeneralUtility::hmac()

### DIFF
--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -258,7 +258,7 @@ in your code.
 
 ..  versionchanged:: 13.1
     Until TYPO3 13 generating the Hash-based Message Authentication Codes (HMACs)
-    was done via :php:`GeneralUtility::hmac()` this has been deprecated with
+    was done via :php:`GeneralUtility::hmac()`; this has been deprecated with
     TYPO3 13.1 in favour of using the `\TYPO3\CMS\Core\Crypto\HashService::hmac`.
 
 See the following example on how to create a URI using the

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -256,6 +256,11 @@ The PHP class responsible for handling the file dumping is the
 :php:`\TYPO3\CMS\Core\Controller\FileDumpController`, which you may also use
 in your code.
 
+..  versionchanged:: 13.1
+    Until TYPO3 13 generating the Hash-based Message Authentication Codes (HMACs)
+    was done via :php:`GeneralUtility::hmac()` this has been deprecated with
+    TYPO3 13.1 in favour of using the `\TYPO3\CMS\Core\Crypto\HashService::hmac`.
+
 See the following example on how to create a URI using the
 :php:`FileDumpController` for a :sql:`sys_file` record with a fixed image size:
 

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid1.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid1.php
@@ -6,17 +6,23 @@ namespace MyVendor\MyExtension\Service;
 
 use MyVendor\MyExtension\Domain\Model\SomeModel;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 class SomeClass
 {
+    public function __construct(private readonly HashService $hashService) {}
+
     public function getPublicUrl(SomeModel $resourceObject): string
     {
         $queryParameterArray = ['eID' => 'dumpFile', 't' => 'f'];
         $queryParameterArray['f'] = $resourceObject->getUid();
         $queryParameterArray['s'] = '320c:280c';
-        $queryParameterArray['token'] = GeneralUtility::hmac(implode('|', $queryParameterArray), 'resourceStorageDumpFile');
+        $queryParameterArray['token'] = $this->hashService->hmac(
+            implode('|', $queryParameterArray),
+            'resourceStorageDumpFile',
+        );
         $publicUrl = GeneralUtility::locationHeaderUrl(PathUtility::getAbsoluteWebPath(Environment::getPublicPath() . '/index.php'));
         $publicUrl .= '?' . http_build_query($queryParameterArray, '', '&', PHP_QUERY_RFC3986);
         return $publicUrl;

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid2.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid2.php
@@ -6,18 +6,23 @@ namespace MyVendor\MyExtension\Service;
 
 use MyVendor\MyExtension\Domain\Model\SomeModel;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 class SomeClass
 {
+    public function __construct(private readonly HashService $hashService) {}
     public function getPublicUrl(SomeModel $resourceObject): string
     {
         $queryParameterArray = ['eID' => 'dumpFile', 't' => 'r'];
         $queryParameterArray['f'] = $resourceObject->getUid();
         $queryParameterArray['s'] = '320c:280c:320:280:320:280';
         $queryParameterArray['cv'] = 'default';
-        $queryParameterArray['token'] = GeneralUtility::hmac(implode('|', $queryParameterArray), 'resourceStorageDumpFile');
+        $queryParameterArray['token'] = $this->hashService->hmac(
+            implode('|', $queryParameterArray),
+            'resourceStorageDumpFile',
+        );
         $publicUrl = GeneralUtility::locationHeaderUrl(PathUtility::getAbsoluteWebPath(Environment::getPublicPath() . '/index.php'));
         $publicUrl .= '?' . http_build_query($queryParameterArray, '', '&', PHP_QUERY_RFC3986);
         return $publicUrl;

--- a/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid3.php
+++ b/Documentation/ApiOverview/Fal/UsingFal/_ExamplesFileFolder/_SomeFileEid3.php
@@ -6,16 +6,21 @@ namespace MyVendor\MyExtension\Service;
 
 use MyVendor\MyExtension\Domain\Model\SomeModel;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Crypto\HashService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
 class SomeClass
 {
+    public function __construct(private readonly HashService $hashService) {}
     public function getPublicUrl(SomeModel $resourceObject): string
     {
         $queryParameterArray = ['eID' => 'dumpFile', 't' => 'p'];
         $queryParameterArray['p'] = $resourceObject->getUid();
-        $queryParameterArray['token'] = GeneralUtility::hmac(implode('|', $queryParameterArray), 'resourceStorageDumpFile');
+        $queryParameterArray['token'] = $this->hashService->hmac(
+            implode('|', $queryParameterArray),
+            'resourceStorageDumpFile',
+        );
         $publicUrl = GeneralUtility::locationHeaderUrl(PathUtility::getAbsoluteWebPath(Environment::getPublicPath() . '/index.php'));
         $publicUrl .= '?' . http_build_query($queryParameterArray, '', '&', PHP_QUERY_RFC3986);
         return $publicUrl;


### PR DESCRIPTION
This is the only mentioning of GeneralUtility::hmac
resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/882
releases: main