### PR TITLE
[TASK] [Backport] Remove superfluous commas in table row (#5051)

### DIFF
--- a/Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv
+++ b/Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv
@@ -1,6 +1,7 @@
-"pages",,,,,,,,,
-,"uid","pid","sorting","deleted","t3_origuid","title",,,
-,1,0,256,0,0,"Connected mode",,,
-"tt_content",,,,,,,,,
+"pages"
+,"uid","pid","sorting","deleted","t3_origuid","title"
+,1,0,256,0,0,"Connected mode"
+
+"tt_content"
 ,"uid","pid","sorting","deleted","sys_language_uid","l18n_parent","l10n_source","t3_origuid","header"
 ,297,1,256,0,0,0,0,0,"Regular Element #1"


### PR DESCRIPTION
* chore: remove superfluous commas in table row

The commas are superfluous. This way a developer has not to count the number of fields.

Additionally, add an empty line between different tables for better readability.

* Update Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv

* Update Documentation/Testing/FunctionalTesting/_FunctionalTests/_Fixture.csv