### PR TITLE
[TASK] Set removal version for icon size constants

### DIFF
--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -103,7 +103,7 @@ The following icon sizes are available as enum values:
     One can also use the class constants of :php:`\TYPO3\CMS\Core\Imaging\Icon`
     if an extension should remain compatible with TYPO3 v13 and older versions.
 
-    The class constants will be removed in a future version of TYPO3.
+    The class constants will be removed in TYPO3 v14.
 
 
 ..  index::


### PR DESCRIPTION
This makes it clearer to the reader, when the constants are removed.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1092
Releases: main, 13.4