### PR TITLE
[BUGFIX] Correct added version for site sets

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/SiteSets.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSets.rst
@@ -6,7 +6,7 @@
 Site sets
 =========
 
-..  versionadded:: 13.3
+..  versionadded:: 13.1
     Site sets have been introduced.
 
 Site sets ship parts of the site configuration as composable pieces. They are


### PR DESCRIPTION
Site sets have been introduced with TYPO3 v13.1, not with v13.3.

Releases: main