### PR TITLE
[TASK] Update ergebnis/composer-normalize to 2.44.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "typo3/cms-core": "dev-main as 13.1"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "~2.41.0",
+        "ergebnis/composer-normalize": "~2.44.0",
         "friendsofphp/php-cs-fixer": "^3.46",
         "garvinhicking/clinspector-gadget": "^0.1.1",
         "symfony/yaml": "^7.0",


### PR DESCRIPTION
This version is compatible with the upcoming PHP 8.4.

Releases: main, 13.4, 12.4