### PR TITLE
[TASK] Fix property examples

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Hydrating/_Blog1.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Hydrating/_Blog1.php
@@ -13,6 +13,8 @@ class Blog extends AbstractEntity
 
     public function __construct(protected string $title)
     {
+        // Posts is not initialized on thawing / fetching from database!!
+        // Must be initialized in initializeObject()!!
         $this->posts = new ObjectStorage();
     }
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Hydrating/_Blog1.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Hydrating/_Blog1.php
@@ -13,7 +13,7 @@ class Blog extends AbstractEntity
 
     public function __construct(protected string $title)
     {
-        // Posts is not initialized on thawing / fetching from database!!
+        // Property "posts" is not initialized on thawing / fetching from database!!
         // Must be initialized in initializeObject()!!
         $this->posts = new ObjectStorage();
     }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_ObjectStorage.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_ObjectStorage.php
@@ -13,5 +13,10 @@ class Entity extends AbstractEntity
      * @var ObjectStorage<ChildEntity>
      * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
      */
-    private ObjectStorage $property;
+    protected ObjectStorage $property;
+
+    public function initializeObject(): void
+    {
+        $this->property = new ObjectStorage();
+    }
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType1.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType1.php
@@ -9,5 +9,5 @@ use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 
 class Entity extends AbstractEntity
 {
-    private ChildEntity|LazyLoadingProxy $property;
+    protected ChildEntity|LazyLoadingProxy $property;
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType2.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType2.php
@@ -8,5 +8,5 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
 class Entity extends AbstractEntity
 {
-    private string|int $property;
+    protected string|int $property;
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType3.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/_Model/_UnionType3.php
@@ -9,5 +9,5 @@ use TYPO3\CMS\Extbase\Persistence\Generic\LazyLoadingProxy;
 
 class Entity extends AbstractEntity
 {
-    private LazyLoadingProxy|ChildEntity $property;
+    protected LazyLoadingProxy|ChildEntity $property;
 }


### PR DESCRIPTION
Always use at least protected for properties, private does not work

Make more clear that Blog 1 is a bad example. However I think we should change didaktics of this section in general.

Releases: main, 13.4