### PR TITLE
[DOCS] Document how the page tree can be changed

### DIFF
--- a/Documentation/ApiOverview/Backend/PageTree.rst
+++ b/Documentation/ApiOverview/Backend/PageTree.rst
@@ -20,7 +20,7 @@ Usage of the page tree is described in
 The page tree can also be navigated via `Keyboard commands (Tutorial for
 Editors) <https://docs.typo3.org/permalink/t3editors:keyboard-commands>`_.
 
-..  contents::
+..  contents:: Table of contents
 
 ..  _page-tree-events:
 

--- a/Documentation/ApiOverview/Backend/PageTree.rst
+++ b/Documentation/ApiOverview/Backend/PageTree.rst
@@ -1,0 +1,42 @@
+:navigation-title: Page tree
+..  include:: /Includes.rst.txt
+..  _page-tree:
+
+==================================
+The page tree in the TYPO3 backend
+==================================
+
+The **page** tree is a hierarchical structure that represents pages and their
+subpages on a website, allowing editors and integrators to easily organize and
+manage content and navigation.
+
+It is displayed on the left of backend modules with
+:ref:`navigationComponent <t3coreapi:confval-backend-module-navigationcomponent>`
+set to `'@typo3/backend/tree/page-tree-element'`.
+
+Usage of the page tree is described in
+`Getting Started Tutorial, Page tree <https://docs.typo3.org/permalink/t3start:page-tree>`_.
+
+The page tree can also be navigated via `Keyboard commands (Tutorial for
+Editors) <https://docs.typo3.org/permalink/t3editors:keyboard-commands>`_.
+
+..  contents::
+
+..  _page-tree-events:
+
+PSR-14 events to influence the functionality of the page tree
+=============================================================
+
+:ref:`AfterPageTreeItemsPreparedEvent`
+    Allows prepared page tree items to be modified.
+:ref:`AfterRawPageRowPreparedEvent`
+    Allows to modify the populated properties of a page and children records
+    before the page is displayed in a page tree.
+
+..  _page-tree-tsconfig:
+
+TsConfig settings to influence the page tree
+============================================
+
+The rendering of the page tree can be influenced via user TsConfig
+:ref:`options.pageTree <t3tsref:confval-useroptions-pagetree>`.

--- a/Documentation/ApiOverview/Backend/PageTree.rst
+++ b/Documentation/ApiOverview/Backend/PageTree.rst
@@ -6,7 +6,7 @@
 The page tree in the TYPO3 backend
 ==================================
 
-The **page** tree is a hierarchical structure that represents pages and their
+The **page tree** is a hierarchical structure that represents pages and their
 subpages on a website, allowing editors and integrators to easily organize and
 manage content and navigation.
 


### PR DESCRIPTION
As there are more and more events now and also still page tsconfig it makes sense to give its own page to the page tree.

Related https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1184

Releases: main, 13.4