### PR TITLE
Update BlogControllerNew.rst.txt

### DIFF
--- a/Documentation/CodeSnippets/Extbase/Controllers/BlogControllerNew.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Controllers/BlogControllerNew.rst.txt
@@ -6,8 +6,9 @@
 
     use Psr\Http\Message\ResponseInterface;
     use T3docs\BlogExample\Domain\Model\Blog;
+    use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
-    class BlogController extends AbstractController
+    class BlogController extends ActionController
     {
         /**
          * Displays a form for creating a new blog


### PR DESCRIPTION
AbstractController has no $this->htmlResponse(). ActionController is right here (as mentioned in the text above)

> Most Extbase controllers are based on the \TYPO3\CMS\Extbase\Mvc\Controller\ActionController 