### PR TITLE
addPlugin must have the parameters  'CType' and $extensionKey

### DIFF
--- a/Documentation/ApiOverview/ContentElements/_Migration/_non_extbase_tca.diff
+++ b/Documentation/ApiOverview/ContentElements/_Migration/_non_extbase_tca.diff
@@ -7,7 +7,8 @@
  ExtensionManagementUtility::addPlugin(
      [$pluginTitle, $pluginSignature, '', 'plugin'],
 -    'list_type',
--    $extensionKey,
++    'CType',
+     $extensionKey,
  );
 
 -// Disable the display of layout and select_key fields for the plugin


### PR DESCRIPTION
addPlugin(
     [$pluginTitle, $pluginSignature, '', 'plugin'],
-    'list_type',
+    'CType',
     $extensionKey,
 );
 
 
 See file 
typo3_src-13.4.9/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php

    public static function addPlugin(array|SelectItem $itemArray, ?string $type = null, ?string $extensionKey = null): void