### PR TITLE
[TASK] Enhance installation overview

### DIFF
--- a/Documentation/Administration/Installation/Index.rst
+++ b/Documentation/Administration/Installation/Index.rst
@@ -32,7 +32,7 @@ TYPO3 can be installed in two ways:
     ..  card:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_
 
         This method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__
-        via a regular backend module. It is ideal for managed hosting, automated updates,
+        via a regular backend module. It is ideal for managed hosting, automated updates by the hosting provider,
         and simpler setups. Also well-suited for beginners due to GUI-based
         extension handling.
 

--- a/Documentation/Administration/Installation/Index.rst
+++ b/Documentation/Administration/Installation/Index.rst
@@ -21,8 +21,8 @@ TYPO3 can be installed in two ways:
     ..  card:: `Composer-based installation <https://docs.typo3.org/permalink/t3coreapi:installation>`_
 
         Composer-based setups are common in professional
-        environments with development teams. Extensions are installed via Packagist
-        (not from the TER), providing more flexibility,
+        environments with development teams. Extensions are installed via `Packagist <https://packagist.org/>`__
+        (not from the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__), providing more flexibility in dependency management,
         better integration with version control, and easier environment
         automation. It is ideal for advanced projects or team-based workflows.
 
@@ -31,9 +31,9 @@ TYPO3 can be installed in two ways:
 
     ..  card:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_
 
-        This method includes access to the TYPO3 Extension Repository (TER)
-        via the backend. It is ideal for managed hosting, automated updates,
-        and simpler setups. Also well suited for beginners due to GUI-based
+        This method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org/>`__
+        via a regular backend module. It is ideal for managed hosting, automated updates,
+        and simpler setups. Also well-suited for beginners due to GUI-based
         extension handling.
 
         Switching to Composer later is possible, but takes effort and means

--- a/Documentation/Administration/Installation/Index.rst
+++ b/Documentation/Administration/Installation/Index.rst
@@ -9,7 +9,7 @@
 TYPO3 installation overview
 ===========================
 
-TYPO3 can be installed in two fully supported ways:
+TYPO3 can be installed in two ways:
 
 ..  card-grid::
     :columns: 1
@@ -20,9 +20,9 @@ TYPO3 can be installed in two fully supported ways:
 
     ..  card:: `Composer-based installation <https://docs.typo3.org/permalink/t3coreapi:installation>`_
 
-        Composer-based setups are common in professional development
-        environments. Extensions are installed via Packagist
-        (not directly from TER), and this approach offers more flexibility,
+        Composer-based setups are common in professional
+        environments with development teams. Extensions are installed via Packagist
+        (not from the TER), providing more flexibility,
         better integration with version control, and easier environment
         automation. It is ideal for advanced projects or team-based workflows.
 
@@ -31,12 +31,12 @@ TYPO3 can be installed in two fully supported ways:
 
     ..  card:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_
 
-        This method provides access to the TYPO3 Extension Repository (TER)
-        via the backend. It’s ideal for managed hosting, automated updates,
-        and simpler setups. Also well suited for beginners due to its GUI-based
+        This method includes access to the TYPO3 Extension Repository (TER)
+        via the backend. It is ideal for managed hosting, automated updates,
+        and simpler setups. Also well suited for beginners due to GUI-based
         extension handling.
 
-        Switching to Composer later is possible, but takes effort and involves
+        Switching to Composer later is possible, but takes effort and means
         restructuring the project.
 
         ..  card-footer:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_ `Migrate to Composer <https://docs.typo3.org/permalink/t3coreapi:migratetocomposer>`_
@@ -45,8 +45,7 @@ TYPO3 can be installed in two fully supported ways:
 Both methods are fully supported and recommended depending on your project
 needs and environment.
 
-As of now, there is **no official plan to deprecate the classic installation**
-method.
+As of now, there is **no official plan to deprecate the classic installation method.**
 
 ..  card-grid::
     :columns: 1

--- a/Documentation/Administration/Installation/Index.rst
+++ b/Documentation/Administration/Installation/Index.rst
@@ -1,12 +1,52 @@
-..  include:: /Includes.rst.txt
+:navigation-title: Installation
 
+..  include:: /Includes.rst.txt
 ..  index:: installation
 
 ..  _installation_index:
 
-============
-Installation
-============
+===========================
+TYPO3 installation overview
+===========================
+
+TYPO3 can be installed in two fully supported ways:
+
+..  card-grid::
+    :columns: 1
+    :columns-md: 2
+    :gap: 4
+    :class: pb-4
+    :card-height: 100
+
+    ..  card:: `Composer-based installation <https://docs.typo3.org/permalink/t3coreapi:installation>`_
+
+        Composer-based setups are common in professional development
+        environments. Extensions are installed via Packagist
+        (not directly from TER), and this approach offers more flexibility,
+        better integration with version control, and easier environment
+        automation. It is ideal for advanced projects or team-based workflows.
+
+        ..  card-footer:: `General installation steps <https://docs.typo3.org/permalink/t3coreapi:installation>`_ `with DDEV <https://docs.typo3.org/permalink/t3start:installation-ddev-tutorial>`_
+            :button-style: btn btn-secondary
+
+    ..  card:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_
+
+        This method provides access to the TYPO3 Extension Repository (TER)
+        via the backend. It’s ideal for managed hosting, automated updates,
+        and simpler setups. Also well suited for beginners due to its GUI-based
+        extension handling.
+
+        Switching to Composer later is possible, but takes effort and involves
+        restructuring the project.
+
+        ..  card-footer:: `Classic installation <https://docs.typo3.org/permalink/t3coreapi:legacyinstallation>`_ `Migrate to Composer <https://docs.typo3.org/permalink/t3coreapi:migratetocomposer>`_
+            :button-style: btn btn-secondary
+
+Both methods are fully supported and recommended depending on your project
+needs and environment.
+
+As of now, there is **no official plan to deprecate the classic installation**
+method.
 
 ..  card-grid::
     :columns: 1
@@ -20,11 +60,6 @@ Installation
         System requirements for the host operating system, including its web
         server and database and how they should be configured prior to
         installation.
-
-    ..  card:: :ref:`Installing TYPO3 <installation>`
-
-        The Installation Guide covers everything needed to install TYPO3. Including a preinstallation
-        checklist and a detailed walk through that details every step of the installation process.
 
     ..  card:: :ref:`Deploying TYPO3 <DeployTYPO3>`
 
@@ -41,11 +76,6 @@ Installation
         In addition, every TYPO3 package also contains a unique file hash that
         can be used to ensure file integrity when downloading the release. This guide
         details how these signatures can be checked and how file hashes can be compared.
-
-    ..  card:: :ref:`Legacy Installation Guide <legacyinstallation>`
-
-        Looking to install TYPO3 the classic way? Whilst this method of installation is no longer recommended, the Legacy Installation
-        Guide demonstrates how TYPO3 can be installed without using Composer.
 
 ..  toctree::
     :hidden:


### PR DESCRIPTION
Added cards for Composer-based and classic installations.

Clarified that both methods are fully supported, and explained when which one is helpful

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/5492 
Releases: main, 13.4, 12.4