### PR TITLE
Update example PHP file for InputTextElement

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -216,12 +216,11 @@ basic, only :php:`OuterWrapContainer` and :php:`InlineControlContainer` currentl
 See the :ref:`TCA reference ctrl section <t3tca:ctrl-reference-container>` for more information on how to configure these
 for containers in TCA.
 
-Example. The :php:`InputTextElement` (standard input element) defines a couple of default wizards and embeds them in its
-main result HTML:
+The `InputTextElement` (standard input element) demonstrates how different wizards are loaded and integrated:
 
 ..  literalinclude:: _InputTextElement.php
     :language: php
-    :caption: EXT:my_extension/Classes/Backend/Form/InputTextElement.php
+    :caption: EXT:backend/Classes/Form/Element/InputTextElement.php
 
 This element defines three wizards to be called by default. The :php:`renderType` concept is re-used, the
 values :php:`localizationStateSelector` are registered within the :php:`NodeFactory` and resolve to class names. They

--- a/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
@@ -6,8 +6,24 @@ namespace MyVendor\MyExtension\Backend\Form;
 
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 
-final class InputTextElement extends AbstractFormElement
+class InputTextElement extends AbstractFormElement
 {
+    /**
+     * Default field information enabled for this element.
+     *
+     * @var array
+     */
+    protected $defaultFieldInformation = [
+        'tcaDescription' => [
+            'renderType' => 'tcaDescription',
+        ],
+    ];
+
+    /**
+     * Default field wizards enabled for this element.
+     *
+     * @var array
+     */
     protected $defaultFieldWizard = [
         'localizationStateSelector' => [
             'renderType' => 'localizationStateSelector',
@@ -30,23 +46,51 @@ final class InputTextElement extends AbstractFormElement
     {
         $resultArray = $this->initializeResultArray();
 
+        $fieldInformationResult = $this->renderFieldInformation();
+        $fieldInformationHtml = $fieldInformationResult['html'];
+
+        $fieldControlResult = $this->renderFieldControl();
+        $fieldControlHtml = $fieldControlResult['html'];
+
         $fieldWizardResult = $this->renderFieldWizard();
         $fieldWizardHtml = $fieldWizardResult['html'];
+
         $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldWizardResult, false);
 
         $mainFieldHtml = [];
         $mainFieldHtml[] = '<div class="form-control-wrap">';
         $mainFieldHtml[] =  '<div class="form-wizards-wrap">';
-        $mainFieldHtml[] =      '<div class="form-wizards-element">';
-        // Main HTML of element done here ...
+        $mainFieldHtml[] =      '<div class="form-wizards-item-element">';
+        $mainFieldHtml[] =          '<input type="text"/>';
         $mainFieldHtml[] =      '</div>';
-        $mainFieldHtml[] =      '<div class="form-wizards-items-bottom">';
-        $mainFieldHtml[] =          $fieldWizardHtml;
-        $mainFieldHtml[] =      '</div>';
+
+        // Add part for FieldControl between the label and the form element
+        if (!empty($fieldControlHtml)) {
+            $mainFieldHtml[] =      '<div class="form-wizards-item-aside form-wizards-item-aside--field-control">';
+            $mainFieldHtml[] =          '<div class="btn-group">';
+            $mainFieldHtml[] =              $fieldControlHtml;
+            $mainFieldHtml[] =          '</div>';
+            $mainFieldHtml[] =      '</div>';
+        }
+
+        // Add part for FieldWizards to the right of element node
+        if (!empty($fieldWizardHtml)) {
+            $mainFieldHtml[] = '<div class="form-wizards-item-bottom">';
+            $mainFieldHtml[] = $fieldWizardHtml;
+            $mainFieldHtml[] = '</div>';
+        }
+
         $mainFieldHtml[] =  '</div>';
         $mainFieldHtml[] = '</div>';
 
-        $resultArray['html'] = implode(LF, $mainFieldHtml);
+        $fullElement = implode(LF, $mainFieldHtml);
+
+        // Add part for FieldInformation to bottom of element node
+        $resultArray['html'] = '
+            <div class="formengine-field-item t3js-formengine-field-item">
+                ' . $fieldInformationHtml . $fullElement . '
+            </div>';
+
         return $resultArray;
     }
 }

--- a/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_InputTextElement.php
@@ -2,9 +2,7 @@
 
 declare(strict_types=1);
 
-namespace MyVendor\MyExtension\Backend\Form;
-
-use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
+namespace TYPO3\CMS\Backend\Form\Element;
 
 class InputTextElement extends AbstractFormElement
 {


### PR DESCRIPTION
The InputTextElement got new default FieldInformation for `tcaDescription`. It was added with TYPO3 9 and I think we should update our example accordingly. I have tried to keep the example as short as possible (as before).