### PR TITLE
chore: use CacheDataCollector for adding cache tags in DataHandler chapter

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -624,6 +624,14 @@ custom ViewHelper):
     :language: php
     :caption: EXT:my_extension/Classes/Controller/SomeController.php
 
+..  versionadded:: 13.3
+    The :ref:`frontend.cache.collector <typo3-request-attribute-frontend-cache-collector>`
+    request attribut has been introduced as a successor of the now deprecated
+    :php:`TypoScriptFrontendController->addCacheTags()` method. Switch to
+    another version of this page for an example in an older TYPO3 version. For
+    compatibility with TYPO3 v12 and v13 use
+    :php:`TypoScriptFrontendController->addCacheTags()`.
+
 Hook for cache post-processing
 ------------------------------
 

--- a/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
+++ b/Documentation/ApiOverview/DataHandler/Database/_SomeController.php
@@ -6,8 +6,9 @@ namespace MyVendor\MyExtension\Controller;
 
 use MyVendor\MyExtension\Domain\Model\ExampleModel;
 use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Cache\CacheDataCollector;
+use TYPO3\CMS\Core\Cache\CacheTag;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 final class SomeController extends ActionController
 {
@@ -15,11 +16,11 @@ final class SomeController extends ActionController
     {
         // ...
 
-        /** @var TypoScriptFrontendController $frontendController */
-        $frontendController = $this->request->getAttribute('frontend.controller');
-        $frontendController->addCacheTags([
-            sprintf('tx_myextension_example_%d', $example->getUid()),
-        ]);
+        /** @var CacheDataCollector $cacheDataCollector */
+        $cacheDataCollector = $this->request->getAttribute('frontend.cache.collector');
+        $cacheDataCollector->addCacheTags(
+            new CacheTag(sprintf('tx_myextension_example_%d', $example->getUid())),
+        );
 
         // ...
     }


### PR DESCRIPTION
This API was introduced with TYPO3 v13.3 and is a successor of `TypoScriptFrontendController->addCacheTags()`.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1042
Releases: main, 13.4