### PR TITLE
(Cherry pick main) Update CreateModuleWithExtbase.rst - rendering example is broken (#5150)

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
@@ -59,8 +59,10 @@ After that you can add titles, menus and buttons using :php:`ModuleTemplate`:
     // use Psr\Http\Message\ResponseInterface
     public function myAction(): ResponseInterface
     {
-        $this->view->assign('someVar', 'someContent');
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+
+        // Example of assignung variables to the view 
+        $moduleTemplate->assign('someVar', 'someContent');
 
         // Example of adding a page-shortcut button
         $routeIdentifier = 'web_examples'; // array-key of the module-configuration
@@ -70,7 +72,6 @@ After that you can add titles, menus and buttons using :php:`ModuleTemplate`:
         $buttonBar->addButton($shortcutButton, ButtonBar::BUTTON_POSITION_RIGHT);
         // Adding title, menus and more buttons using $moduleTemplate ...
 
-        $moduleTemplate->setContent($this->view->render());
         return $moduleTemplate->renderResponse('MyController/MyAction');
     }
 


### PR DESCRIPTION
ModuleTemplate->setContent() does not exist.
It comes with its own view.

Cherry picking into main https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/5150