### PR TITLE
fix: correct method name in changelog to CacheDataCollector

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
@@ -96,7 +96,7 @@ Example: Get minimum lifetime, calculated from all cache tags
     :caption: Get minimum lifetime, calculated from all cache tags
 
     $cacheDataCollector = $request->getAttribute('frontend.cache.collector');
-    $cacheDataCollector->getLifetime();
+    $cacheDataCollector->resolveLifetime();
 
 
 ..  _typo3-request-attribute-frontend-cache-collector-example-get-all-cache-tags:


### PR DESCRIPTION
There is no method "getLifetime()" in the CacheDataCollector. Instead, it should be "resolveLifetime()" which returns the minimum lifetime of all defined cache tags.

Related: https://review.typo3.org/c/Packages/TYPO3.CMS/+/87840
Releases: main, 13.4