### PR TITLE
Fix missing reference to Table properties (ctrl) in "Model" chapter of the Extbase "Tea" extension tutorial

### DIFF
--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
@@ -131,7 +131,7 @@ in listings and in backend forms:
 :php:`tstamp`, :php:`deleted`, ...
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These fields are used to keep timestamp and status information for each record. You can read more about them in the `TCA Reference, chapter ctrl <t3tca:ctrl>`.
+These fields are used to keep timestamp and status information for each record. You can read more about them in the :ref:`TCA Reference, chapter Table properties (ctrl) <t3tca:ctrl>`.
 
 ..  _extbase_tutorial_tea_model_columns:
 


### PR DESCRIPTION
In the Extbase "Tea" extension tutorial, chapter "Model" (https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/Tutorials/Tea/Model.html#model-a-bag-of-tea), the `:ref:` prefix was missing in reference to the "Table properties (ctrl)"" chapter of the TCA Reference.