### PR TITLE
[TASK] Remove mentions of TSFE in Bootstrapping and Middlewares chapters

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Bootstrapping.rst
@@ -12,8 +12,8 @@ calling  :php:`Bootstrap::init()` and serves as an entry point for later calling
 an application class, depending on several context-dependant constraints.
 
 Each application class registers request handlers to
-run a certain request type (e.g. eID or TSFE-logic, or Ajax requests in the Backend). Each application is handed
-over the class loader provided by Composer.
+run a certain request type (e.g. eID or Ajax requests in the backend). Each
+application is handed over the class loader provided by Composer.
 
 Applications
 ============
@@ -25,7 +25,7 @@ There are four types of applications provided by the TYPO3 Core:
 -----------------------------------------
 
 This class handles all incoming web requests coming through :file:`index.php`
-in the public web directory. It handles all regular page (TSFE) and eID requests.
+in the public web directory. It handles all regular page and eID requests.
 
 It checks if all configuration is set, otherwise redirects to the TYPO3 Install
 Tool.

--- a/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Middlewares.rst
@@ -99,7 +99,7 @@ the configuration is not applied. This is usually no problem - Extbase plugins
 are typically either included as :ref:`USER content object <t3tsref:cobj-user>`
 (its content is cached and returned together with other content elements in
 fully-cached page context), or the Extbase plugin is registered as USER_INT. In
-this case, the :ref:`TSFE <tsfe>` takes care of calculating TypoScript before
+this case, the TYPO3 Core takes care of calculating TypoScript before
 the plugin is rendered, while other USER content objects are fetched from page
 cache.
 
@@ -117,7 +117,7 @@ that already use Extbase in a middleware have the following options:
 
 *   Move away from the middleware and register the Extbase instance as a casual
     :ref:`USER_INT <t3tsref:cobj-user-int>` object via TypoScript: Extbase is
-    designed to be executed like this, the TSFE bootstrap will take care of
+    designed to be executed like this, the bootstrap will take care of
     properly calculating TypoScript, and Extbase will run as expected.
 
     Note that with TYPO3 v12, the overhead of USER_INT content objects has been


### PR DESCRIPTION
TypoScriptFrontendController has been deprecated with TYPO3 v13. Therefore, the mentions of TSFE have been removed in those chapters.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 13.4