### PR TITLE
[TASK] Replace deprecated AbstractFile constants by FileType enum

### DIFF
--- a/Documentation/ApiOverview/Fal/Architecture/Database.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Database.rst
@@ -26,8 +26,8 @@ Some important fields:
     ID of the storage where the file is stored.
 
 :sql:`type`
-    The type of the file represented by an integer defined in
-    :php:`\TYPO3\CMS\Core\Resource\AbstractFile`.
+    The type of the file represented by an integer defined by an enum
+    :php:`\TYPO3\CMS\Core\Resource\FileType` value.
 
     See :ref:`globals-constants-file-types` for more details.
 


### PR DESCRIPTION
The AbstractFile constants have been deprecated with v13.0 and were removed with v14.0. The FileType enum takes the place.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/701
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1099
Releases: main, 13.4