### PR TITLE
[TASK] Remove outdated TYPO3 11.x version hints

### DIFF
--- a/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/MoreAboutFileMounts/Index.rst
@@ -46,10 +46,6 @@ File mounts
 Create a new file mount
 =======================
 
-.. versionadded:: 11.3
-   Starting with TYPO3 v11.3 it is possible to create a new file mount via
-   the context menu of the folder.
-
 To create a new file mount go to the module :guilabel:`File > Filelist` and create the
 folder for the mount if it didn't exist yet. Then open the context menu on that
 folder and choose :guilabel:`New File mount`, then give the new file mount a name.

--- a/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/ExpressionBuilder/Index.rst
@@ -40,14 +40,7 @@ See available :ref:`parameter types <database-connection-parameter-types>`.
 Junctions
 =========
 
-..  versionchanged:: 11.5.10
-    The :php:`andX()` and :php:`orX()` methods are replaced by :php:`and()` and
-    :php:`or()` to match with Doctrine DBAL, which
-    `deprecated <https://github.com/doctrine/dbal/commit/84328cd947706210caebcaea3ca0394b3ebc4673>`_
-    these methods. Both methods have been removed with TYPO3 v13.0.
-
 *   :php:`->and()` conjunction
-
 *   :php:`->or()` disjunction
 
 Combine multiple single expressions with :sql:`AND` or :sql:`OR`. Nesting is

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -7,8 +7,6 @@
 ModifyClearCacheActionsEvent
 ============================
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
 is fired in the :php:`\TYPO3\CMS\Backend\Backend\ToolbarItems\ClearCacheToolbarItem`
 class and allows extension authors to modify the clear cache actions, shown

--- a/Documentation/ApiOverview/Events/Events/Core/Cache/CacheFlushEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Cache/CacheFlushEvent.rst
@@ -6,8 +6,6 @@
 CacheFlushEvent
 ===============
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Cache\Event\CacheFlushEvent` is
 fired when :ref:`caches <caching>` are to be cleared.
 

--- a/Documentation/ApiOverview/Events/Events/Core/Cache/CacheWarmupEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Cache/CacheWarmupEvent.rst
@@ -6,8 +6,6 @@
 CacheWarmupEvent
 ================
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Cache\Event\CacheWarmupEvent` is
 fired when :ref:`caches <caching>` are to be warmed up.
 

--- a/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
@@ -6,8 +6,6 @@
 BootCompletedEvent
 ==================
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Core\Event\BootCompletedEvent` is fired
 on every request when TYPO3 has been fully booted, right after all configuration
 files have been added.

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
@@ -6,10 +6,6 @@
 AfterPackageActivationEvent
 ===========================
 
-..  versionadded:: 10.3
-    The event was introduced to replace the Signal/Slot
-    `\TYPO3\CMS\Extensionmanager\Utility\InstallUtility::afterExtensionInstall`.
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent`
 is triggered after a package has been activated.
 

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageDeactivationEvent.rst
@@ -6,10 +6,6 @@
 AfterPackageDeactivationEvent
 =============================
 
-..  versionadded:: 10.3
-    The event was introduced to replace the Signal/Slot
-    `\TYPO3\CMS\Extensionmanager\Utility\InstallUtility::afterExtensionUninstall`.
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Package\Event\AfterPackageDeactivationEvent`
 is triggered after a package has been deactivated.
 

--- a/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/PackagesMayHaveChangedEvent.rst
@@ -6,10 +6,6 @@
 PackagesMayHaveChangedEvent
 ===========================
 
-..  versionadded:: 10.3
-    The event was introduced to replace the Signal/Slot
-    `\TYPO3\CMS\Core\Package\PackageManager::packagesMayHaveChanged`.
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Package\Event\PackagesMayHaveChangedEvent`
 is a marker event to ensure that Core is re-triggering the package ordering and
 package listings.

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
@@ -6,8 +6,6 @@
 AfterFileCommandProcessedEvent
 ==============================
 
