### PR TITLE
[BUGFIX] Adjust links to the new location of TypoScript Guide

### DIFF
--- a/Documentation/Configuration/ConfigurationOverview.rst
+++ b/Documentation/Configuration/ConfigurationOverview.rst
@@ -159,9 +159,9 @@ the incredible power of TypoScript Templating is daily bread for Integrators.
 For an introduction, you may want to read one of the following tutorials:
 
 
-* :ref:`t3ts45:start` - Introduction to TypoScript Templating.
-* :ref:`t3sitepackage:start` - Start a Sitepackage Extension to create a theme
-  for your site using TypoScript and Fluid.
+*   :ref:`TypoScript guide <t3tsref:guide>` - Introduction to TypoScript.
+*   :ref:`t3sitepackage:start` - Start a Sitepackage Extension to create a theme
+    for your site using TypoScript and Fluid.
 
 .. note::
 

--- a/Documentation/Configuration/TypoScript/FrontendTypoScript/Index.rst
+++ b/Documentation/Configuration/TypoScript/FrontendTypoScript/Index.rst
@@ -13,5 +13,5 @@ It is very powerful and this abstraction layer is one reason that the TYPO3
 project survives the ever evolving internet since more than 25 years.
 
 The :ref:`TypoScript Reference <t3tsref:start>` goes into details about the
-usage of TypoScript in the frontend, and :ref:`TypoScript in 45 minutes <t3ts45:start>`
+usage of TypoScript in the frontend, and the :ref:`TypoScript guide <t3tsref:guide>`
 is a kickstart for new TypoScript integrators.

--- a/Documentation/Configuration/TypoScript/Index.rst
+++ b/Documentation/Configuration/TypoScript/Index.rst
@@ -18,13 +18,14 @@ for backend users.
 While the underlying TypoScript syntax is described in this chapter, both use cases
 and their details are found in standalone manuals:
 
--  The :ref:`TypoScript Reference <t3tsref:start>` goes into details about the
-   usage of TypoScript in the frontend.
+*   The :ref:`TypoScript Reference <t3tsref:start>` goes into details about the
+    usage of TypoScript in the frontend.
 
--  The :ref:`TSconfig Reference <t3tsconfig:start>` goes into details about
-   configuring the TYPO3 backend for backend users.
+*   The :ref:`TSconfig Reference <t3tsconfig:start>` goes into details about
+    configuring the TYPO3 backend for backend users.
 
-- A quick kick start to frontend TypoScript is available at :ref:`t3ts45:start`.
+*   A quick kick start to frontend TypoScript is available at
+    :ref:`TypoScript guide <t3tsref:guide>`.
 
 .. note::
 


### PR DESCRIPTION
releases: main, 13.4, 12.4