### PR TITLE
[PRPORT] Update Index.rst

### DIFF
--- a/Documentation/ApiOverview/ContentElements/Index.rst
+++ b/Documentation/ApiOverview/ContentElements/Index.rst
@@ -183,7 +183,7 @@ To register such a plugin as content element you can use function
 ..  literalinclude:: _Plugins/_tt_content_plugin.php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/tt_content.php
 
-By using `'list-type'` as second parameter is is also possible to add the plugin
+By using `'list_type'` as second parameter is is also possible to add the plugin
 as a list type. See :ref:`plugins-list_type`.
 
 **Plugins** are a specific type of content elements. Plugins use the CType='list'.


### PR DESCRIPTION
Preport of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/4835

Already merged into 13.4 and 12.4

Check second parameter $type for the function addPlugin() here: https://github.com/TYPO3/typo3/blob/v12.4.22/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php#L966

It's "list_type", not "list-type"