### PR TITLE
[TASK] Add production logging configuration guide

### DIFF
--- a/Documentation/Administration/Production/Index.rst
+++ b/Documentation/Administration/Production/Index.rst
@@ -36,12 +36,21 @@ running TYPO3 for production.
 
         *   `Backup strategy <https://docs.typo3.org/permalink/t3coreapi:administration-backups>`_
 
+    ..  card:: Configure production logging
+
+        Learn how to properly configure TYPO3 logging for production systems.
+        Covers log levels, rotation, system tools, error monitoring services
+        (e.g., Sentry), and security best practices.
+
+        *   `Logging in production <https://docs.typo3.org/permalink/t3coreapi:production-logging>`_
+
 ..  toctree::
     :titlesonly:
     :hidden:
 
     Backups/Index
     Security/Index
+    Logging/Index
     ReverseProxy/Index
     OPcache/Index
 

--- a/Documentation/Administration/Production/Logging/Index.rst
+++ b/Documentation/Administration/Production/Logging/Index.rst
@@ -1,0 +1,220 @@
+:navigation-title: Logging
+
+..  include:: /Includes.rst.txt
+..  _production-logging:
+
+========================================
+Logging considerations during production
+========================================
+
+In production environments, improperly configured logging can lead to issues
+such as bloated log files, degraded performance, and even website outages due
+to full disk space.
+
+TYPO3 offers several configuration options and tools to help keep log files
+manageable, secure, and relevant. This guide covers practical strategies for
+controlling log volume, reducing noise, and monitoring critical events.
+
+..  seealso::
+
+    For an overview of how logging works inside TYPO3 and how to use it in
+    custom code or extensions, see the :ref:`logging` chapter in the API section.
+
+..  warning::
+
+    Log files can grow rapidly in production and may eventually exhaust
+    available disk space, causing TYPO3 to become unresponsive or inaccessible.
+
+..  contents:: Table of contents
+
+..  _production-logging-level:
+
+Limit the level to be logged
+============================
+
+Each log entry in TYPO3 is associated with a severity level. For details on
+log levels, refer to the TYPO3 documentation:
+`Log levels <https://docs.typo3.org/permalink/t3coreapi:logging-logger-shortcuts>`_.
+
+During development, it is often useful to log detailed information. However,
+on production systems, only critical messages should be written to the log
+to reduce disk usage and improve performance.
+
+By default, when the
+`Application Context <https://docs.typo3.org/permalink/t3coreapi:application-context>`_
+is set to `Production`, only messages with a severity of
+:php-short:`\Psr\Log\LogLevel::ERROR` or higher are logged.
+
+You can also configure different writers for specific log levels. This allows
+you to, for example, write warnings and errors to separate files, or ignore
+lower-severity messages altogether.
+
+The following example demonstrates how to configure log writers per log
+level:
+
+..  literalinclude:: _codesnippets/_loglevels.php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
+
+..  _production-logging-monitor:
+
+Monitor the log and address common log entries
+==============================================
+
+Some log messages may appear frequently without indicating a critical or
+harmful issue. For example, an outdated
+`TypoScript condition <https://docs.typo3.org/permalink/t3tsref:typoscript-syntax-conditions-examples>`_
+written in legacy syntax can trigger log entries every time TypoScript is
+evaluated for a page.
+
+Fixing such recurring issues helps reduce the size of your log files and
+improves the overall quality and maintainability of your code base.
+
+..  _production-logging-rotation:
+
+Use log rotation
+================
+
+..  versionadded:: 13.0
+
+Replace the usage of the :php-short:`\TYPO3\CMS\Core\Log\Writer\FileWriter`
+with :php-short:`\TYPO3\CMS\Core\Log\Writer\RotatingFileWriter`. Define a
+rotation interval and specify how many rotated files should be retained.
+
+..  seealso::
+
+    *   `RotatingFileWriter configuration <https://docs.typo3.org/permalink/t3coreapi:logging-writers-rotatingfilewriter>`_
+
+The following example introduces log rotation for the "main" log file:
+
+..  literalinclude:: /ApiOverview/Logging/Writers/_additionalRotationFileWriter.php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
+
+If you are using extensions such as
+:composer:`apache-solr-for-typo3/solr` that configure custom log files,
+you also need to switch those log files to use the
+:php-short:`\TYPO3\CMS\Core\Log\Writer\RotatingFileWriter`.
+
+..  _production-logging-system-tools:
+
+Use system-Level log management tools
+=====================================
+
+In addition to TYPO3's internal logging features, it's common practice to
+use server-level tools to manage log files. These tools can rotate, archive,
+compress, or delete log files based on size, age, or other criteria.
+
+On Linux systems, consider the following tools:
+
+*   **logrotate** – A standard utility for automatic log rotation, commonly
+    pre-installed on most Linux distributions. It can be configured to manage
+    TYPO3 logs and system logs alike.
+
+*   **systemd-journald** – If your server uses systemd, you can leverage
+    journald for logging, with configurable rotation and retention.
+
+*   **cron jobs with custom scripts** – For more specific needs, administrators
+    may use scheduled scripts to archive or delete logs periodically.
+
+..  tip::
+
+    If using `logrotate`, ensure the log directory (e.g.,
+    :file:`var/log/`) is included in the configuration, and set appropriate
+    permissions so the rotation process can access the files.
+
+..  _production-logging-centralized:
+
+Use centralized error monitoring (e.g., Sentry)
+===============================================
+
+In many production environments, it is common to offload error tracking to a
+centralized service like `Sentry <https://sentry.io>`_. These tools focus on
+capturing unhandled exceptions and application errors with full context,
+including stack traces, request details, and environment variables.
+
+Sentry can often **replace the need for local error log management**,
+especially when it is used as the main tool for observing application behavior
+and alerting on failures. However, local logs may still be useful for storing
+lower-level messages, audit trails, or when dealing with infrastructure-related
+issues.
+
+TYPO3 supports Sentry integration via third-party extensions such as:
+
+*   :composer:`networkteam/sentry-client` (A Sentry client for TYPO3)
+
+..  tip::
+
+    Sentry is best suited for tracking uncaught exceptions and user-facing
+    errors. It is not designed to store full application logs such as debug
+    output or access logs.
+
+..  _deprecation-disable-errors:
+
+Disabling the deprecation log on production
+===========================================
+
+By default, when the
+`Application Context <https://docs.typo3.org/permalink/t3coreapi:application-context>`_
+is set to `Production`, the deprecation log is disabled.
+
+Check the log directory, for example :path:`/path/to/project/var/log` and ensure
+there is no logfile written with `deprecation` in its name.
+
+As a best practice if you configure the deprecation log you should only configure
+it for `Development` contexts, for example:
+
+..  literalinclude:: /ApiOverview/Deprecation/_additional.php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
+
+If, for some reason, the deprecation log is still being written in production,
+you can explicitly disable it by unsetting its configuration:
+
+..  literalinclude:: _codesnippets/_disableDeprecationLog.php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
+
+If the log continues to be written, check the following:
+
+If the deprecation log continues to be written, check the following:
+
+#.  **Verify the Application Context**
+
+    The current context (e.g., `Production`) is shown in the top bar of the TYPO3
+    backend under the :guilabel:`System Information` module.
+
+#.  **Check the resolved configuration**
+
+    Use the :guilabel:`System > Configuration` module (requires
+    :composer:`typo3/cms-lowlevel`) to inspect the effective value of
+    `$GLOBALS['TYPO3_CONF_VARS']['LOG']['TYPO3']['CMS']['deprecations']`.
+
+#.  **Look for overrides in extensions**
+
+    Some extensions may override logging settings in their
+    :file:`ext_localconf.php` or :file:`ext_tables.php`. Check these files
+    if your configuration appears to be ignored.
+
+..  _production-logging-security:
+
+Securing TYPO3 logs in production
+=================================
+
+TYPO3 logs may contain sensitive information that could be exploited by an
+attacker to gain insight into your system. Logs may also include personal
+data such as IP addresses, which must be handled with care to ensure
+privacy compliance.
+
+**In Composer-based TYPO3 installations**, logs are written to
+:path:`/path/to/project/var/log` by default. Since this directory is
+located *outside* the web server’s document root
+(:path:`/path/to/project/public`), it cannot be accessed directly from the
+internet—providing a level of built-in security.
+
+**In Classic-mode TYPO3 installations**, logs are stored in
+:path:`/path/to/project/typo3conf/var/log`. Because the document root in
+Classic mode typically points to :path:`/path/to/project`, this log
+directory is publicly accessible by default. **Additional precautions must
+be taken** to prevent unauthorized access.
+
+..  seealso::
+
+    *   `Secure file permissions (operating system level) <https://docs.typo3.org/permalink/t3coreapi:security-file-directory-permissions>`_
+    *   `Restrict HTTP access <https://docs.typo3.org/permalink/t3coreapi:security-restrict-access-server-level>`_ (for Classic mode)

