### PR TITLE
[CI] Speed up documentation check

### DIFF
--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -14,4 +14,8 @@ jobs:
         run: |
           mkdir -p Documentation-GENERATED-temp \
           && docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
+             ghcr.io/typo3-documentation/render-guides:latest \
+             --config=Documentation \
+             --output-format=singlepage \
+             --no-progress \
+             --fail-on-log


### PR DESCRIPTION
It is sufficient to check one output format for errors (here "singlepage"). With this patch we gain a massive performance improvement, resulting also in less processor cycles and therefore less energy consumption.

Previously, on documentation testing (locally):

    Parsing: 814/814 [============================] 100% Parsed 814 files in 17.35 seconds
    Rendering: 814/814 [===========] 100% Output format html: Rendered 814 documents in 48.17 seconds
    Rendering: 814/814 [============================] 100% Output format singlepage: Rendered 814 documents in 3.51 seconds
    Rendering: 814/814 [============================] 100% Output format interlink: Rendered 814 documents in 0.05 seconds
    Successfully placed 814 rendered HTML, SINGLEPAGE, and INTERLINK files into /project/Documentation-GENERATED-temp

With this patch (locally):

    Parsing: 814/814 [============================] 100% Parsed 814 files in 17.71 seconds
    Rendering: 814/814 [============================] 100% Output format singlepage: Rendered 814 documents in 8.24 seconds
    Successfully placed 814 rendered SINGLEPAGE files into /project/Documentation-GENERATED-temp

Releases: main, 12.4, 11.5