### PR TITLE
[TASK] Add a stub for TYPO3 Administration

### DIFF
--- a/Documentation/Administration/Index.rst
+++ b/Documentation/Administration/Index.rst
@@ -1,0 +1,30 @@
+:navigation-title: Administration
+..  include:: /Includes.rst.txt
+..  _administration:
+
+====================
+TYPO3 administration
+====================
+
+..  card-grid::
+    :columns: 1
+    :columns-md: 2
+    :gap: 4
+    :card-height: 100
+
+    ..  card:: TYPO3 Installation (Composer)
+
+        The getting started guides covers each of the steps required to
+        install TYPO3 using Composer.
+
+        :ref:`Getting started: TYPO3 installation <t3start:install>`
+
+    ..  card:: Upgrading TYPO3
+
+        The TYPO3 upgrade guide explains how to do patch level update, how
+        to update major Core versions and extensions.
+
+        It also explains how to :ref:`Migrate a TYPO3 project to
+        Composer <t3upgrade:migratetocomposer>`.
+
+        :ref:`TYPO3 Upgrade Guide <t3upgrade:upgrading>`

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -41,6 +41,7 @@ management system TYPO3.
     :maxdepth: 1
 
     ApiOverview/Index
+    Administration/Index
     CodingGuidelines/Index
     Configuration/Index
     ExtensionArchitecture/Index


### PR DESCRIPTION
In the long run I would like to move topics on advanced installation here, integrate the Upgrade guide, move advanced information on deployment from Getting Started, move Tuning TYPO3 chapters etc.

This is a first stub so we can move things step by step.

Releases: main, 13.4, 12.4