--- a/Documentation/Administration/Production/Logging/Index.rst
+++ b/Documentation/Administration/Production/Logging/Index.rst
@@ -11,7 +11,7 @@ In production environments, improperly configured logging can lead to issues
 such as bloated log files, degraded performance, and even website outages due
 to full disk space.
 
-TYPO3 offers several configuration options and tools to help keep log files
+TYPO3 has several configuration options and tools to keep log files
 manageable, secure, and relevant. This guide covers practical strategies for
 controlling log volume, reducing noise, and monitoring critical events.
 
@@ -76,7 +76,7 @@ Use log rotation
 
 ..  versionadded:: 13.0
 
-Replace the usage of the :php-short:`\TYPO3\CMS\Core\Log\Writer\FileWriter`
+Replace :php-short:`\TYPO3\CMS\Core\Log\Writer\FileWriter`
 with :php-short:`\TYPO3\CMS\Core\Log\Writer\RotatingFileWriter`. Define a
 rotation interval and specify how many rotated files should be retained.
 
@@ -84,7 +84,7 @@ rotation interval and specify how many rotated files should be retained.
 
     *   `RotatingFileWriter configuration <https://docs.typo3.org/permalink/t3coreapi:logging-writers-rotatingfilewriter>`_
 
-The following example introduces log rotation for the "main" log file:
+The following example adds log rotation for the "main" log file:
 
 ..  literalinclude:: /ApiOverview/Logging/Writers/_additionalRotationFileWriter.php
     :caption: config/system/additional.php | typo3conf/system/additional.php
