### PR TITLE
[Backport 12.4][TASK] Update functional tests examples (#4784)

### DIFF
--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTest.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTest.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [
         'workspaces',
     ];
 
-    public function testSomethingWithWorkspaces()
+    /**
+     * @test
+     */
+    public function somethingWithWorkspaces(): void
     {
         //...
     }

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestConfiguration.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestConfiguration.php
@@ -1,13 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use Symfony\Component\Mailer\Transport\NullTransport;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
     protected array $configurationToUseInTestInstance = [
@@ -16,7 +15,10 @@ class SomeTest extends FunctionalTestCase
         ],
     ];
 
-    public function testSomething()
+    /**
+     * @test
+     */
+    public function something(): void
     {
         //...
     }

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestExtensions.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestExtensions.php
@@ -1,12 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
     protected array $testExtensionsToLoad = [
@@ -14,7 +13,10 @@ class SomeTest extends FunctionalTestCase
         'typo3conf/ext/base_extension',
     ];
 
-    public function testSomethingWithExtensions()
+    /**
+     * @test
+     */
+    public function somethingWithExtensions(): void
     {
         //...
     }

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFiles.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFiles.php
@@ -1,18 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
     protected array $pathsToLinkInTestInstance = [
         'typo3/sysext/impexp/Tests/Functional/Fixtures/Folders/fileadmin/user_upload/typo3_image2.jpg' => 'fileadmin/user_upload/typo3_image2.jpg',
     ];
-    public function testSomethingWithFiles()
+
+    /**
+     * @test
+     */
+    public function somethingWithFiles(): void
     {
         //...
     }

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFrontend.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFrontend.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
-    public function testSomethingWithWorkspaces()
+    /**
+     * @test
+     */
+    public function somethingWithWorkspaces(): void
     {
         $this->setUpFrontendRootPage(
             1,

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestImportDataSet.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestImportDataSet.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MyVendor\MyExtension\Tests\Functional;
 
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "typo3/cms-t3editor": "^12.4",
         "typo3/cms-tstemplate": "^12.4",
         "typo3/cms-viewpage": "^12.4",
-        "typo3/cms-workspaces": "^12.4"
+        "typo3/cms-workspaces": "^12.4",
+        "typo3/testing-framework": "^8.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Mainly:
- Remove superfluous "Test Case" comment
- Add `declare(strict_types=1);` as best practise
- Use `@test` annotation as best practise like the Core does
- Add `void` return type as best practise
- Add `typo3/testing-framework` as requirement to have code completion in the PHP files

Releases: main, 12.4