### PR TITLE
[TASK] Remove typo3/cms-t3editor from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "typo3/cms-setup": "dev-main as 13.1",
         "typo3/cms-styleguide": "dev-main as 13.1",
         "typo3/cms-sys-note": "dev-main as 13.1",
-        "typo3/cms-t3editor": "dev-main as 13.1",
         "typo3/cms-tstemplate": "dev-main as 13.1",
         "typo3/cms-viewpage": "dev-main as 13.1",
         "typo3/cms-workspaces": "dev-main as 13.1",


### PR DESCRIPTION
This system extension has been integrated into EXT:backend with TYPO3 v13.0 and is therefore superfluous.

Releases: main, 13.4