@@ -99,21 +99,21 @@ you also need to switch those log files to use the
 Use system-Level log management tools
 =====================================
 
-In addition to TYPO3's internal logging features, it's common practice to
+In addition to TYPO3's internal logging features, it is common practice to
 use server-level tools to manage log files. These tools can rotate, archive,
-compress, or delete log files based on size, age, or other criteria.
+compress, and delete log files based on size, age, or other criteria.
 
-On Linux systems, consider the following tools:
+On Linux systems, consider using the following tools:
 
 *   **logrotate** – A standard utility for automatic log rotation, commonly
     pre-installed on most Linux distributions. It can be configured to manage
-    TYPO3 logs and system logs alike.
+    TYPO3 logs and system logs.
 
-*   **systemd-journald** – If your server uses systemd, you can leverage
+*   **systemd-journald** – If your server uses systemd, you can use
     journald for logging, with configurable rotation and retention.
 
 *   **cron jobs with custom scripts** – For more specific needs, administrators
-    may use scheduled scripts to archive or delete logs periodically.
+    can use scheduled scripts to archive or delete logs periodically.
 
 ..  tip::
 
@@ -127,13 +127,13 @@ Use centralized error monitoring (e.g., Sentry)
 ===============================================
 
 In many production environments, it is common to offload error tracking to a
