### PR TITLE
[BUGFIX] Default lifetime for cache tags

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
@@ -23,7 +23,7 @@ The API is implemented as a PSR-7 request attribute `frontend.cache.collector`.
 Every cache tag has a lifetime. The minimum lifetime is calculated
 from all given cache tags. API users do not have to deal with it individually.
 
-The default lifetime for a cache tag :php:`PHP_INT_MAX`, so it expires many
+The default lifetime for a cache tag is :php:`PHP_INT_MAX`, so it expires many
 years in the future.
 
 

--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheCollector.rst
@@ -22,7 +22,9 @@ The API is implemented as a PSR-7 request attribute `frontend.cache.collector`.
 
 Every cache tag has a lifetime. The minimum lifetime is calculated
 from all given cache tags. API users do not have to deal with it individually.
-The default lifetime for a cache tag is 86400 seconds (24 hours).
+
+The default lifetime for a cache tag :php:`PHP_INT_MAX`, so it expires many
+years in the future.
 
 
 ..  _typo3-request-attribute-frontend-cache-collector-example-add-single-cache-tag:


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1076
Releases: main, 13.4