### PR TITLE
[BUGFIX] Annotate correct variable

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -691,7 +691,7 @@ The nonce can be retrieved via the
 
     // use TYPO3\CMS\Core\Domain\ConsumableString
 
-    /** @var ConsumableString|null $nonce */
+    /** @var ConsumableString|null $nonceAttribute */
     $nonceAttribute = $this->request->getAttribute('nonce');
     if ($nonceAttribute instanceof ConsumableString) {
         $nonce = $nonceAttribute->consume();


### PR DESCRIPTION
`$nonce` is getting a string returned by `$nonceAttribute->consume()` The annotated ConsumableString is return-type of  `$this->getRequest()->getAttribute('nonce')` and thus belonging to `$nonceAttribute`