-centralized service like `Sentry <https://sentry.io>`_. These tools focus on
-capturing unhandled exceptions and application errors with full context,
+centralized service like `Sentry <https://sentry.io>`_. These tools
+capture unhandled exceptions and application errors with full context,
 including stack traces, request details, and environment variables.
 
 Sentry can often **replace the need for local error log management**,
 especially when it is used as the main tool for observing application behavior
-and alerting on failures. However, local logs may still be useful for storing
+and alerting failures. However, local logs may still be useful for storing
 lower-level messages, audit trails, or when dealing with infrastructure-related
 issues.
 
@@ -157,21 +157,19 @@ By default, when the
 is set to `Production`, the deprecation log is disabled.
 
 Check the log directory, for example :path:`/path/to/project/var/log` and ensure
-there is no logfile written with `deprecation` in its name.
+no logfile has been written with `deprecation` in the name.
 
-As a best practice if you configure the deprecation log you should only configure
-it for `Development` contexts, for example:
+As best practice you should only configure
+deprecation logs for `Development` contexts, for example:
 
 ..  literalinclude:: /ApiOverview/Deprecation/_additional.php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
-If, for some reason, the deprecation log is still being written in production,
+If the deprecation log is still being written in production,
 you can explicitly disable it by unsetting its configuration:
 
 ..  literalinclude:: _codesnippets/_disableDeprecationLog.php
     :caption: config/system/additional.php | typo3conf/system/additional.php
-
-If the log continues to be written, check the following:
 
 If the deprecation log continues to be written, check the following:
 
@@ -198,7 +196,7 @@ Securing TYPO3 logs in production
 =================================
 
 TYPO3 logs may contain sensitive information that could be exploited by an
-attacker to gain insight into your system. Logs may also include personal
+attacker to gain information about your system. Logs may also include personal
 data such as IP addresses, which must be handled with care to ensure
 privacy compliance.
 

--- a/Documentation/Administration/Production/Logging/Index.rst
+++ b/Documentation/Administration/Production/Logging/Index.rst
@@ -36,9 +36,9 @@ Each log entry in TYPO3 is associated with a severity level. For details on
 log levels, refer to the TYPO3 documentation:
 `Log levels <https://docs.typo3.org/permalink/t3coreapi:logging-logger-shortcuts>`_.
 
-During development, it is often useful to log detailed information. However,
-on production systems, only critical messages should be written to the log
-to reduce disk usage and improve performance.
+During development, it is often useful to log detailed information. In
+production, logging should be limited to important issues—typically messages at
+the `ERROR` level or higher—to reduce disk usage and improve performance.
 
 By default, when the
 `Application Context <https://docs.typo3.org/permalink/t3coreapi:application-context>`_

--- a/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
+++ b/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Core\Environment;
+
+// Add this at the very bottom of your system/additional.php
+if (Environment::getContext()->isProduction()) {
+    unset($GLOBALS['TYPO3_CONF_VARS']['LOG']['TYPO3']['CMS']['deprecations']);
+}

--- a/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
+++ b/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use TYPO3\CMS\Core\Core\Environment;
 
 // Add this at the very bottom of your system/additional.php
