### PR TITLE
[!!!][TASK] Remove deprecated class DuplicationBehavior

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_ApiUpload.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_ApiUpload.php
@@ -6,7 +6,7 @@ namespace MyVendor\MyExtension\Controller;
 
 use MyVendor\MyExtension\Domain\Model\Blog;
 use MyVendor\MyExtension\Domain\Repository\BlogRepository;
-use TYPO3\CMS\Core\Resource\DuplicationBehavior;
+use TYPO3\CMS\Core\Resource\Enum\DuplicationBehavior;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;


### PR DESCRIPTION
This should already have been changed in 13.4 as it was already deprecated then.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1108
Releases: main, 13.4