### PR TITLE
[TASK] Get rid of "resname" attribute in XLF files

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_countries.xlf
+++ b/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_countries.xlf
@@ -2,10 +2,10 @@
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" date="2024-01-08T18:44:59Z" product-name="my_extension">
         <body>
-            <trans-unit id="XX.name" resname="XX.name" approved="yes">
+            <trans-unit id="XX.name" approved="yes">
                 <source>Magic Kingdom</source>
             </trans-unit>
-            <trans-unit id="XX.official_name" resname="XX.official_name" approved="yes">
+            <trans-unit id="XX.official_name" approved="yes">
                 <source>Kingdom of Magic and Wonders</source>
             </trans-unit>
         </body>

--- a/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_de.countries.xlf
+++ b/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_de.countries.xlf
@@ -2,11 +2,11 @@
 <xliff version="1.0">
     <file source-language="en" target-language="de" datatype="plaintext" date="2024-01-08T18:44:59Z" product-name="my_extension">
         <body>
-            <trans-unit id="XX.name" resname="XX.name" approved="yes">
+            <trans-unit id="XX.name" approved="yes">
                 <source>Magic Kingdom</source>
                 <target>Magisches Königreich</target>
             </trans-unit>
-            <trans-unit id="XX.official_name" resname="XX.official_name" approved="yes">
+            <trans-unit id="XX.official_name" approved="yes">
                 <source>Kingdom of Magic and Wonders</source>
                 <target>Königreich der Magie und Wunder</target>
             </trans-unit>

--- a/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_tlh.countries.xlf
+++ b/Documentation/ApiOverview/Events/Events/Core/Country/_BeforeCountriesEvaluatedEvent/_tlh.countries.xlf
@@ -2,11 +2,11 @@
 <xliff version="1.0">
     <file source-language="en" target-language="tlh" datatype="plaintext" date="2024-01-08T18:44:59Z" product-name="my_extension">
         <body>
-            <trans-unit id="XX.name" resname="XX.name" approved="yes">
+            <trans-unit id="XX.name" approved="yes">
                 <source>Magic Kingdom</source>
                 <target>‘oHtaHghach wo’</target>
             </trans-unit>
-            <trans-unit id="XX.official_name" resname="XX.official_name" approved="yes">
+            <trans-unit id="XX.official_name" approved="yes">
                 <source>Kingdom of Magic and Wonders</source>
                 <target>‘oHtaHghach je Dojmey wo’</target>
             </trans-unit>

--- a/Documentation/ApiOverview/Localization/ManagingTranslations.rst
+++ b/Documentation/ApiOverview/Localization/ManagingTranslations.rst
@@ -181,7 +181,7 @@ files.
         <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
             <file source-language="en" target-language="gsw_CH" datatype="plaintext" original="EXT:setup/Resources/Private/Language/locallang.xlf">
                 <body>
-                    <trans-unit id="lang_gsw_CH" resname="lang_gsw_CH" approved="yes">
+                    <trans-unit id="lang_gsw_CH" approved="yes">
                         <source>Swiss German</source>
                         <target>Schwiizertüütsch</target>
                     </trans-unit>

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/Faq.rst
@@ -65,19 +65,7 @@ How to convert to the new language XLIFF file format
 
 If you have :ref:`downloaded an XLIFF file <migrate-from-pootle>` from the
 deactivated Pootle language server or an old version of an extension, then it
-does not have the correct format. You need to remove some attributes. And you
-need to add the :xml:`resname` attribute. For this you can use a Linux tool or a
-sophisticated editor to copy the :xml:`id` attribute into the :xml:`resname` of
-the :ref:`XLIFF <xliff>` file based on regular expressions.
-
-In most editors you can use regular expressions, for example, in PhpStorm:
-
-#.  Open the XLIFF file in the editor.
-#.  Press :kbd:`Ctrl` + :kbd:`R` to open the search and replace pane
-#.  Find: `id="(.+?)"` / Replace: `id="$1" resname="$1"`
-#.  Click the regex icon (:guilabel:`.*`) to enable regular expressions.
-#.  Click on button :guilabel:`Replace All`
-
+does not have the correct format. You need to remove some attributes.
 
 Questions about extension integration
 =====================================

--- a/Documentation/ApiOverview/Localization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Localization/XliffFormat.rst
@@ -35,23 +35,9 @@ Basics
 
 Here is a sample XLIFF file:
 
-..  code-block:: xml
+..  literalinclude:: _snippets/_example.xlf
+    :language: xml
     :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-        <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
