### PR TITLE
[TASK] Add docs for database error "row size too large"

### DIFF
--- a/Documentation/ApiOverview/Database/Index.rst
+++ b/Documentation/ApiOverview/Database/Index.rst
@@ -26,3 +26,4 @@ Database (Doctrine DBAL)
    Statement/Index
    Middleware/Index
    TipsAndTricks/Index
+   Troubleshooting/Index

--- a/Documentation/ApiOverview/Database/Troubleshooting/Index.rst
+++ b/Documentation/ApiOverview/Database/Troubleshooting/Index.rst
@@ -1,0 +1,16 @@
+..  include:: /Includes.rst.txt
+
+..  _database-troubleshooting:
+
+===============
+Troubleshooting
+===============
+
+About database error "Row size too large"
+=========================================
+
+MySQL and MariaDB can generate a "Row size too large" error when modifying
+tables with numerous columns. TYPO3 version 13 has implemented measures
+to mitigate this issue in most scenarios. We refer to the changelog:
+:ref:`Important: #104153 - About database error
+"Row size too large" <changelog:important-104153-1718790066>`.


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/949 
Releases: main