### PR TITLE
[TASK] Add port mapping and reverse proxy guidance

### DIFF
--- a/Documentation/Administration/Docker/DockerComposeDemo/Index.rst
+++ b/Documentation/Administration/Docker/DockerComposeDemo/Index.rst
@@ -71,12 +71,48 @@ Visit:
 
     http://localhost:8081
 
+(This URL works because port 8081 on your host maps to port 80 in the container;
+see :ref:`docker-compose-port-mapping`)
+
 Use these installer settings:
 
 -   **Database host**: `db`
 -   **Username**: `db`
 -   **Password**: `db`
 -   **Database name**: `db`
+
+.. _docker-compose-port-mapping:
+
+About port mapping in Docker Compose
+====================================
+
+By default, the TYPO3 container exposes **port 80** internally. In the
+`docker-compose.yml` file, this is mapped to a port on your local machine
+using the `ports` option:
+
+..  code-block:: yaml
+
+    ports:
+      - "8081:80"
+
+This means:
+
+*   `80` is the container’s internal web server port
+*   `8081` is the port on your local machine
+
+With this mapping, you can access TYPO3 at:
+
+..  code-block:: text
+
+    http://localhost:8081
+
+You can change the `8081` part to any available port if needed. The internal
+port `80` should not be changed, as it is required by the TYPO3 image.
+
+..  tip::
+
+    Learn more: `Docker Compose Networking – Ports
+    <https://docs.docker.com/compose/compose-file/#ports>`_
 
 ..  _docker-compose-stop-cleanup:
 

--- a/Documentation/Administration/Docker/DockerDemo/Index.rst
+++ b/Documentation/Administration/Docker/DockerDemo/Index.rst
@@ -143,6 +143,9 @@ Open:
 
     http://localhost:8080
 
+(assuming port 8080 was mapped to internal port 80 during `docker run`;
+see :ref:`classic-docker-ports`)
+
 Use these database settings:
 
 - **Database Host**: `typo3db`
@@ -195,6 +198,36 @@ To start the database container, run:
 ..  code-block:: bash
 
     docker start typo3db
+
+..  _classic-docker-ports:
+
+Understanding port mapping
+==========================
+
+The TYPO3 Docker image exposes an internal web server on **port 80**. In order
+to access this service from your host machine (via a web browser), Docker
+needs to map that internal container port to a port on your host system.
+
+This is done using the `-p` flag in `docker run`:
+
+.. code-block:: bash
+
+    docker run -p 8080:80 ...
+
+In this example:
+
+*   `8080` is the **host port** (your computer)
+*   `80` is the **container port** (inside the TYPO3 image)
+
+This means you can access TYPO3 at `http://localhost:8080`.
+
+You can choose a different host port if needed, as long as it doesn't conflict
+with other services. The container will always serve on port `80` internally.
+
+..  tip::
+
+    Learn more: `Docker Networking – Published Ports
+    <https://docs.docker.com/config/containers/container-networking/#published-ports>`_
 
 ..  _classic-docker-reset:
 

--- a/Documentation/Administration/Docker/Production/Index.rst
+++ b/Documentation/Administration/Docker/Production/Index.rst
@@ -23,6 +23,7 @@ strategies.
     Distribution/Index
     Database/Index
     FilePermissions/Index
+    Ports/Index
     ReverseProxy/Index
 
 ..  seealso::

--- a/Documentation/Administration/Docker/Production/Ports/Index.rst
+++ b/Documentation/Administration/Docker/Production/Ports/Index.rst
@@ -1,0 +1,49 @@
+:navigation-title: Ports
+
+..  include:: /Includes.rst.txt
+.. _container-hosting-ports:
+
+===================================================
+Ports when running TYPO3 on container-based hosting
+===================================================
+
+..  include:: /Administration/Docker/Production/_Experimental.rst.txt
+
+When deploying TYPO3 to a container-based hosting platform, make sure that the
+container's **internal port 80** is correctly exposed to the outside.
+
+Most platforms handle this by routing incoming traffic to a fixed external
+port (for example, port 443 for HTTPS) and forwarding it to port 80 inside the
+container. You do **not** need to modify the TYPO3 image or change its
+internal port.
+
+Make sure your hosting configuration (such as ingress or service mapping)
+forwards traffic to port `80` inside the container.
+
+..  tip::
+
+    The TYPO3 container listens on port 80 — this is a convention. If your
+    host platform expects a different internal port, you must configure
+    port mapping accordingly.
+
+..  _classic-docker-reverse-proxy:
+
+Using HTTPS and reverse proxies
+===============================
+
+If you are accessing TYPO3 via `https://` but the container receives
+traffic on internal port `80`, TYPO3 may detect the request as `http://`
+and generate a site configuration with the wrong scheme.
+
+This can lead to redirect loops or broken links in the frontend.
+
+To fix this, you should use a **reverse proxy** (such as Traefik or nginx)
+that handles HTTPS and forwards the original request information to TYPO3.
+
+..  seealso::
+    For details, see: :ref:`reverse-proxy-container`
+
+After installation, **check your site configuration** in TYPO3. If it was
+automatically created with a `http://` base URL but you're accessing the site
+via `https://`, you must adjust the base URL manually in the backend:
+:guilabel:`Site Management > Sites`.


### PR DESCRIPTION
Add new chapter on port usage in container-based TYPO3 hosting

Explain how internal port 80 maps to external ports and when reverse proxies are required for HTTPS

Point users to reverse proxy chapter and highlight site config correction if TYPO3 generates an incorrect base URL

Releases: main, 13.4, 12.4
Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/5738