-..  versionadded:: 11.4
-
 The PSR-14 event
 :php:`\TYPO3\CMS\Core\Resource\Event\AfterFileCommandProcessedEvent` can be used
 to perform additional tasks for specific file commands. For example, trigger a

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
@@ -6,8 +6,6 @@
 ModifyFileDumpEvent
 ===================
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Resource\Event\ModifyFileDumpEvent` is
 fired in the :php:`\TYPO3\CMS\Core\Controller\FileDumpController` and allows
 extensions to perform additional access / security checks before dumping a file.

--- a/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/ExtensionManager/AvailableActionsForExtensionEvent.rst
@@ -6,10 +6,6 @@
 AvailableActionsForExtensionEvent
 =================================
 
-..  versionadded:: 10.3
-    The event was introduced to replace the Signal/Slot
-    `\TYPO3\CMS\Extensionmanager\ViewHelper\ProcessAvailableActionsViewHelper::processActions`.
-
 The PSR-14 event
 :php:`\TYPO3\CMS\Extensionmanager\Event\AvailableActionsForExtensionEvent`
 is triggered when rendering an additional action (currently within

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -6,8 +6,6 @@
 ProcessFileListActionsEvent
 ===========================
 
-..  versionadded:: 11.4
-
 The PSR-14 event :php:`\TYPO3\CMS\Core\Configuration\Event\ProcessFileListActionsEvent`
 is fired after generating the actions for the files and folders listing in the
 :guilabel:`File > Filelist` module.

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyResolvedFrontendGroupsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyResolvedFrontendGroupsEvent.rst
@@ -6,10 +6,6 @@
 ModifyResolvedFrontendGroupsEvent
 =================================
 
-..  versionadded:: 11.5
-    This event is intended to restore the functionality found in the
-    :php:`getGroupsFE` authentication service that was removed in TYPO3 v11.
-
 The PSR-14 event :php:`\TYPO3\CMS\Frontend\Authentication\ModifyResolvedFrontendGroupsEvent`
 event allows frontend groups to be added to a (frontend) request, regardless of
 whether a user is logged in or not.

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/BeforeRedirectEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/BeforeRedirectEvent.rst
@@ -10,9 +10,6 @@ BeforeRedirectEvent
 The PSR-14 event :php:`\TYPO3\CMS\FrontendLogin\Event\BeforeRedirectEvent` is
 triggered before a redirect is made.
 
-..  versionadded:: 11.5.26/12.3
-    The methods :php:`setRedirectUrl()` and :php:`getRequest()` are available.
-
 Example
 =======
 

--- a/Documentation/ApiOverview/Fal/Architecture/Events.rst
+++ b/Documentation/ApiOverview/Fal/Architecture/Events.rst
@@ -274,7 +274,6 @@ for more information about this class.
 =======================================================
 
 :ref:`AfterFileCommandProcessedEvent`
-    ..  versionadded:: 11.4
 
     The event can be used to perform additional tasks for specific file
     commands. For example, trigger a custom indexer after a file has been

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -232,8 +232,6 @@ mbox
 Validators
 ----------
 
-..  versionadded:: 11.0
-
 Using additional validators can help to identify if a provided email address
 is valid or not. By default, the validator
 :php:`\Egulias\EmailValidator\Validation\RFCValidation` is used. The following

--- a/Documentation/ApiOverview/RequestLifeCycle/Typo3Request.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/Typo3Request.rst
@@ -31,8 +31,6 @@ the PSR-7 base request object is given as argument to the called method.
 Extbase controller
 ------------------
 
-..  versionadded:: 11.3
-
 The request object compatible with the PSR-7
 :php:`\Psr\Http\Message\ServerRequestInterface` is available in an
 :ref:`Extbase controller <extbase-action-controller>` via the class property

--- a/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
+++ b/Documentation/ApiOverview/SiteHandling/AccessingSiteConfiguration.rst
@@ -62,12 +62,9 @@ Methods:
     // current site language
     $siteLanguage = $request->getAttribute('language');
 
-
-..  versionchanged:: 11.3
-    The :ref:`Extbase <extbase>` request class implements the
-    PSR-7 :php:`\Psr\Http\Message\ServerRequestInterface`. Therefore, you can
-    retrieve all needed attributes from the request object.
-
+The :ref:`Extbase <extbase>` request class implements the
+PSR-7 :php:`\Psr\Http\Message\ServerRequestInterface`. Therefore, you can
+retrieve all needed attributes from the request object.
 
 ..  index:: pair: Site handling; SiteFinder
 ..  _sitehandling-sitefinder-object:

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -535,8 +535,6 @@ the TYPO3 frontend:
         :type: bool
         :Default: false (for existing installations), true (for new installations)
 
-        ..  versionadded:: 10.4.35/11.5.23/12.2
-
         If this option is enabled, the same validation is used to calculate a
         "cHash" value as when a valid or invalid "cHash" parameter is given to a
         request, even when no "cHash" is given.

--- a/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
@@ -13,11 +13,6 @@ requests. They should therefore be optimized for speed.
 See :ref:`extension-files-locations` for a full list of file and
 directory names typically used in extensions.
 
-..  versionchanged:: 11.4
-    With TYPO3 v11.4 the files :file:`ext_localconf.php` and :file:`ext_tables.php`
-    are scoped into the global namespace on warmup of the cache.
-    Therefore, :php:`use` statements can now be used inside these files.
-
 ..  warning::
     The content of the files :file:`ext_localconf.php` and
     :file:`ext_tables.php` **must not** be wrapped in a

--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -92,10 +92,9 @@ Subsequently:
   general Composer information
 * see :ref:`ext-composer-json-properties` below for TYPO3 specific hints
 
-..  versionchanged:: 11.4
-    The ordering of installed extensions and their dependencies are loaded from
-    the :file:`composer.json <extension-composer-json>` file, instead of :file:`ext_emconf.php` in
-    Composer-based installations.
+The ordering of installed extensions and their dependencies are loaded from
+the :file:`composer.json <extension-composer-json>` file, instead of :file:`ext_emconf.php` in
+Composer-based installations.
 
 ..  note::
     Extension authors should ensure that the information in the

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtEmconf.rst
@@ -29,10 +29,9 @@ It is also needed for :ref:`Writing functional tests <t3coreapi:testing-writing-
 with the `typo3/testing-framework <https://github.com/TYPO3/testing-framework>` in v8 and
 earlier.
 
-..  versionchanged:: 11.4
-    In Composer-based installations, the ordering of installed extensions and
-    their dependencies is loaded from the :file:`composer.json <extension-composer-json>` file, instead of
-    :file:`ext_emconf.php`
+In Composer-based installations, the ordering of installed extensions and
+their dependencies is loaded from the :file:`composer.json <extension-composer-json>` file, instead of
+:file:`ext_emconf.php`
 
 The only content included is an associative array,
 :php:`$EM_CONF[extension key]`. The keys are described in the table below.


### PR DESCRIPTION
ALL LTS versions support these feature now. Version information can still be found in older versions of this document.

Releases: main, 13.4