### PR TITLE
[BUGFIX] Add a missing word in custom permissions chapter

### DIFF
--- a/Documentation/ApiOverview/Backend/CustomPermissions.rst
+++ b/Documentation/ApiOverview/Backend/CustomPermissions.rst
@@ -23,7 +23,7 @@ Registration
 Options are configured in the global variable
 :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']` in
 :file:`EXT:my_extension/ext_tables.php`. The syntax is demonstrated in
-the following example, which a custom permission option:
+the following example, which registers two custom permission options:
 
 ..  literalinclude:: _CustomPermissions/_ext_tables.php
     :language: php


### PR DESCRIPTION
Additionally, not only one option is registered in the example, but two options. Therefore, this has been also adjusted.

Releases: main, 12.4, 11.5