### PR TITLE
[BUGFIX] Fix curly brace indentation

### DIFF
--- a/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
+++ b/Documentation/CodingGuidelines/CglPhp/PhpSyntaxFormatting.rst
@@ -165,7 +165,7 @@ the same level as the construct with the opening brace. Example:
         } else {
             // generate simple form here
         }
-   }
+    }
 
 The following is not allowed:
 


### PR DESCRIPTION
I stumbled over this (ironic) curly brace indentation issue while reading about curly brace indentations in the "PHP syntax formatting" section.