### PR TITLE
[TASK] Improve search results for IsContentUsedOnPageLayoutEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -20,7 +20,7 @@ setting it to false displays it:
 
 ..  warning::
     **Unused elements detected on this page**
-    These elements don't belong to any of the available columns of this page. You should either delete 
+    These elements don't belong to any of the available columns of this page. You should either delete
     them or move them to existing columns. We highlighted the problematic records for you.
 
 ..  _IsContentUsedOnPageLayoutEvent-example:

--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -15,9 +15,18 @@ IsContentUsedOnPageLayoutEvent
 Use the PSR-14 event :php:`\TYPO3\CMS\Backend\View\Event\IsContentUsedOnPageLayoutEvent`
 to identify if content has been used in a column that is not in a backend layout.
 
-Example
-=======
+Setting :php:`$event->setUsed(true)` prevent the following message for the affected content element,
+setting it to false displays it:
 
+..  warning::
+    **Unused elements detected on this page**
+    These elements don't belong to any of the available columns of this page. You should either delete 
+    them or move them to existing columns. We highlighted the problematic records for you.
+
+..  _IsContentUsedOnPageLayoutEvent-example:
+
+Example: Display "Unused elements detected on this page" for elements with missing parent
+=========================================================================================
 
 ..  literalinclude:: _IsContentUsedOnPageLayoutEvent/_ContentUsedOnPage.php
     :language: php
@@ -25,7 +34,9 @@ Example
 
 ..  include:: /_includes/EventsAttributeAdded.rst.txt
 
-API
-===
+..  _IsContentUsedOnPageLayoutEvent-api:
+
+API of IsContentUsedOnPageLayoutEvent
+=====================================
 
 ..  include:: /CodeSnippets/Events/Backend/IsContentUsedOnPageLayoutEvent.rst.txt


### PR DESCRIPTION
Add the warning message from TYPO3 Backend as developers will search for it. Improve headlines, add anchors

Releases: main, 12.4