-// Or your site packages ext_localconf.php to override settings 
+// Or your site packages ext_localconf.php to override settings
 // made by other extensions
 if (Environment::getContext()->isProduction()) {
     unset($GLOBALS['TYPO3_CONF_VARS']['LOG']['TYPO3']['CMS']['deprecations']);

--- a/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
+++ b/Documentation/Administration/Production/Logging/_codesnippets/_disableDeprecationLog.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use TYPO3\CMS\Core\Core\Environment;
 
 // Add this at the very bottom of your system/additional.php
+// Or your site packages ext_localconf.php to override settings 
+// made by other extensions
 if (Environment::getContext()->isProduction()) {
     unset($GLOBALS['TYPO3_CONF_VARS']['LOG']['TYPO3']['CMS']['deprecations']);
 }

--- a/Documentation/Administration/Production/Logging/_codesnippets/_loglevels.php
+++ b/Documentation/Administration/Production/Logging/_codesnippets/_loglevels.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Psr\Log\LogLevel;
+use TYPO3\CMS\Core\Log\Writer\Enum\Interval;
+use TYPO3\CMS\Core\Log\Writer\NullWriter;
+use TYPO3\CMS\Core\Log\Writer\RotatingFileWriter;
+
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['writerConfiguration'] = [
+    LogLevel::WARNING => [
+        // Explicitly disable warning level logs
+        NullWriter::class => [],
+    ],
+    LogLevel::ERROR => [
+        // Keep error level logs for a week
+        RotatingFileWriter::class => [
+            'interval' => Interval::DAILY,
+            'maxFiles' => 7,
+        ],
+    ],
+    LogLevel::CRITICAL => [
+        // Keep critical level logs for eight weeks
+        RotatingFileWriter::class => [
+            'interval' => Interval::WEEKLY,
+            'maxFiles' => 8,
+        ],
+    ],
+];

--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -38,7 +38,7 @@ it.
 ..  seealso::
 
     To learn how to properly disable the deprecation log in production, see
-    :ref:`production-logging-disable-deprecation`.
+    :ref:`deprecation-disable-errors`.
 
 ..  _deprecation-enable-errors-gui:
 

--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -10,10 +10,10 @@ Deprecation handling: logging, marking and finding deprecations
 ===============================================================
 
 TYPO3 logs calls to deprecated functions to help developers identify and update
-outdated code. Deprecated methods are removed in future TYPO3 versions, so
-usage should be avoided.
+outdated code. Deprecated methods will be removed in future TYPO3 versions, so
+they should be avoided.
 
-Deprecations are triggered with :php:`trigger_error()` and pass through TYPO3’s
+Deprecations are triggered by :php:`trigger_error()` and pass through TYPO3’s
 logging and exception system. In development, they are shown as exceptions by
 default; in production, they are typically ignored.
 
@@ -30,9 +30,9 @@ default; in production, they are typically ignored.
 Enabling the deprecation log
 ============================
 
-TYPO3 ships with a default configuration, in which deprecation logging is
+TYPO3 ships with a default configuration where deprecation logging is
 **disabled**. If you upgrade to the latest TYPO3 version, you need to change
-your development configuration to enable deprecation logging in case you need
+your development configuration to enable deprecation logging if you need
 it.
 
 ..  seealso::
@@ -58,7 +58,7 @@ selecting the :guilabel:`Live` preset instead.
 
     Enabling the debug preset
 
-The debug preset enables also some other debug settings.
+The debug preset also enables some other debug settings.
 
 ..  note::
     These steps only enable/disable the :ref:`FileWriter <logging-writers-FileWriter>`,

--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -1,48 +1,46 @@
+:navigation-title: Deprecation Handling
+
 ..  include:: /Includes.rst.txt
-..  index:: ! Deprecation
-..  _deprecation:
-
-===========
-Deprecation
-===========
-
-..  contents::
-    :local:
-
-..  index:: Deprecation; Log
 ..  _deprecation_introduction:
 ..  _cgl-deprecation:
+..  _deprecation:
 
-Introduction
-============
+===============================================================
+Deprecation handling: logging, marking and finding deprecations
+===============================================================
 
-Calls to deprecated functions are logged to track usage of deprecated/outdated
-methods in the TYPO3 Core. Developers have to make sure to adjust their code to
-avoid using this old functionality since deprecated methods will be removed in
-future TYPO3 releases.
+TYPO3 logs calls to deprecated functions to help developers identify and update
+outdated code. Deprecated methods are removed in future TYPO3 versions, so
+usage should be avoided.
 
-Deprecations use the PHP method :php:`trigger_error('a message', E_USER_DEPRECATED)`
-and run through the logging and exception stack of the TYPO3 Core. There are
-several methods that help extension developers in dispatching deprecation
-errors. In the development context, deprecations are turned into exceptions by
-default and ignored in the production context.
+Deprecations are triggered with :php:`trigger_error()` and pass through TYPO3’s
+logging and exception system. In development, they are shown as exceptions by
+default; in production, they are typically ignored.
 
 ..  note::
     For information how to handle deprecations in the TYPO3 Core,
     see the Contribution Guide: :ref:`t3contribute:deprecations`.
 
+..  contents:: Table of content
+    :local:
 
 ..  index:: Deprecation; Log enabling
-..  _deprecation_disable_errors:
-..  _deprecation_enable_errors:
+..  _deprecation-enable-errors:
 
-Enabling deprecation errors
-===========================
+Enabling the deprecation log
+============================
 
 TYPO3 ships with a default configuration, in which deprecation logging is
 **disabled**. If you upgrade to the latest TYPO3 version, you need to change
 your development configuration to enable deprecation logging in case you need
 it.
+
+..  seealso::
+
+    To learn how to properly disable the deprecation log in production, see
+    :ref:`production-logging-disable-deprecation`.
+
+..  _deprecation-enable-errors-gui:
 
 Via GUI
 -------
@@ -67,6 +65,8 @@ The debug preset enables also some other debug settings.
     which comes with the TYPO3 default configuration. If you manually configured
     **additional** writers for the `TYPO3.CMS.deprecations` logger, you need to
     manually remove them to completely disable deprecation logging.
+
+..  _deprecation-enable-errors-config:
 
 Via configuration file directly
 -------------------------------

--- a/Documentation/ApiOverview/Logging/Configuration/Index.rst
+++ b/Documentation/ApiOverview/Logging/Configuration/Index.rst
@@ -1,3 +1,5 @@
+:navigation-title: Configuration
+
 ..  include:: /Includes.rst.txt
 ..  index:: pair: Logging; Configuration
 ..  _logging-configuration:
@@ -12,6 +14,13 @@ the log manager automatically applies its configuration.
 The logger configuration is read from :php:`$GLOBALS['TYPO3_CONF_VARS']['LOG']`,
 which contains an array reflecting the namespace and class hierarchy of your
 TYPO3 project.
+
+..  seealso::
+
+    Are you configuring logging for a live TYPO3 instance?
+    See :ref:`production-logging` for best practices on logging in production
+    environments, including log rotation, log levels, file storage, and
+    monitoring tools like Sentry.
 
 For example, to apply a configuration for all loggers within the
 :php:`\TYPO3\CMS\Core\Cache` namespace, the configuration is read from

--- a/Documentation/ApiOverview/Logging/Index.rst
+++ b/Documentation/ApiOverview/Logging/Index.rst
@@ -1,10 +1,22 @@
+:navigation-title: Logging
+
 ..  include:: /Includes.rst.txt
 ..  index:: ! Logging
 ..  _logging:
 
-=======
-Logging
-=======
+=======================================
+The logging framework (developer guide)
+=======================================
+
+This chapter is intended for **developers** who want to use TYPO3’s logging
+framework in their extensions, middleware, or custom services.
+
+It explains the internal architecture of the logging system and how to interact
+with it programmatically.
+
+If you're looking for production-level logging guidance (e.g., log rotation,
+monitoring, or security), see:
+:ref:`production-logging`.
 
 The chapter :ref:`logging-quickstart` helps you get started.
 
