### PR TITLE
chore: remove superfluous commas in table row

### DIFF
--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv
@@ -1,6 +1,6 @@
 "pages"
 ,"uid","pid","sorting","deleted","t3_origuid","title"
-,1,0,256,0,0,"Connected mode",,,
+,1,0,256,0,0,"Connected mode"
 
 "tt_content"
 ,"uid","pid","sorting","deleted","sys_language_uid","l18n_parent","l10n_source","t3_origuid","header"


### PR DESCRIPTION
The commas are superfluous. This way a developer has not to count the number of fields.

Additionally, add an empty line between different tables for better readability.