### PR TITLE
Adjust examples for pagination

### DIFF
--- a/Documentation/ApiOverview/Pagination/_ArrayPaginatorExampleController.php
+++ b/Documentation/ApiOverview/Pagination/_ArrayPaginatorExampleController.php
@@ -32,12 +32,7 @@ final class ExampleController extends ActionController
 
         // ... more logic ...
 
-        $this->view->assignMultiple(
-            [
-                'pagination' => $pagination,
-                'paginator' => $paginator,
-            ],
-        );
+        $this->view->assign('pagination', $pagination);
 
         return $this->htmlResponse();
     }

--- a/Documentation/ApiOverview/Pagination/_ArrayPaginatorExamplePagination.html
+++ b/Documentation/ApiOverview/Pagination/_ArrayPaginatorExamplePagination.html
@@ -11,6 +11,6 @@
     </f:for>
 </ul>
 
-<f:for each="{paginator.paginatedItems}" as="item">
+<f:for each="{pagination.paginator.paginatedItems}" as="item">
     {item}
 </f:for>

--- a/Documentation/ApiOverview/Pagination/_SlidingWindowExampleController.php
+++ b/Documentation/ApiOverview/Pagination/_SlidingWindowExampleController.php
@@ -38,13 +38,7 @@ final class ExampleController extends ActionController
 
         // ... more logic ...
 
-        $this->view->assign(
-            'pagination',
-            [
-                'pagination' => $pagination,
-                'paginator' => $paginator,
-            ],
-        );
+        $this->view->assign('pagination', $pagination);
 
         return $this->htmlResponse();
     }


### PR DESCRIPTION
It is not necessary to pass "paginator" to the view as it can be retrieved via the pagination object.

Releases: main, 13.4, 12.4