### PR TITLE
fix: add missing step in legacy installation

### DIFF
--- a/Documentation/Administration/Installation/LegacyInstallation.rst
+++ b/Documentation/Administration/Installation/LegacyInstallation.rst
@@ -47,6 +47,7 @@ Installing on a Unix Server
    .. code-block:: bash
       :caption: /var/www/site/$
 
+      mkdir public
       cd public
       ln -s ../typo3_src-13.x.y typo3_src
       ln -s typo3_src/index.php index.php


### PR DESCRIPTION
Before changing to a "public" directory, that directory must be created.