### PR TITLE
[TASK] Remove outdated note about removal of Fluid widgets

### DIFF
--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -6,12 +6,6 @@
 Pagination
 ==========
 
-.. note::
-
-   Pagination via Fluid widgets was removed, see
-   :doc:`ext_core:Changelog/11.0/Breaking-92529-AllFluidWidgetFunctionalityRemoved`.
-   Use the API documented here to implement your own pagination.
-
 The TYPO3 Core provides an interface to implement the native pagination of lists like arrays or
 query results of Extbase.
 


### PR DESCRIPTION
Fluid widgets were removed with TYPO3 v11.0. For TYPO3 v13 this note can be removed safely.

Releases: main