### PR TITLE
[DOCS] Fix confvals syntax structure in BE.rst

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -22,9 +22,8 @@ the TYPO3 backend:
 
 ..  confval-menu::
     :name: globals-typo3-conf-vars-be
-    :display: tree
+    :display: table
     :type:
-    :Default: max=50
 
 ..  _typo3ConfVars_be_fileadminDir:
 


### PR DESCRIPTION
Wrong settings in confvals destroyed table view.

Backports needed: 12, 13