### PR TITLE
Remove unknown `type` in configuration array

### DIFF
--- a/Documentation/ApiOverview/PageTypes/_ext_tables.php
+++ b/Documentation/ApiOverview/PageTypes/_ext_tables.php
@@ -12,7 +12,6 @@ $dokTypeRegistry = GeneralUtility::makeInstance(PageDoktypeRegistry::class);
 $dokTypeRegistry->add(
     $customPageDoktype,
     [
-        'type' => 'web',
         'allowedTables' => '*',
     ],
 );


### PR DESCRIPTION
The snippet passes a `type => ‘web’` in the configuration array - but there is no indication of the meaning of this. A search in the PageDoktypeRegistry was unsuccessful. The entry is not evaluated here. Nothing could be found in the rest of the core either. And even when asked via Mastodon, there was no indication of the meaning/necessity.