### PR TITLE
Use Icon instead of IconSize

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_AdminModuleControllerSetUpDocHeader.rst.txt
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_AdminModuleControllerSetUpDocHeader.rst.txt
@@ -7,7 +7,7 @@
     use Psr\Http\Message\ServerRequestInterface;
     use TYPO3\CMS\Backend\Template\Components\ButtonBar;
     use TYPO3\CMS\Backend\Template\ModuleTemplate;
-    use TYPO3\CMS\Core\Imaging\IconSize;
+    use TYPO3\CMS\Core\Imaging\Icon;
 
     final readonly class AdminModuleController
     {
@@ -21,7 +21,7 @@
                 ->setHref($uriBuilderPath)
                 ->setTitle('A Title')
                 ->setShowLabelText(true)
-                ->setIcon($this->iconFactory->getIcon('actions-extension-import', IconSize::SMALL->value));
+                ->setIcon($this->iconFactory->getIcon('actions-extension-import', Icon::SIZE_SMALL));
             $buttonBar->addButton($list, ButtonBar::BUTTON_POSITION_LEFT, 1);
         }
     }


### PR DESCRIPTION
IconSize was introduced in v13 and Icon was deprecated.  In v12, we still have to use the older way.

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101475-IconSizeStringConstants.html