### PR TITLE
[BUGFIX] Fix documentation about custom page type icon

### DIFF
--- a/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
+++ b/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
@@ -57,8 +57,8 @@ you can utilize :php:`typeicon_classes`.
 
 It is possible to define additional type icons for special case pages:
 
-*   Page contains content from another page `<doktype>-mountpoint`,
-    For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-mountpoint']`.
+*   Page contains content from another page `<doktype>-contentFromPid`,
+    For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-contentFromPid']`.
 *   Page is hidden in navigation `<doktype>-hideinmenu`
     For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-hideinmenu']`.
 *   Page is the root of the site `<doktype>-root`


### PR DESCRIPTION
The identifier should be contentFromPid instead of mountpoint.

The docs from 11.5 are still correct.

Releases: main, 12.4
Related: 59bc5475b518dd07c5a8af98764d3a4c3d711482