### PR TITLE
add crosslink for locallang file reference

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
@@ -122,7 +122,7 @@ Module configuration options
 
         The value of each array entry can either be a `string` containing the static text, or a locallang label reference.
        
-        Alternatively define the path of a locallang file reference.
+        Alternatively define the path of a :ref:`locallang file reference <t3coreapi:xliff-files>`.
         A referenced file should contain the following label keys:
 
         *   `mlang_tabs_tab` (used as module title)


### PR DESCRIPTION
Help the user to find the needed string format.