### PR TITLE
no suffix EventListener but Listener

### DIFF
--- a/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
+++ b/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
@@ -400,7 +400,7 @@ Best practices
     package. Be careful about the context that should be exposed.
 
 *   The same applies to creating a new event listener PHP class: Add
-    an :php:`EventListener` suffix to the PHP class, and move it to a folder
+    an :php:`Listener` suffix to the PHP class, and move it to a folder
     :file:`Classes/EventListener/`.
 
 *   Emitters (TYPO3 Core or extension authors) should always use


### PR DESCRIPTION
I have checked the TYPO3 Core. Only the suffix Listener is used with class names which implement event listeners.