@@ -19,6 +31,11 @@ TYPO3 Logging consists of the following components:
 *   :ref:`Processors <logging-processors>` which enhance the log record with
     more detailed information.
 
+..  seealso::
+
+    Are you looking for information on how to configure logging for production
+    environments (log rotation, error monitoring, security)? See
+    `Logging in production <https://docs.typo3.org/permalink/t3coreapi:production-logging>`_.
 
 **Contents:**
 

--- a/Documentation/ApiOverview/Logging/Index.rst
+++ b/Documentation/ApiOverview/Logging/Index.rst
@@ -8,7 +8,7 @@
 The logging framework (developer guide)
 =======================================
 
-This chapter is intended for **developers** who want to use TYPO3’s logging
+This chapter is intended for **developers** who want to use the TYPO3 logging
 framework in their extensions, middleware, or custom services.
 
 It explains the internal architecture of the logging system and how to interact

--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -1,10 +1,12 @@
+:navigation-title: Quickstart
+
 ..  include:: /Includes.rst.txt
 ..  index:: Logging; Quickstart
 ..  _logging-quickstart:
 
-==========
-Quickstart
-==========
+==========================================
+Quickstart: Writing to the logger from PHP
+==========================================
 
 ..  index::
     Logging; Instantiation

--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -10,6 +10,13 @@ The purpose of a log writer is (usually) to save all log records into a
 persistent storage, like a log file, a database table, or to a remote syslog
 server.
 
