### PR TITLE
Fix CSP `remove` mutation example result

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -304,7 +304,7 @@ The following modes are available:
 
         ..  code-block:: http
 
-            Content-Security-Policy: img-src 'self'
+            Content-Security-Policy: default-src 'self'
 
     ..  confval:: set
         :name: content-security-policy-mode-set


### PR DESCRIPTION
The example result for `remove` mutation is wrong : https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentSecurityPolicy/Index.html#confval-content-security-policy-mode-remove

As the `img-src` directive is completly removed, it should only be`default-src` left.

`12.4` and `13.4` branches are also affected.