### PR TITLE
Fix link to security.usePasswordPolicyForFrontendUsers feature

### DIFF
--- a/Documentation/ApiOverview/PasswordPolicies/Index.rst
+++ b/Documentation/ApiOverview/PasswordPolicies/Index.rst
@@ -37,7 +37,7 @@ The password policy applies to:
 *   Setting a new password for a backend user in :guilabel:`User settings`
 *   Resetting a password for a backend user
 *   Resetting a password for a frontend user (see also the feature toggle
-    ":ref:`typo3ConfVars_sys_features_security.usePasswordPolicyForFrontendUsers`")
+    ":ref:`security.usePasswordPolicyForFrontendUsers <t3coreapi:globals-typo3-conf-vars-sys-features-security-usepasswordpolicyforfrontendusers>`")
 *   Password fields in tables :sql:`be_users` and :sql:`fe_users`
 
 Optionally, a password policy can be configured for custom TCA fields of the


### PR DESCRIPTION
On [Password Policies](https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/PasswordPolicies/Index.html#password-policies) the link to the "security.usePasswordPolicyForFrontendUsers" feature was missing.