+..  seealso::
+
+    If you are looking for guidance on configuring logging for production
+    environments — such as log rotation, file locations, retention, or
+    integration with tools like Sentry — see the chapter
+    :ref:`production-logging`.
+
 Different log writers offer possibilities to log into different targets.
 :ref:`Custom log writers <logging-writers-custom>` can extend the functionality
 shipped with TYPO3 Core.

--- a/Documentation/Configuration/Typo3ConfVars/LOG.rst
+++ b/Documentation/Configuration/Typo3ConfVars/LOG.rst
@@ -9,8 +9,15 @@
 LOG - Logging configuration
 ===========================
 
-:php:`$GLOBALS['TYPO3_CONF_VARS']['LOG']` holds the logging configuration. Have
-a look into the :ref:`logging` chapter for more details.
+The array :php:`$GLOBALS['TYPO3_CONF_VARS']['LOG']` defines how TYPO3 handles
+logging—what gets logged, how it's formatted, and where it's written.
 
-You can find the default logging configuration shipped with TYPO3 in the file
-:t3src:`core/Configuration/DefaultConfiguration.php`.
+Depending on your role, there are two relevant guides:
+
+*   For **developers** implementing logging in extensions or custom services,
+    see the :ref:`logging` chapter (developer guide).
+*   For **system administrators** and **DevOps** configuring logging in
+    production environments, see :ref:`production-logging`.
+
+The default logging configuration shipped with TYPO3 can be found in:
+:t3src:`core/Configuration/DefaultConfiguration.php`

--- a/Documentation/Configuration/Typo3ConfVars/LOG.rst
+++ b/Documentation/Configuration/Typo3ConfVars/LOG.rst
@@ -10,12 +10,12 @@ LOG - Logging configuration
 ===========================
 
 The array :php:`$GLOBALS['TYPO3_CONF_VARS']['LOG']` defines how TYPO3 handles
-logging—what gets logged, how it's formatted, and where it's written.
+logging—what gets logged, how it is formatted, and where it is written.
 
 Depending on your role, there are two relevant guides:
 
 *   For **developers** implementing logging in extensions or custom services,
-    see the :ref:`logging` chapter (developer guide).
+    see :ref:`logging` chapter.
 *   For **system administrators** and **DevOps** configuring logging in
     production environments, see :ref:`production-logging`.
 


### PR DESCRIPTION
Add new chapter on configuring TYPO3 logging for production environments

Covers log levels, rotation, deprecation log disabling, centralized error monitoring (e.g., Sentry), and system log management tools

Clarify separation between developer-focused logging API and production usage; add cross-links between related chapters for better navigation

Backport to 12.4 would have to be done manually due to the introduction of the rotatinglogwriter with v13.0

Releases: main, 13.4