### PR TITLE
Fix duplicate MailMessage usage in documentation

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -450,7 +450,6 @@ Fluid:
 
     // Create the message
     $mail = GeneralUtility::makeInstance(MailMessage::class);
-    $email = new MailMessage();
 
     // Prepare and send the message
     $mail
@@ -491,7 +490,7 @@ Or, if you prefer, do not concatenate the calls:
     use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Core\Mail\MailMessage;
 
-    $email = new MailMessage();
+    $mail = GeneralUtility::makeInstance(MailMessage::class);
     $mail->from(new Address('john.doe@example.org', 'John Doe'));
     $mail->to(
         new Address('receiver@example.org', 'Max Mustermann'),


### PR DESCRIPTION
To create a message, you should use GeneralUtility::makeInstance(MailMessage::class);

Used Variables should be the same