### PR TITLE
Remove tools section from extension documentation

### DIFF
--- a/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
@@ -1,10 +1,10 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Extension development; Documentation
-   Path; EXT:{extkey}/Documentation/
-.. _extension-documentation:
-.. _extension-documentation-sphinx:
-.. _extension-documentation-readme:
+..  include:: /Includes.rst.txt
+..  index::
+    Extension development; Documentation
+    Path; EXT:{extkey}/Documentation/
+..  _extension-documentation:
+..  _extension-documentation-sphinx:
+..  _extension-documentation-readme:
 
 ====================
 Adding documentation
@@ -19,26 +19,26 @@ extension.
 The TYPO3 documentation platform https://docs.typo3.org centralizes documentation
 for each project. It supports different types of documentation:
 
-#. The *full documentation*, stored in :file:`EXT:{extkey}/Documentation/`.
-#. The *single file documentation*, such as a simple README file stored in
-   :file:`EXT:{extkey}/README.rst`.
+#.  The *full documentation*, stored in :file:`EXT:{extkey}/Documentation/`.
+#.  The *single file documentation*, such as a simple README file stored in
+    :file:`EXT:{extkey}/README.rst`.
 
 We recommend the first approach for the following reasons:
 
--  **Output formats:** Full documentations can be automatically rendered as HTML
-   or TYPO3-branded PDF.
--  **Cross-references:** It is easy to cross-reference to other chapters and
-   sections of other manuals (either TYPO3 references or extension manuals).
-   The links are automatically updated when pages or sections are moved.
--  **Many content elements:** The Sphinx template used for rendering the full
-   documentation provides many useful content elements to improve the structure
-   and look of your documentation.
+-   **Output formats:** Full documentations can be automatically rendered as HTML
+    or TYPO3-branded PDF.
+-   **Cross-references:** It is easy to cross-reference to other chapters and
+    sections of other manuals (either TYPO3 references or extension manuals).
+    The links are automatically updated when pages or sections are moved.
+-   **Many content elements:** The Sphinx template used for rendering the full
+    documentation provides many useful content elements to improve the structure
+    and look of your documentation.
 
 For more details on both approaches see the :ref:`File structure <h2document:file-structure>`
 page and for more information on writing TYPO3 documentation in general, see the
 :ref:`Writing documentation <h2document:start>` guide.
 
-.. _extension-documentation-tools:
+..  _extension-documentation-tools:
 
 Tools
 =====
@@ -46,8 +46,8 @@ Tools
 Although it is possible to write every single line of a full documentation
 from scratch, the TYPO3 community provides tools to support you:
 
--  A `Sample Manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`_
-   is available to be immediately copied into your own extension.
--  The :composer:`friendsoftypo3/extension-builder`
-   optionally generates a documentation skeleton together with the extension
-   skeleton.
+-   A `Sample Manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`_
+    is available to be immediately copied into your own extension.
+-   The :composer:`friendsoftypo3/extension-builder`
+    optionally generates a documentation skeleton together with the extension
+    skeleton.

--- a/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Documentation.rst
@@ -5,6 +5,7 @@
 ..  _extension-documentation:
 ..  _extension-documentation-sphinx:
 ..  _extension-documentation-readme:
+..  _extension-documentation-tools:
 
 ====================
 Adding documentation
@@ -37,17 +38,3 @@ We recommend the first approach for the following reasons:
 For more details on both approaches see the :ref:`File structure <h2document:file-structure>`
 page and for more information on writing TYPO3 documentation in general, see the
 :ref:`Writing documentation <h2document:start>` guide.
-
-..  _extension-documentation-tools:
-
-Tools
-=====
-
-Although it is possible to write every single line of a full documentation
-from scratch, the TYPO3 community provides tools to support you:
-
--   A `Sample Manual <https://github.com/TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual>`_
-    is available to be immediately copied into your own extension.
--   The :composer:`friendsoftypo3/extension-builder`
-    optionally generates a documentation skeleton together with the extension
-    skeleton.


### PR DESCRIPTION
The tools section is out-dated.
The copy template for new extension documentation is archived and extension_builder is only available until TYPO3 11.
I have moved the header marker to top section

Resolves: #5480 
Releases: main, 13.4