### PR TITLE
Update DefaultQuerySettings.rst.txt

### DIFF
--- a/Documentation/CodeSnippets/Extbase/Domain/DefaultQuerySettings.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Domain/DefaultQuerySettings.rst.txt
@@ -6,14 +6,12 @@
 
     use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface;
-    use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
 
     class CommentRepository extends Repository
     {
         public function initializeObject(): void
         {
-            /** @var QuerySettingsInterface $querySettings */
-            $querySettings = GeneralUtility::makeInstance(Typo3QuerySettings::class);
+            $querySettings = $this->createQuery()->getQuerySettings();
             // Show comments from all pages
             $querySettings->setRespectStoragePage(false);
             $this->setDefaultQuerySettings($querySettings);


### PR DESCRIPTION
https://api.typo3.org/main/classes/TYPO3-CMS-Extbase-Persistence-Repository.html#method_setDefaultQuerySettings 

I'd like to change the documentation because generating a new Object will throw away things like StoragePid from settings.

Changing the "existing" DefaultQuerySettings is often more useful

At least I'd like to have both options