### PR TITLE
[Backport 13.4][TASK] Remove typo3/cms-t3editor from composer.json (#4877)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
         "typo3/cms-setup": "^13.4",
         "typo3/cms-styleguide": "^13.4",
         "typo3/cms-sys-note": "^13.4",
-        "typo3/cms-t3editor": "^13.4",
         "typo3/cms-tstemplate": "^13.4",
         "typo3/cms-viewpage": "^13.4",
         "typo3/cms-workspaces": "^13.4",


### PR DESCRIPTION
This system extension has been integrated into EXT:backend with TYPO3 v13.0 and is therefore superfluous.

Releases: main, 13.4