### PR TITLE
fix: add _arguments to Plugin route enhancer configuration

### DIFF
--- a/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
+++ b/Documentation/ApiOverview/Routing/AdvancedRoutingConfiguration.rst
@@ -221,12 +221,14 @@ would need to set up two configurations of the plugin enhancer for
       ForgotPassword:
         type: Plugin
         limitToPages: [13]
-        routePath: '/forgot-password/{user}/{hash}'
+        routePath: '/forgot-password/{user_id}/{hash}'
         namespace: 'tx_felogin_pi1'
+        _arguments:
+          user_id: uid
         defaults:
           forgot: '1'
         requirements:
-          user: '[0-9]{1,3}'
+          user_id: '[a-z]+'
           hash: '^[a-zA-Z0-9]{32}$'
 
 If a URL is generated with the above parameters the resulting link


### PR DESCRIPTION
You have to map the user_id to a field, this part was missing.

See: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/core/Classes/Routing/Enhancer/PluginEnhancer.php#L31-L41
Releases: main, 13.4, 12.4