### PR TITLE
Add notice about `strict_types=1` in `ext_emconf.php` (#4668)

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
@@ -66,7 +66,8 @@ Example:
 
 ..  attention::
     Due to limitations of the TER (`TYPO3 Extension Repository <https://extensions.typo3.org>`__),
-    `$_EXTKEY` should be used here and **not** a constant or a string.
+    `$_EXTKEY` should be used here and **not** a constant or a string. Furthermore, the 
+    `ext_emconf.php` must not declare `strict_types=1`, otherwise TER upload will fail.
 
 
 ..  t3-field-list-table::


### PR DESCRIPTION
Preport for https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/4668