### PR TITLE
Update create page type documentation #5050

### DIFF
--- a/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
+++ b/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
@@ -16,58 +16,83 @@ the directions below to the end:
 ..  versionchanged:: 12.0
     A new :php:`PageDoktypeRegistry` was introduced replacing the
     :php:`$GLOBALS['PAGES_TYPES']` array. Use the version selector to look up
-    the syntax in the corresponding documentation version for older TYPO3 versions.
+    the syntax in the corresponding documentation version for older
+    TYPO3 versions.
 
-The first step is to add the new page type to the
-:php:`\TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry`. Then you need to add
-the icon chosen for the new page type and allow users to drag and drop the new
-page type to the page tree.
+..  rst-class:: bignums
 
-The new page type is added to the :php:`PageDoktypeRegistry` in
-:file:`ext_tables.php`:
+1.  Add new page type to :php:`PageDoktypeRegistry`
 
-..  literalinclude:: _ext_tables.php
-    :language: php
-    :caption: EXT:examples/ext_tables.php
+    The new page type has to be added to the
+    :php:`\TYPO3\CMS\Core\DataHandling\PageDoktypeRegistry`. TYPO3 uses this
+    registry internally to only allow specific tables to be inserted on that
+    page type. This registry will not add or modify any TCA. In example below
+    all kind of tables (`*`) are allowed to be inserted on the new page type.
 
-We need to add the following :ref:`user TSconfig <t3tsref:usertsconfig>`
-to all users, so that the new page type is displayed in the wizard:
+    The new page type is added to the :php:`PageDoktypeRegistry` in
+    :file:`ext_tables.php`:
 
-..  literalinclude:: _user.tsconfig
-    :language: typoscript
-    :caption: EXT:examples/Configuration/user.tsconfig
+    ..  literalinclude:: _ext_tables.php
+        :language: php
+        :caption: EXT:examples/ext_tables.php
 
-The :ref:`icon <icon>` is registered in :file:`Configuration/Icons.php`:
+2.  Add an icon chosen for the new page type
 
-..  literalinclude:: _Icons.php
-    :language: php
-    :caption: EXT:examples/Configuration/Icons.php
+    You need to add the icon chosen for the new page type and allow users to
+    drag and drop the new page type to the page tree.
 
-Furthermore we need to modify the configuration of page records. As one can modify the pages, we
-need to add the new doktype as an select option and associate it with the configured icon. That is done in
-:file:`Configuration/TCA/Overrides/pages.php`:
+    We need to add the following :ref:`user TSconfig <t3tsref:usertsconfig>`
+    to all users, so that the new page type is displayed in the wizard:
 
+    ..  literalinclude:: _user.tsconfig
+        :language: typoscript
+        :caption: EXT:examples/Configuration/user.tsconfig
 
-..  literalinclude:: _pages.php
-    :language: php
-    :caption: EXT:examples/Configuration/TCA/Overrides/pages.php
+    The :ref:`icon <icon>` is registered in :file:`Configuration/Icons.php`:
 
-As you can see from the example, to make sure you get the correct icons,
-you can utilize :php:`typeicon_classes`.
+    ..  literalinclude:: _Icons.php
+        :language: php
+        :caption: EXT:examples/Configuration/Icons.php
 
-It is possible to define additional type icons for special case pages:
+    It is possible to define additional type icons for special case pages:
 
-*   Page contains content from another page `<doktype>-contentFromPid`,
-    For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-contentFromPid']`.
-*   Page is hidden in navigation `<doktype>-hideinmenu`
-    For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-hideinmenu']`.
-*   Page is the root of the site `<doktype>-root`
-    For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-root']`.
+    *   Page contains content from another page `<doktype>-contentFromPid`,
+        For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-contentFromPid']`.
+    *   Page is hidden in navigation `<doktype>-hideinmenu`
+        For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-hideinmenu']`.
+    *   Page is the root of the site `<doktype>-root`
+        For example: :php:`$GLOBALS['TCA']['pages']['ctrl']['typeicon_classes']['116-root']`.
 
-..  note::
+    ..  note::
 
-    Make sure to add the additional icons using the :ref:`Icon API <icon>`!
+        Make sure to add the additional icons using the :ref:`Icon API <icon>`!
 
+3.  Add new page type to doktype selector
+
+    We need to modify the configuration of page records. As one can modify the
+    pages, we need to add the new doktype as a select option and associate it
+    with the configured icon. That is done in
+    :file:`Configuration/TCA/Overrides/pages.php`:
+
+    ..  literalinclude:: _pages.php
+        :language: php
+        :caption: EXT:examples/Configuration/TCA/Overrides/pages.php
+
+    As you can see from the example, to make sure you get the correct icons,
+    you can utilize :php:`typeicon_classes`.
+
+4.  Define your own columns for new page type
+
+    By default the new page type will render all columns of default
+    page type (`DEFAULT (1)`). If you want to chose your own columns you have
+    to copy over all columns from default page type:
+
+    ..  literalinclude:: _pagesCopyDefaultPageType.php
+        :language: php
+        :caption: EXT:examples/Configuration/TCA/Overrides/pages.php
+
+    Now you can modify TCA with Core API like
+    :php:`ExtensionManagementUtility::addToAllTCAtypes();`
 
 Further Information
 -------------------

--- a/Documentation/ApiOverview/PageTypes/_pages.php
+++ b/Documentation/ApiOverview/PageTypes/_pages.php
@@ -19,6 +19,7 @@ defined('TYPO3') or die();
             'group' => 'special',
         ],
     );
+
     // Add the icon to the icon class configuration
     $GLOBALS['TCA']['pages']['ctrl']['typeicon_classes'][$customPageDoktype] = $customIconClass;
 })();

--- a/Documentation/ApiOverview/PageTypes/_pagesCopyDefaultPageType.php
+++ b/Documentation/ApiOverview/PageTypes/_pagesCopyDefaultPageType.php
@@ -1,0 +1,12 @@
+<?php
+
+defined('TYPO3') or die();
+
+// encapsulate all locally defined variables
+(function () {
+    // ...code from previous example
+
+    // Copy over all columns from default page type to allow TCA modifications
+    // with f.e. ExtensionManagementUtility::addToAllTCAtypes()
+    $GLOBALS['TCA']['pages']['types'][116] = $GLOBALS['TCA']['pages']['types'][1];
+})();


### PR DESCRIPTION
PageDoktypeRegistry was introduced with 12.0. So, backport 13 and 12 needed.