### PR TITLE
[BUGFIX] Respect string enum specifier in site settings editor

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/SiteSettingDefinitions.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSettingDefinitions.rst
@@ -105,6 +105,17 @@ Site setting definition properties
             by editing  the :file:`config/sites/my-site/settings.yaml` directly,
             but not from within the editor.
 
+        ..  confval:: enum
+            :type: array
+            :name: enum
+            :types: :confval:`site-setting-type-string`
+
+            Site settings can provide possible options via the `enum` specifier,
+            that will be selectable in the editor GUI.
+
+            ..  literalinclude:: _Settings/_enum_settings.definitions.yaml
+                :caption: EXT:my_extension/Configuration/Sets/MySet/settings.definitions.yaml
+
 ..  _definition-types:
 
 Definition types

--- a/Documentation/ApiOverview/SiteHandling/_Settings/_enum_settings.definitions.yaml
+++ b/Documentation/ApiOverview/SiteHandling/_Settings/_enum_settings.definitions.yaml
@@ -1,0 +1,7 @@
+settings:
+  my.enumSetting:
+    label: 'My setting with options'
+    type: string
+    enum:
+      valueA: 'Label of value A'
+      valueB: 'Label of value B'


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1083

Releases: main, 13.4