### PR TITLE
[TASK] Avoid TSFE in Context chapter

### DIFF
--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -168,7 +168,7 @@ Overlay types
 
 :php:`LanguageAspect::OVERLAYS_OFF`
     Just fetch records from the selected language as given by
-    :php:`$GLOBALS['TSFE']->sys_language_content`. No overlay will happen, no
+    :php:`LanguageAspect->getContentId()`. No overlay will happen, no
     fetching of the records from the default language. This boils down to
     "free mode" language handling. Records without a default language parent are
     included.


### PR DESCRIPTION
TSFE has been deprecated with TYPO3 v13 and will be removed with TYPO3 v14. Therefore, this mentioning has to be dropped.

Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/9.4/Deprecation-85543-Language-relatedPropertiesInTypoScriptFrontendControllerAndPageRepository.html#migration
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 13.4