### PR TITLE
[TASK] Clarify variable scope withing TCA files (#4754)

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -16,7 +16,8 @@ All files in this directory are automatically included during the TYPO3
 
 ..  versionadded:: 12.0
     Files within :file:`Configuration/TCA/` files are loaded within a dedicated scope.
-    This means that variables defined in those files can't leak into the following files.
+    This means that variables defined in those files cannot leak to any other 
+    TCA file during the TCA compilation process.
 
     ..  note::
         In TYPO3 v11 and below, variables declared in these files were in a shared scope,

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -20,7 +20,7 @@ All files in this directory are automatically included during the TYPO3
 
     ..  note::
         In TYPO3 v11 and below, variables declared in these files were in a shared scope,
-        with the risk of a leakage to the following files. The use of :php:`call_user_func`
+        with the risk of a leakage to the following files. The use of :php:`call_user_func()`
         wrap was a common workaround.
 
 :file:`<tablename>.php`

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -14,6 +14,14 @@ The folder :file:`EXT:my_extension/Configuration/TCA/` may contain or override
 All files in this directory are automatically included during the TYPO3
 :ref:`bootstrap <bootstrapping>`.
 
+..  versionadded:: 12.0
+    Files within :file:`Configuration/TCA/` files are loaded within a dedicated scope.
+    This means that variables defined in those files can't leak into the following files.
+
+    ..  note::
+        Until TYPO3 v12, variables declared in these files were in a shared scope,
+        with the risk of a leakage to the following files. The use of :php:`call_user_func`
+        wrap was a common workaround.
 
 :file:`<tablename>.php`
 =======================

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -19,7 +19,7 @@ All files in this directory are automatically included during the TYPO3
     This means that variables defined in those files can't leak into the following files.
 
     ..  note::
-        Until TYPO3 v12, variables declared in these files were in a shared scope,
+        In TYPO3 v11 and below, variables declared in these files were in a shared scope,
         with the risk of a leakage to the following files. The use of :php:`call_user_func`
         wrap was a common workaround.
 

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -16,7 +16,7 @@ All files in this directory are automatically included during the TYPO3
 
 ..  versionadded:: 12.0
     Files within :file:`Configuration/TCA/` files are loaded within a dedicated scope.
-    This means that variables defined in those files cannot leak to any other 
+    This means that variables defined in those files cannot leak to any other
     TCA file during the TCA compilation process.
 
     ..  note::

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/_fe_users.php
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/_fe_users.php
@@ -2,11 +2,9 @@
 
 declare(strict_types=1);
 
-call_user_func(static function () {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
-        'fe_users',
-        'tx_myextension_options, tx_myextension_special',
-        '',
-        'after:password',
-    );
-});
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+    'fe_users',
+    'tx_myextension_options, tx_myextension_special',
+    '',
+    'after:password',
+);

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
@@ -36,6 +36,14 @@ will usually take effect without any special measures.
     Loading order also matters if you have multiple extensions overriding the same field,
     probably even contradicting each other.
 
+..  versionadded:: 12.0
+    Files within :file:`Configuration/TCA/` files are loaded within a dedicated scope.
+    This means that variables defined in those files can't leak into the following files.
+
+    ..  note::
+        Until TYPO3 v12, variables declared in these files were in a shared scope,
+        with the risk of a leakage to the following files. The use of :php:`call_user_func`
+        wrap was a common workaround.
 
 For more information about an extension's structure, please refer to the
 :ref:`extension architecture <extension-architecture>` chapter.

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/StoringChanges/Index.rst
@@ -41,7 +41,7 @@ will usually take effect without any special measures.
     This means that variables defined in those files can't leak into the following files.
 
     ..  note::
-        Until TYPO3 v12, variables declared in these files were in a shared scope,
+        In TYPO3 v11 and below, variables declared in these files were in a shared scope,
         with the risk of a leakage to the following files. The use of :php:`call_user_func`
         wrap was a common workaround.
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ docs: ## Generate projects documentation (from "Documentation" directory)
 
 	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
 
+.PHONY: docs-live
+docs-live: ## Generate projects documentation (from "Documentation" directory) and serves it on localhost:5173
+	docker run --rm -it --pull always \
+		-v "./Documentation:/project/Documentation" \
+		-v "./Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp" \
+		-p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest
+
+	xdg-open "http://localhost:5173/Documentation-GENERATED-temp/Index.html"
+
 .PHONY: test-docs
 test-docs: ## Test the documentation rendering
 	mkdir -p Documentation-GENERATED-temp

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,6 @@ docs: ## Generate projects documentation (from "Documentation" directory)
 
 	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
 
-.PHONY: docs-live
-docs-live: ## Generate projects documentation (from "Documentation" directory) and serves it on localhost:5173
-	docker run --rm -it --pull always \
-		-v "./Documentation:/project/Documentation" \
-		-v "./Documentation-GENERATED-temp:/project/Documentation-GENERATED-temp" \
-		-p 5173:5173 ghcr.io/garvinhicking/typo3-documentation-browsersync:latest
-
-	xdg-open "http://localhost:5173/Documentation-GENERATED-temp/Index.html"
-
 .PHONY: test-docs
 test-docs: ## Test the documentation rendering
 	mkdir -p Documentation-GENERATED-temp


### PR DESCRIPTION
References TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/4756
Releases: main,12.4

I don't know if a backport to older version should be done.
As a developper, I would also like to clarify the behavior for 11.5 LTS and maybe 10.4. Tell me if and how to proceed.