-            <header/>
-            <body>
-                <trans-unit id="headerComment" resname="headerComment">
-                    <source>The default Header Comment.</source>
-                </trans-unit>
-                <trans-unit id="generator" resname="generator">
-                    <source>The "Generator" Meta Tag.</source>
-                </trans-unit>
-            </body>
-        </file>
-    </xliff>
 
 The following attributes should be populated properly in order to get the
 best support in external translation tools:
@@ -59,10 +45,8 @@ best support in external translation tools:
 :xml:`original` (in :xml:`<file>` tag)
     This property contains the path to the xlf file.
 
-:xml:`resname` (in :xml:`<trans-unit>` tag)
-    Its content is shown to translators. It should be a copy of the
-    :xml:`id` property.
-
+If the external tool used depends on the attribute `resname` you can also
+define it. TYPO3 does not consider this attribute.
 
 ..  _xliff-translated-file-name:
 
@@ -99,25 +83,9 @@ that contains the translated string.
 
 This is how the translation of our sample file might look like:
 
-..  code-block:: xml
+..  literalinclude:: _snippets/_example2.xlf
+    :language: xml
     :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-        <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
-            <header/>
-            <body>
-                <trans-unit id="headerComment" resname="headerComment" approved="yes">
-                    <source>The default Header Comment.</source>
-                    <target>Der Standard-Header-Kommentar.</target>
-                </trans-unit>
-                <trans-unit id="generator" resname="generator" approved="yes">
-                    <source>The "Generator" Meta Tag.</source>
-                    <target>Der "Generator"-Meta-Tag.</target>
-                </trans-unit>
-            </body>
-        </file>
-    </xliff>
 
 Only one language can be stored per file, and each translation into another
 language is placed in an additional file.
@@ -164,6 +132,8 @@ ID naming
 It is recommended to apply the following rules for defining identifiers (the
 :xml:`id` attribute).
 
+.. _xliff-id-naming-dots:
+
 Separate by dots
 ----------------
 
@@ -184,6 +154,8 @@ Bad examples:
 
 
 ..  index:: XLIFF; Namespace
+
+.. _xliff-id-naming-namespace:
 
 Namespace
 ---------
@@ -208,6 +180,8 @@ Bad example:
 Namespaces should be defined by context.
 ``menuAbstract.CType`` could also be a reasonable namespace
 if the context is about ``menuAbstract``.
+
+.. _xliff-id-naming-lower-camel:
 
 lowerCamelCase
 --------------

--- a/Documentation/ApiOverview/Localization/_de.locallang_modadministration.xlf
+++ b/Documentation/ApiOverview/Localization/_de.locallang_modadministration.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.0">
     <file source-language="en" datatype="plaintext" date="2013-03-09T18:44:59Z" product-name="examples">
         <body>
-            <trans-unit id="pages.title_formlabel" resname="pages.title_formlabel" approved="yes">
+            <trans-unit id="pages.title_formlabel" approved="yes">
                 <source>Most important title</source>
                 <target>Wichtigster Titel</target>
             </trans-unit>

--- a/Documentation/ApiOverview/Localization/_snippets/_example.xlf
+++ b/Documentation/ApiOverview/Localization/_snippets/_example.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+        <header/>
+        <body>
+            <trans-unit id="headerComment">
+                <source>The default Header Comment.</source>
+            </trans-unit>
+            <trans-unit id="generator">
+                <source>The "Generator" Meta Tag.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Documentation/ApiOverview/Localization/_snippets/_example2.xlf
+++ b/Documentation/ApiOverview/Localization/_snippets/_example2.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+        <header/>
+        <body>
+            <trans-unit id="headerComment" approved="yes">
+                <source>The default Header Comment.</source>
+                <target>Der Standard-Header-Kommentar.</target>
+            </trans-unit>
+            <trans-unit id="generator" approved="yes">
+                <source>The "Generator" Meta Tag.</source>
+                <target>Der "Generator"-Meta-Tag.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -797,7 +797,7 @@ configurations.
         ..  code-block:: xml
             :caption: EXT:my_extension/Resources/Private/Language/locallang.xml
 
-            <trans-unit id="label2" resname="label2" approved="yes">
+            <trans-unit id="label2" approved="yes">
                 <source>This is label #2</source>
                 <target>Ceci est le libellé no. 2</target>
             </trans-unit>


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1167
See: https://forge.typo3.org/issues/105647
Releases: main, 13.4, 12.4