### PR TITLE
[PREPORT] fe_user > fe_users

### DIFF
--- a/Documentation/ApiOverview/ContentElements/Index.rst
+++ b/Documentation/ApiOverview/ContentElements/Index.rst
@@ -211,7 +211,7 @@ The news records are stored in a custom database table (`tx_news_domain_model_ne
 and can be edited in the backend.
 
 There are also system extensions that have plugins. :composer:`typo3/cms-felogin`
-has a plugin that allow frontend users, stored in table `fe_user` to log into
+has a plugin that allow frontend users, stored in table `fe_users` to log into
 the website. :composer:`typo3/cms-indexed-search` has a plugin that can be
 used to search in the index and display search results.
 


### PR DESCRIPTION
Preport of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/4836 into main

Was already merged in 12.4 and 13.4