### PR TITLE
[TASK] Add example on domain model object type convertion

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -56,3 +56,21 @@ The registration and configuration of a type converter is done in the extension'
             priority: 10
             target: \DateTime
             sources: int,string
+
+.. note::
+   For convertions of Extbase controller action parameters into Extbase domain
+   model objects the incoming data is usually a numeric but in case of an update
+   action it might as well be an array containing its ID as property `__identifier`.
+
+   Thus the configuration should list :php:`array` as one of its sources:
+
+   ..  code-block:: yaml
+       :caption: EXT:my_extension/Configuration/Services.yaml
+
+       services:
+         MyVendor\MyExtension\Property\TypeConverter\MyCustomModelObjectConverter:
+           tags:
+             - name: extbase.type_converter
+               priority: 10
+               target: MyVendor\MyExtension\Domain\Model\MyCustomModel
+               sources: int,string,array

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -58,8 +58,8 @@ The registration and configuration of a type converter is done in the extension'
             sources: int,string
 
 .. note::
-   For convertions of Extbase controller action parameters into Extbase domain
-   model objects the incoming data is usually a numeric but in case of an update
+   For conversions of Extbase controller action parameters into Extbase domain
+   model objects the incoming data is usually a numeric type, but in case of an update
    action it might as well be an array containing its ID as property `__identifier`.
 
    Thus the configuration should list :php:`array` as one of its sources:


### PR DESCRIPTION
It took me quite some time to figure out that my TYPO3 12 registration of the type converter was simply missing "array" as source property. So I've added a little section on that matter to the docs.

This was the origin of the payload to the action controller:
```
<f:form action="update" name="isPost" object="{myObject}" objectName="myObject" class="form">
    <f:form.textarea rows="5" property="comment" />
    <f:form.submit name="submit" class="btn btn-success" value="Update my hidden object" />
</f:form>
```