### PR TITLE
Update ExtTablesSql.rst

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
@@ -87,9 +87,6 @@ auto-generated fields, if they are not manually defined in the
     Often set to sql:`cruser` or sql:`createdby`
 
 :php:`['ctrl']['delete'] = 'my_field_name'`
-    Often set to :php:`deleted`
-
-:php:`['ctrl']['delete'] = 'my_field_name'`
     Often set to :sql:`deleted`.
 
 :php:`['ctrl']['enablecolumns']['disabled'] = 'my_field_name'`


### PR DESCRIPTION
There was a duplicate definition of the deleted field. The difference to the other field definition was that the format was defined as :php: in RST. Because of the :sql: format of the other fields I guess the definition with :php: can be removed?