### PR TITLE
cookiedomain is tied to one TYPO3 instance

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -112,7 +112,9 @@ configurations.
    value to ".example.org" (replace example.org with your domain!), login
    sessions will be shared across subdomains. Alternatively, if you have more
    than one domain with sub-domains, you can set the value to a regular
-   expression to match against the domain of the HTTP request.
+   expression to match against the domain of the HTTP request. This however requires
+   that all sub-domains are within the same TYPO3 instance, because a session can be tied
+   to only one database.
 
    The result of the match is used as the domain for the cookie. for example :
    php:`/\.(example1|example2)\.com$/` or :php:`/\.(example1\.com)|(example2\.net)$/`.


### PR DESCRIPTION
Add a hint that all subdomains must lie in one TYPO3 instance.

See discussion at 
https://typo3.slack.com/archives/C028JEPJL/p1727869545849999