### PR TITLE
Fixed TypoScript imports

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/_Sets/_site-package/_setup.rst.txt
+++ b/Documentation/ApiOverview/SiteHandling/_Sets/_site-package/_setup.rst.txt
@@ -4,5 +4,5 @@
 ..  code-block:: typoscript
     :caption: EXT:site_package/Configuration/Sets/SitePackage/setup.typoscript
 
-    @import './TypoScript/*.typoscript'
-    @import './TypoScript/Navigation/*.typoscript'
+    @import 'EXT:site_package/Configuration/TypoScript/*.typoscript'
+    @import 'EXT:site_package/Configuration/TypoScript/Navigation/*.typoscript'


### PR DESCRIPTION
The documentation for this code snippet states the following: `These TypoScript files use @import statements to import files from the extension's directory Configuration/TypoScript`. The code snippet does however not import from `Configuration/TypoScript` folder, but from the relative path (defined by the dot) in the current directory (`EXT:site_package/Configuration/Sets/SitePackage/`).

