### PR TITLE
[TASK] Update name of Slack channel for the TYPO3 localization team

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
@@ -20,13 +20,13 @@ Setup
 =====
 
 Get in contact with the team in the TYPO3 Slack channel
-`#cig-crowdin-localization`_ with the following information:
+`#typo3-localization-team`_ with the following information:
 
 #.  Extension name
 #.  Your email address for an invitation to Crowdin, so you will get the correct
     role for your project.
 
-..  _#cig-crowdin-localization: https://typo3.slack.com/app_redirect?channel=CMUG7C04F
+..  _#typo3-localization-team: https://typo3.slack.com/app_redirect?channel=CR75200FL
 
 
 Integration

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -12,7 +12,7 @@ Frequently asked questions (FAQ)
 
 ..  note::
     If you miss a question, please share it in the Slack channel
-    `#cig-crowdin-localization <https://typo3.slack.com/app_redirect?channel=CMUG7C04F>`__.
+    `#typo3-localization-team <https://typo3.slack.com/app_redirect?channel=CR75200FL>`__.
 
 
 General questions


### PR DESCRIPTION
The TYPO3 localization team wants to shut down the Slack channel #cig-crowdin-localization in favor of #typo3-localization-team.