### PR TITLE
Add information about when the AfterCachedPageIsPersistedEvent was added

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
@@ -6,10 +6,12 @@
 AfterCachedPageIsPersistedEvent
 ===============================
 
-   This event together with :ref:`AfterCacheableContentIsGeneratedEvent` has
-   been introduced to serve as a direct replacement for the removed hook:
+..  versionadded:: 12.0
 
-   * :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['insertPageIncache']`
+    This event together with :ref:`AfterCacheableContentIsGeneratedEvent` has
+    been introduced to serve as a direct replacement for the removed hook:
+
+    *   :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['insertPageIncache']`
 
 The PSR-14 event :php:`\TYPO3\CMS\Frontend\Event\AfterCachedPageIsPersistedEvent`
 is commonly used to generate a static file cache. This event is only called if


### PR DESCRIPTION
This avoids the "quote style" of this information.

See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97862-NewPSR-14EventsForManipulatingFrontendPageGenerationAndCacheBehaviour.html