### PR TITLE
Warn that method must be called initializeObject

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
@@ -175,10 +175,10 @@ calls this method automatically after loading the object:
 
 ..  warning::
 
-    The method must have the exact name `initializeObject()` as it is 
-    **called by its name**. Unfortunary, the method was wrongly
-    called in old examples the Extbase Book by Michael Schams and usage
-    of the wrong method names has survived in numberous Extensions.
+    Make sure you write the `initializeObject()` method name correctly (the method is
+    **called by name** in Extbase). Unfortunately, the method name was written
+    incorrectly in some older Extbase textbooks and has
+    survived in numerous extensions, making them error-prone.
 
     ..  code-block:: diff
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
@@ -173,6 +173,19 @@ calls this method automatically after loading the object:
 ..  literalinclude:: Hydrating/_codesnippets/_Blog3.php
     :caption: EXT:my_extension/Classes/Domain/Model/Blog.php
 
+..  warning::
+
+    The method must have the exact name `initializeObject()` as it is 
+    **called by its name**. Unfortunary, the method was wrongly
+    called in old examples the Extbase Book by Michael Schams and usage
+    of the wrong method names has survived in numberous Extensions.
+
+    ..  code-block:: diff
+
+        - protected function initStorageObjects()
+        + protected function initializeObject()
+
+
 ..  _extbase-model-properties-default-values-cpp:
 
 Avoid: Constructor property promotion


### PR DESCRIPTION
Releases: main, 13.4, 12.4
Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/5799