### PR TITLE
Update fieldControl example in _pages.php

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -256,6 +256,9 @@ Register the control in :file:`Configuration/TCA/Overrides/pages.php`:
     :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
 
+.. note::
+  The `fieldControl identifier` must be unique.
+
 Add the PHP class for rendering the control in
 :file:`Classes/FormEngine/FieldControl/ImportDataControl.php`:
 

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -256,8 +256,8 @@ Register the control in :file:`Configuration/TCA/Overrides/pages.php`:
     :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
 
-.. note::
-  The `fieldControl identifier` must be unique.
+..  note::
+    The `fieldControl identifier` must be unique.
 
 Add the PHP class for rendering the control in
 :file:`Classes/FormEngine/FieldControl/ImportDataControl.php`:

--- a/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
@@ -11,7 +11,7 @@ defined('TYPO3') or die();
             'type' => 'input',
             'eval' => 'int, unique',
             'fieldControl' => [
-                'importControl' => [
+                'my_fieldControl_button' => [
                     'renderType' => 'importDataControl',
                 ],
             ],

--- a/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
@@ -11,7 +11,7 @@ defined('TYPO3') or die();
             'type' => 'input',
             'eval' => 'int, unique',
             'fieldControl' => [
-                'my_fieldControl_button' => [
+                'my_fieldControl_identifier' => [
                     'renderType' => 'importDataControl',
                 ],
             ],


### PR DESCRIPTION
If there are duplicate fieldControl identifiers, e.g. from different extensions, an exception is raised in NodeFactory.
See [forge issue](https://forge.typo3.org/issues/106177)

This change makes it obvious, that this is actually a custom value