### PR TITLE
Correct the default values of CorePasswordValidator

### DIFF
--- a/Documentation/ApiOverview/Authentication/PasswordPolicies/Index.rst
+++ b/Documentation/ApiOverview/Authentication/PasswordPolicies/Index.rst
@@ -120,28 +120,28 @@ The following options are available:
 ..  confval:: upperCaseCharacterRequired
 
     :type: bool
-    :Default: false
+    :Default: true
 
     If set to :php:`true` at least one upper case character (`A`-`Z`) is required.
 
 ..  confval:: lowerCaseCharacterRequired
 
     :type: bool
-    :Default: false
+    :Default: true
 
     If set to :php:`true` at least one lower case character (`a`-`z`) is required.
 
 ..  confval:: digitCharacterRequired
 
     :type: bool
-    :Default: false
+    :Default: true
 
     If set to :php:`true` at least one digit character (`0`-`9`) is required.
 
 ..  confval:: specialCharacterRequired
 
     :type: bool
-    :Default: false
+    :Default: true
 
     If set to :php:`true` at least one special character (not `0`-`9`, `a`-`z`,
     `A`-`Z`) is required.


### PR DESCRIPTION
According to [typo3/cms-core/Configuration/DefaultConfiguration.php](https://github.com/TYPO3/typo3/blob/main/typo3/sysext/core/Configuration/DefaultConfiguration.php#L1381-L1390) all values are `true` by default.