### PR TITLE
[TASK] Use mergeRecursiveWithOverrule in PSR site config event

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_ImportRoutesIntoSiteConfiguration.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_ImportRoutesIntoSiteConfiguration.php
@@ -7,6 +7,7 @@ namespace MyVendor\MyExtension\Configuration\EventListener;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 use TYPO3\CMS\Core\Configuration\Event\SiteConfigurationLoadedEvent;
 use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 
 #[AsEventListener(
     identifier: 'my-extension/import-routes-into-site-configuration',
@@ -23,9 +24,12 @@ final readonly class ImportRoutesIntoSiteConfiguration
     {
         $routeConfiguration = $this->yamlFileLoader->load(self::ROUTES);
 
-        $configuration = array_merge_recursive(
+        // Using this method instead of array_merge_recursive will
+        // prevent duplicate keys, and also allow to use the special
+        // "_UNSET" handling properly.
+        $configuration = ArrayUtility::mergeRecursiveWithOverrule(
             $event->getConfiguration(),
-            $routeConfiguration,
+            $$routeConfiguration,
         );
 
         $event->setConfiguration($configuration);


### PR DESCRIPTION
See https://forge.typo3.org/issues/106813 - the array_merge_recursive() function has the drawkback of introducing duplicate keys.

Instead, this now prefery mergeRecursiveWithOverrule, which can also handle the '__UNSET' special values.