### PR TITLE
Fix list items for RootlineUtility under "Bad examples" section of utilty classes CGL

### DIFF
--- a/Documentation/CodingGuidelines/PhpArchitecture/StaticMethods.rst
+++ b/Documentation/CodingGuidelines/PhpArchitecture/StaticMethods.rst
@@ -139,10 +139,9 @@ Bad Examples
 
 *   :php:`Core/Utility/RootlineUtility`
 
-  * Not static.
+    *    Not static.
 
-  * Should probably be a dedicated class construct, probably a service
-    is not enough. Why is this not part of a tree structure?
+    *    Should probably be a dedicated class construct, probably a service is not enough. Why is this not part of a tree structure?
 
 
 Red Flags

--- a/Documentation/CodingGuidelines/PhpArchitecture/StaticMethods.rst
+++ b/Documentation/CodingGuidelines/PhpArchitecture/StaticMethods.rst
@@ -139,9 +139,9 @@ Bad Examples
 
 *   :php:`Core/Utility/RootlineUtility`
 
-    *    Not static.
+    *   Not static.
 
-    *    Should probably be a dedicated class construct, probably a service is not enough. Why is this not part of a tree structure?
+    *   Should probably be a dedicated class construct, probably a service is not enough. Why is this not part of a tree structure?
 
 
 Red Flags


### PR DESCRIPTION
List items for RootlineUtility example were broken at https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/CodingGuidelines/PhpArchitecture/StaticMethods.html#bad-examples