### PR TITLE
[TASK] Move CSRF-like request code snippets

### DIFF
--- a/Documentation/ApiOverview/Authentication/_CSRFlikeRequestTokenHandling/_MyController.php
+++ b/Documentation/ApiOverview/Authentication/_CSRFlikeRequestTokenHandling/_MyController.php
@@ -1,0 +1,22 @@
+<?php
+
+use TYPO3\CMS\Core\Security\RequestToken;
+use TYPO3\CMS\Fluid\View\StandaloneView;
+
+final class MyController
+{
+    private StandaloneView $view;
+
+    public function showFormAction()
+    {
+        // creating new request token with scope 'my/process' and hand over to view
+        $requestToken = RequestToken::create('my/process');
+        $this->view->assign('requestToken', $requestToken);
+        // ...
+    }
+
+    public function processAction()
+    {
+        // for the implementation, see below
+    }
+}

--- a/Documentation/ApiOverview/Authentication/_CSRFlikeRequestTokenHandling/_MyProcessController.php
+++ b/Documentation/ApiOverview/Authentication/_CSRFlikeRequestTokenHandling/_MyProcessController.php
@@ -1,0 +1,41 @@
+<?php
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\SecurityAspect;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class MyController
+{
+    public function showFormAction()
+    {
+        // for the implementation, see above
+    }
+
+    public function processAction()
+    {
+        $context = GeneralUtility::makeInstance(Context::class);
+        $securityAspect = SecurityAspect::provideIn($context);
+        $requestToken = $securityAspect->getReceivedRequestToken();
+
+        if ($requestToken === null) {
+            // No request token was provided in the request
+            // for example, (overridden) templates need to be adjusted
+        } elseif ($requestToken === false) {
+            // There was a request token, which could not be verified with the nonce
+            // for example, when nonce cookie has been overridden by another HTTP request
+        } elseif ($requestToken->scope !== 'my/process') {
+            // There was a request token, but for a different scope
+            // for example, when a form with different scope was submitted
+        } else {
+            // The request token was valid and for the expected scope
+            $this->doTheMagic();
+            // The middleware takes care to remove the cookie in case no other
+            // nonce value shall be emitted during the current HTTP request
+            if ($requestToken->getSigningSecretIdentifier() !== null) {
+                $securityAspect->getSigningSecretResolver()->revokeIdentifier(
+                    $requestToken->getSigningSecretIdentifier(),
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
And fix them as they were not linting.

This is a preparation for https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1005 where the StandaloneView is deprecated for TYPO3 v13.

Releases: main, 12.4