### PR TITLE
[TASK] Use Test attribute in functional test examples

### DIFF
--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_GeneratorTest.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_GeneratorTest.php
@@ -2,11 +2,9 @@
 
 namespace TYPO3\CMS\Styleguide\Tests\Functional\TcaDataGenerator;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class GeneratorTest extends FunctionalTestCase
 {
     /**
@@ -16,10 +14,8 @@ class GeneratorTest extends FunctionalTestCase
         'typo3conf/ext/styleguide',
     ];
 
-    /**
-     * @test
-     */
-    public function generatorCreatesBasicRecord()
+    #[Test]
+    public function generatorCreatesBasicRecord(): void
     {
         //...
     }

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTest.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class SomeTest extends FunctionalTestCase
@@ -12,9 +13,7 @@ class SomeTest extends FunctionalTestCase
         'workspaces',
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function somethingWithWorkspaces(): void
     {
         //...

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestConfiguration.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -15,9 +16,7 @@ class SomeTest extends FunctionalTestCase
         ],
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function something(): void
     {
         //...

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestExtensions.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestExtensions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class SomeTest extends FunctionalTestCase
@@ -13,9 +14,7 @@ class SomeTest extends FunctionalTestCase
         'typo3conf/ext/base_extension',
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function somethingWithExtensions(): void
     {
         //...

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFiles.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFiles.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class SomeTest extends FunctionalTestCase
@@ -12,9 +13,7 @@ class SomeTest extends FunctionalTestCase
         'typo3/sysext/impexp/Tests/Functional/Fixtures/Folders/fileadmin/user_upload/typo3_image2.jpg' => 'fileadmin/user_upload/typo3_image2.jpg',
     ];
 
-    /**
-     * @test
-     */
+    #[Test]
     public function somethingWithFiles(): void
     {
         //...

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFrontend.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestFrontend.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class SomeTest extends FunctionalTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function somethingWithWorkspaces(): void
     {
         $this->setUpFrontendRootPage(

--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestImportDataSet.php
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_SomeTestImportDataSet.php
@@ -4,20 +4,19 @@ declare(strict_types=1);
 
 namespace MyVendor\MyExtension\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
-/**
- * Test case
- */
 class SomeTest extends FunctionalTestCase
 {
-    public function testSomething()
+    #[Test]
+    public function importData(): void
     {
-        // Load a xml file relative to test case file
+        // Load a CSV file relative to test case file
         $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
-        // Load a xml file of some extension
+        // Load a CSV file of some extension
         $this->importCSVDataSet('EXT:frontend/Tests/Functional/Fixtures/pages-title-tag.csv');
-        // Load a xml file provided by the typo3/testing-framework package
+        // Load a CSV file provided by the typo3/testing-framework package
         $this->importCSVDataSet('PACKAGE:typo3/testing-framework/Resources/Core/Functional/Fixtures/pages.csv');
     }
 }


### PR DESCRIPTION
typo3/testing-framwork in version 8.2 is used with TYPO3 v13. It requires as least PHPUnit v10 which provides the `#[Test]` attribute. Therefore, this attribute is used instead of the `@test` annotation.

Releases: main