### PR TITLE
Fix example for SiteConfigurationLoadedEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_ImportRoutesIntoSiteConfiguration.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/_SiteConfigurationLoadedEvent/_ImportRoutesIntoSiteConfiguration.php
@@ -23,15 +23,16 @@ final readonly class ImportRoutesIntoSiteConfiguration
     public function __invoke(SiteConfigurationLoadedEvent $event): void
     {
         $routeConfiguration = $this->yamlFileLoader->load(self::ROUTES);
+        $siteConfiguration = $event->getConfiguration();
 
         // Using this method instead of array_merge_recursive will
         // prevent duplicate keys, and also allow to use the special
         // "_UNSET" handling properly.
-        $configuration = ArrayUtility::mergeRecursiveWithOverrule(
-            $event->getConfiguration(),
-            $$routeConfiguration,
+        ArrayUtility::mergeRecursiveWithOverrule(
+            $siteConfiguration,
+            $routeConfiguration,
         );
 
-        $event->setConfiguration($configuration);
+        $event->setConfiguration($siteConfiguration);
     }
 }


### PR DESCRIPTION
There are quite some errors in this piece of code:

- The first parameter of ArrayUtility::mergeRecursiveWithOverrule() is expected by reference, therefore a variable must be used.
- The result of the method is written back to the variable passed as first parameter, so no return value is available
- $routeConfiguration as second parameter was passed wrong (with double $$)

Releases: main, 13.4