### PR TITLE
[TASK] Add link to felogin error redirect handler

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
@@ -44,6 +44,10 @@ For an example implementation of the :php:`PageErrorHandlerInterface`, take a
 look at :t3src:`core/Classes/Error/PageErrorHandler/PageContentErrorHandler.php`
 or :t3src:`core/Classes/Error/PageErrorHandler/FluidPageErrorHandler.php`.
 
+For a custom 403 error handler with redirect to a login form, please see
+:ref:`Custom error handler implementation for 403 redirects
+<typo3/cms-felogin:felogin-how-to-implement-403redirect-error-handler>`.
+
 Properties
 ==========
 


### PR DESCRIPTION
Googling for a custom error handler only led me to this page and not actually https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/Examples/Index.html#custom-error-handler-implementation-for-403-redirects - I think this cross reference would be helpful.

Releases: main, 13.4, 12.4