### PR TITLE
[TASK] Explain UriBuilder usage in Extbase ViewHelpers

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/UriBuilder.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/UriBuilder.rst
@@ -14,7 +14,8 @@ Usage in an Extbase controller
 ==============================
 
 The URI builder is available as a property in a controller class which extends
-the :ref:`extbase-action-controller` class.
+the :ref:`extbase-action-controller` class. The request context is automatically
+available to the UriBuilder.
 
 Example:
 
@@ -58,6 +59,28 @@ via constructor in a class:
     :ref:`currentContentObject <typo3-request-attribute-current-content-object>`,
     an automatic fallback is applied in TYPO3 v12, triggering a PHP deprecation
     warning. The fallback has been removed in TYPO3 v13.
+
+..  _extbase-uri-builder-viewhelper:
+Example in Extbase ViewHelper
+-----------------------------
+
+..  literalinclude:: _UriBuilder/_MyLinkViewHelper.php
+    :caption: EXT:my_extension/Classes/ViewHelper/MyLinkViewHelper.php
+
+..  note::
+    This example was taken from :php:`TYPO3\CMS\Fluid\ViewHelpers\Uri\ActionViewHelper`
+    of the TYPO3 Core. These ViewHelpers are always a useful example to see the best practice on how
+    to retrieve request context.
+
+..  attention::
+    This example uses the :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper` to be extended from,
+    which does not have its own constructor, making constructor-based dependency injection straight forward.
+    However, if you use :php:`TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper` as a base, which already
+    provides a constructor, be sure to call :php:`parent::_construct()` in your custom constructor.
+    Alternatively (though less recommendable), you can use :php:`GeneralUtility::makeInstance()` to retrieve
+    the UriBuilder instance, or use method-based injection (:php:`injectUriBuilder(UriBuilder $uriBuilder)`).
+    See :ref:`Dependency injection <t3coreapi:Dependency-Injection>` for more details.
+
 
 ..  _uri-builder-api:
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/UriBuilder.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/UriBuilder.rst
@@ -79,6 +79,7 @@ Example in Extbase ViewHelper
     provides a constructor, be sure to call :php:`parent::_construct()` in your custom constructor.
     Alternatively (though less recommendable), you can use :php:`GeneralUtility::makeInstance()` to retrieve
     the UriBuilder instance, or use method-based injection (:php:`injectUriBuilder(UriBuilder $uriBuilder)`).
+    Note, always flush the TYPO3 cache after adding/modifying ViewHelpers with new injected dependencies.
     See :ref:`Dependency injection <t3coreapi:Dependency-Injection>` for more details.
 
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
@@ -10,9 +10,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 final class MyLinkViewHelper extends AbstractViewHelper
 {
-    public function __construct(private UriBuilder $uriBuilder)
-    {
-    }
+    public function __construct(private UriBuilder $uriBuilder) {}
 
     public function render(): string
     {
@@ -25,7 +23,7 @@ final class MyLinkViewHelper extends AbstractViewHelper
         } else {
             throw new \RuntimeException(
                 'The rendering context of this ViewHelper is missing a valid request object, probably because it is used outside of Extbase context.',
-                1730537505
+                1730537505,
             );
         }
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller\MyController;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+final class MyLinkViewHelper extends AbstractViewHelper
+{
+    public function __construct(private UriBuilder $uriBuilder)
+    {
+    }
+
+    public function render(): string
+    {
+        if ($this->renderingContext->hasAttribute(ServerRequestInterface::class)) {
+            $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
+        } else {
+            throw new \RuntimeException(
+                'The rendering context of this ViewHelper is missing a valid request object, probably because it is used outside of Extbase context.',
+                1730537505
+            );
+        }
+
+        // Request context is needed before $this->uriBuilder is first used for returning links.
+        // Note: this will not be reset on calling $this->uriBuilder->reset()!
+        $this->uriBuilder->setRequest($request);
+
+        $url = $this->uriBuilder
+            ->reset()
+            ->setTargetPageUid(2751)
+            ->uriFor(
+                'anotherAction',
+                [
+                    'myRecord' => 21,
+                ],
+                'MyController',
+                'myextension',
+                'myplugin',
+            );
+
+        // do something with $url, for example:
+        return 'Link: ' . $url . '</a>';
+    }
+}

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_UriBuilder/_MyLinkViewHelper.php
@@ -16,7 +16,11 @@ final class MyLinkViewHelper extends AbstractViewHelper
 
     public function render(): string
     {
-        if ($this->renderingContext->hasAttribute(ServerRequestInterface::class)) {
+        if (method_exists($this->renderingContext, 'getRequest')) {
+            // TYPO3 v12 compatibility
+            $request = $this->renderingContext->getRequest();
+        } elseif ($this->renderingContext->hasAttribute(ServerRequestInterface::class)) {
+            // TYPO3 v13+ compatibility
             $request = $this->renderingContext->getAttribute(ServerRequestInterface::class);
         } else {
             throw new \RuntimeException(


### PR DESCRIPTION
Explain usage of UriBuilder inside ViewHelpers with Dependency Injection and retrieving context independent from TYPO3_REQUEST. Code example is compatible to main, 13.4 and 12.4.

This was recently asked for multiple times:

https://typo3.slack.com/archives/C025BQLFA/p1730408358146759
https://forge.typo3.org/issues/105531#change-531777

(Note: this should be a pre-patch. Some other information on this page is outdated for 13.4 and needs adoption, especially due to TYPO3_REQUEST usage. Follow-up patches could remove the v12/v13 code fork, unsure about this best practice to suppor two LTSs here?)

Releases: main, 13.4, 12.4