### PR TITLE
[TASK] Prefer "Autoconfigure" attribute over the Services.yaml configuration

### DIFF
--- a/Documentation/ApiOverview/Seo/PageTitleApi.rst
+++ b/Documentation/ApiOverview/Seo/PageTitleApi.rst
@@ -84,13 +84,9 @@ example the site title, you can implement a page title provider as follows:
     The :ref:`frontend.page.information attribute <typo3-request-attribute-frontend-page-information>`
     has been introduced.
 
-As we need to :ref:`inject <DependencyInjection>` the class :php:`SiteFinder`
-to retrieve the current site configuration, we must make the new page title
-provider :ref:`public <knowing-what-to-make-public>`:
-
-..  literalinclude:: _ExampleWebsiteTitle/_Services.yaml
-    :language: yaml
-    :caption: EXT:my_sitepackage/Configuration/Services.yaml
+The class must be set to :ref:`public <t3coreapi:What-to-make-public>`, because
+we :ref:`inject <DependencyInjection>` the class :php:`SiteFinder` as
+dependency.
 
 Then **flush the cache** in :guilabel:`Admin Tools > Maintenance > Flush TYPO3
 and PHP Cache`.

--- a/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_Services.yaml
+++ b/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_Services.yaml
@@ -1,8 +1,0 @@
-services:
-  _defaults:
-    autowire: true
-    autoconfigure: true
-    public: false
-
-  MyVendor\MySitepackage\PageTitle\WebsiteTitleProvider:
-    public: true

--- a/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
+++ b/Documentation/ApiOverview/Seo/_ExampleWebsiteTitle/_WebsiteTitleProvider.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace MyVendor\MySitepackage\PageTitle;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\PageTitle\PageTitleProviderInterface;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Frontend\Page\PageInformation;
 
+#[Autoconfigure(public: true)]
 final readonly class WebsiteTitleProvider implements PageTitleProviderInterface
 {
     public function __construct(


### PR DESCRIPTION
This way, one file to maintain less. An it is easier for the user to copy/paste the example.

Releases: main, 13.4