### PR TITLE
Fix Text Role

### DIFF
--- a/Documentation/ApiOverview/ErrorAndExceptionHandling/Examples/Index.rst
+++ b/Documentation/ApiOverview/ErrorAndExceptionHandling/Examples/Index.rst
@@ -139,7 +139,7 @@ In :file:`config/system/settings.php` or :file:`config/system/additional.php`:
     the `Writer configuration <https://docs.typo3.org/permalink/t3coreapi:logging-configuration-writer>`_ of the Logging API. 
     In production or from a performance perspective, you may not want this. 
     The default value is :php:`\Psr\Log\LogLevel::WARNING`. 
-    Depending on project requirements, the loglevel can be increased to :PHP:`\Psr\Log\LogLevel::ERROR`
+    Depending on project requirements, the loglevel can be increased to :php:`\Psr\Log\LogLevel::ERROR`
     (or higher).
 
 In :file:`.htaccess`:


### PR DESCRIPTION
Uppercase-written TextRoles are not (or in another way) interpreted. Concretely, for PR  #5214, backslashes have been swallowed.

Related: #5214