### PR TITLE
[TASK] Add new chapter for rsync-based TYPO3 deployment

### DIFF
--- a/Documentation/Administration/Installation/Deployment/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Index.rst
@@ -167,7 +167,7 @@ Steps:
 ..  note::
 
     Use a deployment script or tool such as
-    `Rsync <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_ or
+    `rsync <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_ or
     `Deployer <https://docs.typo3.org/permalink/t3coreapi:deployment-deployer>`_
     to automate regular deployments and avoid overwriting persistent data.
 

--- a/Documentation/Administration/Installation/Deployment/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Index.rst
@@ -78,6 +78,9 @@ Steps:
     -   :path:`vendor/`,
     -   Files from the project directory: :file:`composer.json`, :path:`composer.lock`
 
+    You can speed up the transfer using archive tools like zip or tar, or use
+    `rsync <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_.
+
 #.  Import the database on the production server, for example using
     `mysql <https://dev.mysql.com/doc/refman/8.0/en/mysql.html>`_:
 
@@ -146,6 +149,10 @@ Steps:
 
     -   :path:`var/`, :path:`public/fileadmin/`, (these are managed on the server)
 
+    You can speed up the transfer using archive tools like zip or tar, or use
+    `rsync deployment of TYPO3 <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_
+    to copy only changed files.
+
 3.  If database changes are required:
 
     -   Run the Upgrade Wizard in the TYPO3 backend
@@ -159,7 +166,8 @@ Steps:
 
 ..  note::
 
-    Use a deployment script or tool such as `rsync` or
+    Use a deployment script or tool such as
+    `Rsync <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_ or
     `Deployer <https://docs.typo3.org/permalink/t3coreapi:deployment-deployer>`_
     to automate regular deployments and avoid overwriting persistent data.
 
@@ -235,6 +243,7 @@ The following section contains examples for various deployment tools and how the
 ..  toctree::
     :titlesonly:
 
+    Rsync/Index
     Deployer/Index
     Surf/Index
     Magallanes/Index

--- a/Documentation/Administration/Installation/Deployment/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Index.rst
@@ -150,7 +150,7 @@ Steps:
     -   :path:`var/`, :path:`public/fileadmin/`, (these are managed on the server)
 
     You can speed up the transfer using archive tools like zip or tar, or use
-    `rsync deployment of TYPO3 <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_
+    `rsync <https://docs.typo3.org/permalink/t3coreapi:deployment-rsync>`_
     to copy only changed files.
 
 3.  If database changes are required:

--- a/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
@@ -18,9 +18,10 @@ by synchronizing project files from a local environment (such as a
 to a production server over
 `SSH <https://www.digitalocean.com/community/tutorials/what-is-ssh>`_.
 
-rsync is often used for **small to medium-sized projects** or teams who prefer
+rsync is often used for small to medium-sized projects, or by teams who prefer
 a controlled and scriptable way to deploy TYPO3 without setting up full
-:abbr:`CI/CD (Continuous Integration / Continuous Deployment)` systems.
+:abbr:`CI/CD (Continuous Integration / Continuous Deployment)` systems. It can
+also be part of automated workflows in larger or more complex environments.
 
 By default, rsync only transfers changed files, compared to uploading zip or tar archives,
 and avoids the need to unpack anything on the server.

--- a/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
@@ -22,7 +22,7 @@ rsync is often used for **small to medium-sized projects** or teams who prefer
 a controlled and scriptable way to deploy TYPO3 without setting up full
 :abbr:`CI/CD (Continuous Integration / Continuous Deployment)` systems.
 
-Compared to uploading zip or tar archives, rsync only transfers changed files
+By default, rsync only transfers changed files, compared to uploading zip or tar archives,
 and avoids the need to unpack anything on the server.
 
 Unlike tools such as

--- a/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
@@ -26,11 +26,14 @@ also be part of automated workflows in larger or more complex environments.
 By default, rsync only transfers changed files, compared to uploading zip or tar archives,
 and avoids the need to unpack anything on the server.
 
-Unlike tools such as
+Tools like
 `Deployer <https://docs.typo3.org/permalink/t3coreapi:deployment-deployer>`_
-or `TYPO3 Surf <https://docs.typo3.org/permalink/t3coreapi:deployment-typo3-surf>`_,
-rsync does not offer rollbacks or automated deployment steps. However, it gives
-you full control over what is transferred and when.
+or `TYPO3 Surf <https://docs.typo3.org/permalink/t3coreapi:deployment-typo3-surf>`_
+often use rsync internally to transfer files, but add features such as
+automated deployment steps, release management, and rollback support on top.
+
+Using rsync directly gives you full control over what is transferred and when,
+but you are responsible for handling additional deployment tasks yourself.
 
 ..  seealso::
 

--- a/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
@@ -37,4 +37,4 @@ you full control over what is transferred and when.
     -   `Beginner tutorial (Linuxize) <https://linuxize.com/post/how-to-use-rsync-for-local-and-remote-data-transfer-and-synchronization/>`_
     -   `rsync manual <https://linux.die.net/man/1/rsync>`_
 
-..  todo:: Add recipes for Composer-based and classic installations.
+..  todo:: Add "how-to instructions" for Composer-based and classic installations.

--- a/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
+++ b/Documentation/Administration/Installation/Deployment/Rsync/Index.rst
@@ -1,0 +1,40 @@
+:navigation-title: Rsync
+
+..  include:: /Includes.rst.txt
+..  _deployment-rsync:
+
+=========================
+Rsync deployment of TYPO3
+=========================
+
+`rsync <https://rsync.samba.org/>`_ is a command-line tool for copying files
+between systems.
+
+It can be used to deploy both
+`Composer-based <https://docs.typo3.org/permalink/t3coreapi:installation>`_
+and `classic TYPO3 installations <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_
+by synchronizing project files from a local environment (such as a
+`DDEV setup <https://docs.typo3.org/permalink/t3start:installation-ddev-tutorial>`_)
+to a production server over
+`SSH <https://www.digitalocean.com/community/tutorials/what-is-ssh>`_.
+
+rsync is often used for **small to medium-sized projects** or teams who prefer
+a controlled and scriptable way to deploy TYPO3 without setting up full
+:abbr:`CI/CD (Continuous Integration / Continuous Deployment)` systems.
+
+Compared to uploading zip or tar archives, rsync only transfers changed files
+and avoids the need to unpack anything on the server.
+
+Unlike tools such as
+`Deployer <https://docs.typo3.org/permalink/t3coreapi:deployment-deployer>`_
+or `TYPO3 Surf <https://docs.typo3.org/permalink/t3coreapi:deployment-typo3-surf>`_,
+rsync does not offer rollbacks or automated deployment steps. However, it gives
+you full control over what is transferred and when.
+
+..  seealso::
+
+    -   `rsync homepage <https://rsync.samba.org/>`_
+    -   `Beginner tutorial (Linuxize) <https://linuxize.com/post/how-to-use-rsync-for-local-and-remote-data-transfer-and-synchronization/>`_
+    -   `rsync manual <https://linux.die.net/man/1/rsync>`_
+
+..  todo:: Add recipes for Composer-based and classic installations.


### PR DESCRIPTION
- Introduce rsync as a deployment method for Composer-based and classic projects
- Explain when to use rsync compared to zip/tar or advanced tools like Deployer
- Link to SSH and rsync documentation for beginners
- Mark placeholder for deployment command recipes (todo)

Releases: main, 13.4, 12.4