### PR TITLE
[TASK] Unify YAML in Content Security Policy examples

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp.yaml
@@ -2,31 +2,31 @@
 inheritDefault: true
 mutations:
   # Results in `default-src 'self'`
-  - mode: set
-    directive: 'default-src'
+  - mode: "set"
+    directive: "default-src"
     sources:
       - "'self'"
 
   # Extends the ancestor directive ('default-src'),
   # thus reuses 'self' and adds additional sources
   # Results in `img-src 'self' data: https://*.typo3.org`
-  - mode: extend
-    directive: 'img-src'
+  - mode: "extend"
+    directive: "img-src"
     sources:
-      - 'data:'
-      - 'https://*.typo3.org'
+      - "data:"
+      - "https://*.typo3.org"
 
   # Extends the ancestor directive ('default-src'),
   # thus reuses 'self' and adds additional sources
   # Results in `script-src 'self' 'nonce-[random]'`
   # ('nonce-proxy' is substituted when compiling the policy)
-  - mode: extend
-    directive: 'script-src'
+  - mode: "extend"
+    directive: "script-src"
     sources:
       - "'nonce-proxy'"
 
   # Results in `worker-src blob:`
-  - mode: set
-    directive: 'worker-src'
+  - mode: "set"
+    directive: "worker-src"
     sources:
-      - 'blob:'
+      - "blob:"

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_append.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_append.yaml
@@ -1,15 +1,15 @@
 mutations:
-  - mode: set
+  - mode: "set"
     directive: "default-src"
     sources:
       - "'self'"
 
-  - mode: set
+  - mode: "set"
     directive: "img-src"
     sources:
-      - example.org
+      - "example.org"
 
-  - mode: append
+  - mode: "append"
     directive: "img-src"
     sources:
-      - example.com
+      - "example.com"

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_extend.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_extend.yaml
@@ -1,10 +1,10 @@
 mutations:
-  - mode: set
+  - mode: "set"
     directive: "default-src"
     sources:
       - "'self'"
 
-  - mode: extend
+  - mode: "extend"
     directive: "img-src"
     sources:
       - "example.com"

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_reduce.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_reduce.yaml
@@ -1,12 +1,12 @@
 mutations:
-  - mode: set
+  - mode: "set"
     directive: "img-src"
     sources:
       - "'self'"
       - "data:"
       - "example.com"
 
-  - mode: reduce
+  - mode: "reduce"
     directive: "img-src"
     sources:
       - "data:"

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_remove.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_remove.yaml
@@ -1,13 +1,13 @@
 mutations:
-  - mode: set
+  - mode: "set"
     directive: "default-src"
     sources:
       - "'self'"
 
-  - mode: set
+  - mode: "set"
     directive: "img-src"
     sources:
       - "data:"
 
-  - mode: remove
+  - mode: "remove"
     directive: "img-src"

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_set.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_mode_set.yaml
@@ -1,5 +1,5 @@
 mutations:
-  - mode: set
+  - mode: "set"
     directive: "img-src"
     sources:
       - "'self'"


### PR DESCRIPTION
The string values in the examples are sometimes with or without double quotes, sometimes with a single quote. This is now streamlined, and double quotes always used.

Please also note, that "static" sources in CSP are always enclosed in single quotes, like `'self'`, resulting in `"'self'"` in YAML.

Releases: main, 12.4