### PR TITLE
[FEATURE] #101580 - Introduce Content-Security-Policy-Report-Only handling

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -36,9 +36,15 @@ web page context.
 Content Security Policy declarations can be applied to a TYPO3 website in
 frontend and backend scope with a dedicated API.
 
-To delegate Content Security Policy handling to TYPO3 frontend, the feature flag
-:ref:`security.frontend.enforceContentSecurityPolicy <typo3ConfVars_sys_features_security.frontend.enforceContentSecurityPolicy>`
-needs to be enabled.
+To delegate Content Security Policy handling to TYPO3 frontend, at least one of
+the feature flags
+
+*   :confval:`globals-typo3-conf-vars-sys-features-security-frontend-enforceContentSecurityPolicy`
+    (for enforcing)
+*   :confval:`globals-typo3-conf-vars-sys-features-security-frontend-reportContentSecurityPolicy`
+    (for report-only mode, available since TYPO3 v12.4.20)
+
+need to be enabled.
 
 ..  versionchanged:: 13.0
 

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -656,7 +656,29 @@ configurations.
         :Default: false
 
         If enabled, the :ref:`Content Security Policy <content-security-policy>`
-        is applied in frontend scope.
+        is enforced in frontend scope (HTTP header `Content-Security-Policy`).
+
+        This option can be enabled in combination with
+        :confval:`globals-typo3-conf-vars-sys-features-security-frontend-reportContentSecurityPolicy`.
+        Then both headers are set.
+
+    ..  _typo3ConfVars_sys_features_security.frontend.reportContentSecurityPolicy:
+
+    ..  confval:: security.frontend.reportContentSecurityPolicy
+        :name: globals-typo3-conf-vars-sys-features-security-frontend-reportContentSecurityPolicy
+        :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['security.frontend.reportContentSecurityPolicy']
+        :type: bool
+        :Default: false
+
+        ..  versionadded:: 12.4.20
+
+        If enabled, the :ref:`Content Security Policy <content-security-policy>`
+        is applied in frontend scope as report-only (HTTP header
+        `Content-Security-Policy-Report-Only`).
+
+        This option can be enabled in combination with
+        :confval:`globals-typo3-conf-vars-sys-features-security-frontend-enforceContentSecurityPolicy`.
+        Then both headers are set.
 
     ..  _typo3ConfVars_sys_features_security.frontend.allowInsecureFrameOptionInShowImageController:
 


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1001
Releases: main, 12.4