### PR TITLE
Use getRecordType() in PageContentPreviewRenderingEvent example

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_PageContentPreviewRenderingEvent/_MyEventListener.php
@@ -18,7 +18,7 @@ final readonly class MyEventListener
             return;
         }
 
-        if ($event->getRecord()['CType'] === 'example_ctype') {
+        if ($event->getRecordType() === 'example_ctype') {
             $event->setPreviewContent('<div>...</div>');
         }
     }


### PR DESCRIPTION
This method has been introduced with TYPO3 v13. So there is no need anymore to fiddle around with an array.

See: https://github.com/TYPO3/typo3/commit/ecf1093a3ca43855d89518478df3718a363fdd46#diff-dbda3dfe55c459250d90ea41e00474110ec34561d0b1600baf50ce1d00404ed4

Releases: main, 13.4