### PR TITLE
[TASK] Use request attribute instead of TSFE in page title API example

### DIFF
--- a/Documentation/ApiOverview/Seo/PageTitleApi.rst
+++ b/Documentation/ApiOverview/Seo/PageTitleApi.rst
@@ -80,6 +80,10 @@ example the site title, you can implement a page title provider as follows:
 ..  literalinclude:: _ExampleWebsiteTitle/_WebsiteTitleProvider.php
     :caption: EXT:my_sitepackage/Classes/PageTitle/WebsiteTitleProvider.php
 
+..  versionchanged:: 13.0
+    The :ref:`frontend.page.information attribute <typo3-request-attribute-frontend-page-information>`
+    has been introduced.
+
 As we need to :ref:`inject <DependencyInjection>` the class :php:`SiteFinder`
 to retrieve the current site configuration, we must make the new page title
 provider :ref:`public <knowing-what-to-make-public>`:

--- a/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
+++ b/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
@@ -4,30 +4,33 @@ declare(strict_types=1);
 
 namespace MyVendor\MySitepackage\PageTitle;
 
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\PageTitle\PageTitleProviderInterface;
 use TYPO3\CMS\Core\Site\SiteFinder;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Page\PageInformation;
 
-final class WebsiteTitleProvider implements PageTitleProviderInterface
+final readonly class WebsiteTitleProvider implements PageTitleProviderInterface
 {
     public function __construct(
-        private readonly SiteFinder $siteFinder,
+        private SiteFinder $siteFinder,
     ) {}
 
     public function getTitle(): string
     {
-        $site = $this->siteFinder->getSiteByPageId($this->getTypoScriptFrontendController()->page['uid']);
+        /** @var PageInformation $pageInformation */
+        $pageInformation = $this->getRequest()->getAttribute('frontend.page.information');
+
+        $site = $this->siteFinder->getSiteByPageId($pageInformation->getId());
         $titles = [
-            $this->getTypoScriptFrontendController()->page['title'],
+            $pageInformation->getPageRecord()['title'],
             $site->getAttribute('websiteTitle'),
         ];
 
-        // do something
         return implode(' - ', $titles);
     }
 
-    private function getTypoScriptFrontendController(): TypoScriptFrontendController
+    private function getRequest(): ServerRequestInterface
     {
-        return $GLOBALS['TSFE'];
+        return $GLOBALS['TYPO3_REQUEST'];
     }
 }


### PR DESCRIPTION
The TypoScriptFrontendController has been marked as deprecated with TYPO3 v13.4. Therefore, this example has been adjusted to avoid calling TSFE methods.

Additionally:

- The whole class is marked as readonly.
- The "do something" comment is removed as it does not serve any purpose here.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 13.4