### PR TITLE
Raise requirement for "languageId: 0" in each site

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -61,8 +61,8 @@ Configuration properties
     :Example: :yaml:`1`
 
     For the default/main language of the given site, use value :yaml:`0`. For
-    additional languages use a number greater than :yaml:`0`. Every site should
-    have at last one language configured - with :yaml:`languageId: 0`.
+    additional languages use a number greater than :yaml:`0`. Every site must
+    have at last one language configured with :yaml:`languageId: 0`.
 
     ..  attention::
         Once pages, content or records are created in a specific language, the


### PR DESCRIPTION
As tests have shown, it is not possible to have a site without a "languageId: 0" language. Various places in the TYPO3 backend will complain about missing pages/records.