### PR TITLE
[TASK] Update ergebnis/composer-normalize to 2.44.0 (#4878)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "typo3/cms-core": "^12.4"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "~2.41.0",
+        "ergebnis/composer-normalize": "~2.44.0",
         "friendsofphp/php-cs-fixer": "^3.51",
         "garvinhicking/clinspector-gadget": "^0.1.2",
         "symfony/yaml": "^6.4",


### PR DESCRIPTION
This version is compatible with the upcoming PHP 8.4.

Releases: main, 13.4