### PR TITLE
[TASK] List common configuration file locations as files (#5283)

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst
@@ -1,13 +1,15 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Extension development; Configuration/Backend
-   Path; EXT:{extkey}/Configuration/Backend
+:navigation-title: Backend
 
-.. _extension-configuration-backend:
+..  include:: /Includes.rst.txt
+..  index::
+    Extension development; Configuration/Backend
+    Path; EXT:{extkey}/Configuration/Backend
 
-===============
-:file:`Backend`
-===============
+..  _extension-configuration-backend:
+
+========================================
+Extension folder `Configuration/Backend`
+========================================
 
 The folder :file:`EXT:my_extension/Configuration/Backend/` may contain
 configuration that is important within the TYPO3 Backend.
@@ -15,46 +17,47 @@ configuration that is important within the TYPO3 Backend.
 All files in this directory are automatically included during the TYPO3
 bootstrap.
 
-.. _extension-configuration-backend-ajaxroutes:
+..  _extension-configuration-backend-ajaxroutes:
 
-:file:`AjaxRoutes.php`
-======================
+..  typo3:file:: AjaxRoutes.php
+    :scope: extension
+    :path: /Configuration/Backend/
+    :regex: /^.*Configuration\/Backend\/AjaxRoutes\.php$/
+    :shortDescription: Defines routes for backend Ajax requests
 
-Complete path: :file:`EXT:my_extension/Configuration/Backend/AjaxRoutes.php`
+    In this file routes for Ajax requests that should be used in the backend can
+    be defined.
 
-In this file routes for Ajax requests that should be used in the backend can
-be defined.
+    Read more about :ref:`Using Ajax in the backend <ajax-backend>`.
 
-Read more about :ref:`Using Ajax in the backend <ajax-backend>`.
+..  include:: /CodeSnippets/Manual/Extension/Configuration/BackendAjaxRoutes.rst.txt
 
-.. include:: /CodeSnippets/Manual/Extension/Configuration/BackendAjaxRoutes.rst.txt
+..  _extension-configuration-backend-routes:
 
+..  typo3:file:: Routes.php
+    :scope: extension
+    :path: /Configuration/Backend/
+    :regex: /^.*Configuration\/Backend\/Routes\.php$/
+    :shortDescription: Defines routes for backend controllers
 
-.. _extension-configuration-backend-routes:
+    This file maps the URI paths used in the backend to the controller that should
+    be used.
 
-:file:`Routes.php`
-==================
+    Most backend routes defined in the TYPO3 core can be found in the following
+    file, which you can use as example:
 
-Complete path: :file:`EXT:my_extension/Configuration/Backend/Routes.php`
+    :t3src:`backend/Configuration/Backend/Routes.php`
 
-This file maps from paths used in the backend to the controller that should
-be used.
+    Read more about :ref:`Backend routing <backend-routing>`.
 
-Most backend routes defined in the TYPO3 core can be found in the following
-file, which you can use as example:
+..  _extension-configuration-backend-modules:
 
-:t3src:`backend/Configuration/Backend/Routes.php`
+..  typo3:file:: Modules.php
+    :scope: extension
+    :path: /Configuration/Backend/
+    :regex: /^.*Configuration\/Backend\/Modules\.php$/
+    :shortDescription: Defines the backend module configuration
 
-Read more about :ref:`Backend routing <backend-routing>`.
-
-
-.. _extension-configuration-backend-modules:
-
-:file:`Modules.php`
-====================
-
-Complete path: :file:`EXT:my_extension/Configuration/Backend/Modules.php`.
-
-This file is used for the
-:ref:`Backend module configuration <backend-modules-configuration>`. See that
-chapter for details.
+    This file is used for the
+    :ref:`Backend module configuration <backend-modules-configuration>`. See that
+    chapter for details.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/ContentSecurityPolicies.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/ContentSecurityPolicies.rst
@@ -8,10 +8,16 @@
 :file:`ContentSecurityPolicies.php`
 ===================================
 
-.. versionadded:: 12.3
+..  typo3:file:: ContentSecurityPolicies.php
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/ContentSecurityPolicies\.php$/
+    :shortDescription: Provides Content Security Policies for frontend and backend.
 
-This file provides :ref:`Content Security Policies <content-security-policy>`
-for frontend and backend.
+    ..  versionadded:: 12.3
 
-For details see the chapter about
-:ref:`Extension-specific Content Security Policy <content-security-policy-extension>`.
+    This file provides :ref:`Content Security Policies <content-security-policy>`
+    for frontend and backend.
+
+    For details see the chapter about
+    :ref:`Extension-specific Content Security Policy <content-security-policy-extension>`.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Index.rst
@@ -1,10 +1,10 @@
 .. include:: /Includes.rst.txt
-.. _extension-configuration-extbase:
-.. index:: Path; EXT:{extkey}/Configuration/Extbase
+..  _extension-configuration-extbase:
+..  index:: Path; EXT:{extkey}/Configuration/Extbase
 
-================================
-:file:`Extbase`
-================================
+=========
+`Extbase`
+=========
 
 This configuration folder can contain the following subfolders:
 

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Persistence/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Persistence/Index.rst
@@ -8,12 +8,17 @@
 
 This folder can contain the following files:
 
-:file:`Classes.php`
-===================
+..  _extension-configuration-extbase-persistence-classes:
 
-In the file :file:`EXT:my_extension/Configuration/Extbase/Persistence/Classes.php` the
-mapping between a database table and its model can be configured. The mapping
-in this file overrides the automatic mapping by naming convention.
+..  typo3:file:: Classes.php
+    :scope: extension
+    :path: /Configuration/Extbase/Persistence/Classes.php
+    :regex: /^.*Configuration\/Extbase\/Persistence\/Classes\.php$/
+    :shortDescription: Contains the mapping between a database table and its Extbase model
 
-..  seealso::
-    :ref:`Connecting the model to the database <extbase-Persistence>`
+    In the file :file:`EXT:my_extension/Configuration/Extbase/Persistence/Classes.php` the
+    mapping between a database table and its model can be configured. The mapping
+    in this file overrides the automatic mapping by naming convention.
+
+    ..  seealso::
+        :ref:`Connecting the model to the database <extbase-Persistence>`

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Icons.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Icons.rst
@@ -8,10 +8,16 @@
 :file:`Icons.php`
 =================
 
-In this file custom icons can be registered in the
-:php:`\TYPO3\CMS\Core\Imaging\IconRegistry`.
+..  typo3:file:: Icons.php
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/Icons\.php$/
+    :shortDescription: Registration of custom icons
 
-See the :ref:`Icon API <icon>` for details.
+    In this file custom icons can be registered in the
+    :php:`\TYPO3\CMS\Core\Imaging\IconRegistry`.
+
+    See the :ref:`Icon API <icon>` for details.
 
 ..  literalinclude:: /ApiOverview/Icon/_Icons.php
     :language: php

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Index.rst
@@ -1,3 +1,5 @@
+:navigation-title: Configuration
+
 ..  include:: /Includes.rst.txt
 ..  index::
     Extension development; File name conventions
@@ -5,9 +7,9 @@
 ..  _extension-files-configuration:
 ..  _extension-configuration-files:
 
-======================
-:file:`Configuration`
-======================
+================================
+Extension folder `Configuration`
+================================
 
 The folder :file:`EXT:my_extension/Configuration/` may contain
 configuration of different types.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/PageTsconfig.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/PageTsconfig.rst
@@ -13,11 +13,17 @@
    :file:`Configuration/page.tsconfig` is automatically included for all
    pages.
 
-In this file global page TSconfig can be stored. It will be automatically
-included for all pages.
+..  typo3:file:: page.tsconfig
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/page\.tsconfig$/
+    :shortDescription: Global page TSconfig
 
-For details see
-:ref:`Setting the page TSconfig globally <t3tsref:pagesettingdefaultpagetsconfig>`.
+    In this file global page TSconfig can be stored. It will be automatically
+    included for all pages.
+
+    For details see
+    :ref:`Setting the page TSconfig globally <t3tsref:pagesettingdefaultpagetsconfig>`.
 
 
 .. code-block:: typoscript

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/RequestMiddlewaresPhp.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/RequestMiddlewaresPhp.rst
@@ -9,13 +9,17 @@
 :file:`RequestMiddlewares.php`
 ================================
 
-Full path to this file is: :file:`Configuration/RequestMiddlewares.php`.
+..  typo3:file:: RequestMiddlewares.php
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/RequestMiddlewares\.php$/
+    :shortDescription: Configuration of user-defined middlewares for frontend and backend
 
-Configuration of user-defined middlewares for frontend and backend. Extensions
-that add middlewares or disable existing middlewares configure them in this
-file. The file must return an array with the configuration.
+    Configuration of custom middleware for frontend and backend. Extensions that
+    add middleware or disable existing middleware are configured in this file. The
+    file must return an array with the configuration.
 
-See :ref:`Configuring middlewares <request-handling-configuring-middlewares>`
-for details.
+    See :ref:`Configuring middlewares <request-handling-configuring-middlewares>`
+    for details.
 
-.. include:: /CodeSnippets/Manual/Extension/Configuration/RequestMiddlewares.rst.txt
+..  include:: /CodeSnippets/Manual/Extension/Configuration/RequestMiddlewares.rst.txt

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst
@@ -1,12 +1,26 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Extension development; Configuration/Services.yaml
-   Path; EXT:{extkey}/Configuration/Services.yaml
-.. _extension-configuration-services-yaml:
+..  include:: /Includes.rst.txt
+..  index::
+    Extension development; Configuration/Services.yaml
+    Path; EXT:{extkey}/Configuration/Services.yaml
+..  _extension-configuration-services-yaml:
 
-================================
-:file:`Services.yaml`
-================================
+===============
+`Services.yaml`
+===============
+
+It is possible to use a YAML or PHP format:
+
+..  typo3:file:: Services.yaml
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/Services\.yaml$/
+    :shortDescription: Dependency injection service configuration
+
+..  typo3:file:: Services.php
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/Services\.php$/
+    :shortDescription: Dependency injection service configuration
 
 Services can be configured in this file. TYPO3 uses it for:
 

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst
@@ -1,15 +1,17 @@
+:navigation-title: TCA
+
 ..  include:: /Includes.rst.txt
 ..  index::
     Extension development; Configuration/TCA
     Path; EXT:{extkey}/Configuration/TCA
 ..  _extension-configuration-tca:
 
-===========
-:file:`TCA`
-===========
+====================================
+Extension folder `Configuration/TCA`
+====================================
 
 The folder :file:`EXT:my_extension/Configuration/TCA/` may contain or override
-:ref:`TCA (TYPO3 configuration array) <t3tca:introduction>` data.
+:ref:`TCA (Table Configuration Array) <t3tca:introduction>` data.
 
 All files in this directory are automatically included during the TYPO3
 :ref:`bootstrap <bootstrapping>`.
@@ -24,21 +26,36 @@ All files in this directory are automatically included during the TYPO3
         with the risk of a leakage to the following files. The use of :php:`call_user_func()`
         wrap was a common workaround.
 
-:file:`<tablename>.php`
-=======================
+..  _extension-configuration-tca-table:
 
-One file per database table, using the name of the table for the file, plus
-".php". Only for new tables.
+`Configuration/TCA/<tablename>.php`
+===================================
 
+..  typo3:file:: <tablename>.php
+    :name: configuration-tca
+    :scope: extension
+    :path: /Configuration/TCA
+    :regex: /^.*Configuration\/TCA\/.*\.php$/
+    :shortDescription: Contains the TCA (Table Configuration Array), which initially defines the table <tablename>. Change TCA of existing tables in directory TCA/Overrides
+
+    One file per database table, using the name of the table for the file, plus
+    ".php". Only for new tables, provided by the extension itself. **Must not** be used to change existing tables provided by other extensions.
 
 ..  index:: Path; EXT:{extkey}/Configuration/TCA/Overrides
 ..  _extension-configuration-tca-overrides:
 
-:file:`Overrides`
-=================
+`Configuration/TCA/Overrides/somefile.php`
+==========================================
 
-For extending existing tables.
+..  typo3:file:: somefile.php
+    :name: configuration-tca-overrides
+    :scope: extension
+    :path: /Configuration/TCA/Overrides
+    :regex: /^.*Configuration\/TCA\/Overrides\/.*\.php$/
+    :shortDescription: Extends the TCA (Table Configuration Array) of a table
 
-General advice: One file per database table, using the name of the table for the
-file, plus :file:`.php`. For more information, see the chapter
-:ref:`Extending the TCA array <storing-changes-extension>`.
+    For extending existing tables.
+
+    General advice: One file per database table, using the name of the table for the
+    file, plus :file:`.php`. For more information, see the chapter
+    :ref:`Extending the TCA array <storing-changes-extension>`.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TsConfig/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TsConfig/Index.rst
@@ -2,18 +2,26 @@
 .. _extension-configuration-tsconfig:
 .. index:: Path; EXT:{extkey}/Configuration/TsConfig
 
-================================
+================
 :file:`TsConfig`
-================================
+================
 
-Configuration/TsConfig/Page
-  page TSconfig, see chapter :ref:`'page TSconfig' in the TSconfig Reference
-  <t3tsref:PageTSconfig>`. Files should have the file extension
-  :file:`.tsconfig`.
+..  typo3:file:: something.tsconfig
+    :scope: extension
+    :path: /Configuration/TsConfig/Page
+    :regex: /^.*Configuration\/TsConfig\/Page\/.*\.tsconfig$/
+    :shortDescription: Contains page TSconfig files. The path is convention, the files must end on .tsconfig.
 
-.. index:: Path; EXT:{extkey}/Configuration/TsConfig/User
+    page TSconfig, see chapter :ref:`'page TSconfig' in the TSconfig Reference
+    <t3tsref:PageTSconfig>`. Files should have the file extension
+    :file:`.tsconfig`.
 
-Configuration/TsConfig/User
-  User TSconfig, see chapter :ref:`'user TSconfig' in the TSconfig Reference
-  <t3tsref:UserTSconfig>`. Files should have the file extension
-  :file:`.tsconfig`.
+..  typo3:file:: something.tsconfig
+    :scope: extension
+    :path: /Configuration/TsConfig/User
+    :regex: /^.*Configuration\/TsConfig\/User\/.*\.tsconfig$/
+    :shortDescription: Contains user TSconfig files. The path is convention, the files must end on .tsconfig.
+
+    User TSconfig, see chapter :ref:`'user TSconfig' in the TSconfig Reference
+    <t3tsref:UserTSconfig>`. Files must have the file extension
+    :file:`.tsconfig`.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/TypoScript/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/TypoScript/Index.rst
@@ -4,9 +4,9 @@
    Path; EXT:{extkey}/Configuration/TypoScript
 .. _extension-configuration-typoscript:
 
-================================
+==================
 :file:`TypoScript`
-================================
+==================
 
 By convention all TypoScript, that can be included manually, should
 be stored in the folder :file:`EXT:my_extension/Configuration/TypoScript/`.
@@ -19,74 +19,31 @@ be stored in the folder :file:`EXT:my_extension/Configuration/TypoScript/`.
 TypoScript constants should be stored in a file called :file:`constants.typoscript`
 and TypoScript setup in a file called :file:`setup.typoscript`.
 
-.. code-block:: none
-   :caption: TypoScript folder
+..  typo3:file:: constants.typoscript
+    :scope: extension
+    :path: /Configuration/TypoScript
+    :regex: /^.*Configuration\/TypoScript\/.*constants\.typoscript/
+    :shortDescription: Contains the TypoScript constants of the extension. The path is convention, the file name mandatory.
 
-   $ tree packages/my_extension/Configuration/TypoScript/
-   ├── constants.typoscript
-   └── setup.typoscript
+..  typo3:file:: setup.typoscript
+    :scope: extension
+    :path: /Configuration/TypoScript
+    :regex: /^.*Configuration\/TypoScript\/.*setup\.typoscript/
+    :shortDescription: Contains the TypoScript setup of the extension. The path is convention, the file name mandatory.
 
-These two files will be included via
+These two files are made available for inclusion in TypoScript records with
 :php:`ExtensionManagementUtility::addStaticFile` in the file
 :file:`Configuration/TCA/Overrides/sys_template.php`:
 
-.. code-block:: php
+.. literalinclude:: _snippets/_sys_template.php
    :caption: EXT:my_extension/Configuration/TCA/Overrides/sys_template.php
 
-   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-       'my_extension',
-       'Configuration/TypoScript/',
-       'Examples TypoScript'
-   );
+It is also possible to use subfolders or a differently named folder. The file
+names have to stay exactly the same including case.
 
