### PR TITLE
Update CreateModuleWithExtbase.rst

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
@@ -67,7 +67,15 @@ After that you can add titles, menus and buttons using :php:`ModuleTemplate`:
     {
         $this->view->assign('someVar', 'someContent');
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
-        // Adding title, menus, buttons, etc. using $moduleTemplate ...
+
+        // Example of adding a page-shortcut button
+        $routeIdentifier = 'web_examples'; // array-key of the module-configuration
+        $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
+        $shortcutButton = $buttonBar->makeShortcutButton()->setDisplayName('Shortcut to my action')->setRouteIdentifier($routeIdentifier);
+        $shortcutButton->setArguments(['controller' => 'MyController', 'action' => 'my']);
+        $buttonBar->addButton($shortcutButton, ButtonBar::BUTTON_POSITION_RIGHT);
+        // Adding title, menus and more buttons using $moduleTemplate ...
+
         $moduleTemplate->setContent($this->view->render());
         return $this->htmlResponse($moduleTemplate->renderContent());
     }


### PR DESCRIPTION
Extend the code example how to create links to Extbase controller actions in modules. It is not obvious based on the current documentation, that the array-key of the new module-configuration must be used, plus passing the controller and action name as arguments.

The issue was solved in Slack (thanks Garvin!) and is now added here for future use.