### PR TITLE
[TASK] #105230 - Declare TypoScriptFrontendController deprecated

### DIFF
--- a/Documentation/ApiOverview/Assets/Index.rst
+++ b/Documentation/ApiOverview/Assets/Index.rst
@@ -225,6 +225,11 @@ Using the TypoScriptFrontendController
     The property :php:`additionalHeaderData` has been marked as internal
     and should not be used.
 
+..  deprecated:: 13.4
+    The class :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController`
+    and its global instance :php:`$GLOBALS['TSFE']` have been marked as
+    deprecated. The class will be removed with TYPO3 v14.
+
 ..  code-block:: php
 
     $GLOBALS['TSFE']->additionalHeaderData[$name] = $javaScriptCode;

--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
@@ -8,6 +8,14 @@
 Frontend controller
 ===================
 
+..  deprecated:: 13.4
+    The class :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController`
+    and its global instance :php:`$GLOBALS['TSFE']` have been marked as
+    deprecated. The class will be removed with TYPO3 v14.
+
+    Use the :ref:`frontend.page.information <typo3-request-attribute-frontend-page-information>`
+    request attribute for page-related properties.
+
 The :php:`frontend.controller` frontend request attribute provides access to the
 :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController` object.
 

--- a/Documentation/ApiOverview/TSFE/Index.rst
+++ b/Documentation/ApiOverview/TSFE/Index.rst
@@ -6,6 +6,11 @@
 TSFE
 ====
 
+..  deprecated:: 13.4
+    The class :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController`
+    and its global instance :php:`$GLOBALS['TSFE']` have been marked as
+    deprecated. The class will be removed with TYPO3 v14.
+
 ..  contents::
     :local:
 
@@ -99,13 +104,12 @@ Access the :php:`\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer`
     // !!! discouraged
     $cObj = $GLOBALS['TSFE']->cObj;
 
-Obtain TSFE from the request attribute
-:ref:`frontend.controller <typo3-request-attribute-frontend-controller>`:
+Obtain the current content object in an Extbase controller from the request attribute
+:ref:`currentContentObject <typo3-request-attribute-current-content-object>`:
 
 ..  code-block:: php
 
-    $frontendController = $request->getAttribute('frontend.controller');
-    $cObj = $frontendController->cObj;
+    $currentContentObject = $request->getAttribute('currentContentObject');
 
 In the case of the :ref:`USER content object <t3tsref:cobj-user>` (for example,
 a non-Extbase plugin) use setter injection:


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 13.4