-If there should be more then one set of TypoScript templates that may be
-included, you can use store them in sub folders.
-
-If your TypoScript is complex and you need to break it up into several files
-you should use the ending :file:`.typoscript` for these files.
-
-.. code-block:: none
-   :caption: TypoScript folder, extended
-
-   $ tree packages/my_extension/Configuration/TypoScript/
-   ├── Example1
-   │    ├── constants.typoscript
-   │    └── setup.typoscript
-   ├── SpecialFeature2
-   │    ├── Setup
-   │    │    ├── SomeIncludes.typoscript
-   │    │    └── OtherIncludes.typoscript
-   │    ├── constants.typoscript
-   │    └── setup.typoscript
-   ├── constants.typoscript
-   └── setup.typoscript
-
-In this case :php:`ExtensionManagementUtility::addStaticFile` needs to be called
-for each folder that should be available in the TypoScript template record:
-
-.. code-block:: php
-   :caption: EXT:my_extension/Configuration/TCA/Overrides/sys_template.php
-
-   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-       'my_extension',
-       'Configuration/TypoScript/',
-       'My Extension - Main TypoScript'
-   );
-
-   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-       'my_extension',
-       'Configuration/TypoScript/Example1/',
-       'My Extension - Additional example 1'
-   );
-
-   \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-       'my_extension',
-       'Configuration/TypoScript/SpecialFeature2/',
-       'My Extension - Some special feature'
-   );
-
-.. note::
-   For historic reasons you might still see filenames like :file:`setup.ts` and
-   :file:`setup.txt`. For backward compatibility reasons these are still
-   included by :php:`ExtensionManagementUtility::addStaticFile`. However all
-   new TypoScript files should have the file ending :file:`.typoscript`.
+..  warning::
+    In Sites that use no Site set it is possible, though not recommended,
+    to provide TypoScript that is always included.
+    See :ref:`ext_typoscript_constants_typoscript` and
+    :ref:`ext_typoscript_setup_typoscript`. These files are not included when
+    site uses a set.

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/UserTsconfig.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/UserTsconfig.rst
@@ -1,0 +1,26 @@
+..  include:: /Includes.rst.txt
+..  index::
+    Extension development; Configuration/user.tsconfig
+    Path; EXT:{extkey}/Configuration/user.tsconfig
+..  _extension-configuration-user_tsconfig:
+
+=====================
+:file:`user.tsconfig`
+=====================
+
+..  typo3:file:: user.tsconfig
+    :scope: extension
+    :path: /Configuration/
+    :regex: /^.*Configuration\/user\.tsconfig$/
+    :shortDescription: Global user TSconfig
+
+In this file global :ref:`user TSconfig <t3tsref:usertsconfig>` can be stored. It will
+be automatically included for the whole TYPO3 installation during build time.
+
+For details see
+:ref:`Setting the user TSconfig globally <t3tsref:usersettingdefaultusertsconfig>`.
+
+..  code-block:: typoscript
+    :caption: EXT:my_extension/Configuration/user.tsconfig
+
+    page.TCEMAIN.table.pages.disablePrependAtCopy = 1


### PR DESCRIPTION
* [TASK] List common configuration file locations as files

This uses the new rst feature https://github.com/TYPO3-Documentation/render-guides/pull/898

Releases: main, 13.4, 12.4

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/Backend/Index.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/ContentSecurityPolicies.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/Extbase/Index.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/RequestMiddlewaresPhp.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/TsConfig/Index.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/TsConfig/Index.rst

* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/TypoScript/Index.rst

* Apply suggestions from code review



* Apply suggestions from code review



* Update Documentation/ExtensionArchitecture/FileStructure/Configuration/TCA/Index.rst

---------