### PR TITLE
[BUGFIX] Use IconSize enums instead of deprecated Icon constants

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyInlineElementControlsEvent/_MyEventListener.php
@@ -7,8 +7,8 @@ namespace MyVendor\MyExtension\Backend\EventListener;
 use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementControlsEvent;
 use TYPO3\CMS\Backend\Form\Event\ModifyInlineElementEnabledControlsEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[AsEventListener(
@@ -37,7 +37,7 @@ final readonly class MyEventListener
             $event->setControl(
                 'tx_my_control',
                 '<a href="/some/url" class="btn btn-default t3js-modal-trigger">'
-                . $iconFactory->getIcon('my-icon-identifier', Icon::SIZE_SMALL)->render()
+                . $iconFactory->getIcon('my-icon-identifier', IconSize::SMALL)->render()
                 . '</a>',
             );
         }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyLinkExplanationEvent/_MyEventListener.php
@@ -6,8 +6,8 @@ namespace MyVendor\MyExtension\Backend\EventListener;
 
 use TYPO3\CMS\Backend\Form\Event\ModifyLinkExplanationEvent;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 
 #[AsEventListener(
     identifier: 'my-extension/backend/modify-link-explanation',
@@ -26,7 +26,7 @@ final readonly class MyEventListener
                 'icon',
                 $this->iconFactory->getIcon(
                     'my-custom-link-icon',
-                    Icon::SIZE_SMALL,
+                    IconSize::SMALL,
                 )->render(),
             );
         }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyResultItemInLiveSearchEvent/_MyEventListener.php
@@ -9,8 +9,8 @@ use TYPO3\CMS\Backend\Search\Event\ModifyResultItemInLiveSearchEvent;
 use TYPO3\CMS\Backend\Search\LiveSearch\DatabaseRecordProvider;
 use TYPO3\CMS\Backend\Search\LiveSearch\ResultItemAction;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 
@@ -42,7 +42,7 @@ final readonly class MyEventListener
              */
             $showHistoryAction = (new ResultItemAction('view_history'))
                 ->setLabel($this->languageService->sL('LLL:EXT:core/Resources/Private/Language/locallang_mod_web_list.xlf:history'))
-                ->setIcon($this->iconFactory->getIcon('actions-document-history-open', Icon::SIZE_SMALL))
+                ->setIcon($this->iconFactory->getIcon('actions-document-history-open', IconSize::SMALL))
                 ->setUrl((string)$this->uriBuilder->buildUriFromRoute('record_history', [
                     'element' => $resultItem->getExtraData()['table'] . ':' . $resultItem->getExtraData()['uid'],
                 ]));


### PR DESCRIPTION
The Icon constants have been deprected an v13.0 and were removed in v14.0. Instead, the IconSize enum has to be used.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1092
Releases: main, 13.4