### PR TITLE
[TASK] Streamline MimeTypeValidator option handling in FileUpload

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/Index.rst
@@ -340,13 +340,53 @@ for the detected MIME type.
 Options:
 
 `allowedMimeTypes`
-    Allowed MIME types (using */* IANA media types)
+    Array with list of allowed MIME types (using */* IANA media types),
+    like :php:`['image/jpeg', 'image/png']`.
 
 `ignoreFileExtensionCheck`
     If set to :php:`true`, the file extension check is disabled.
     Be aware of security implications when setting this to :php:`true`.
+    When enabled, the MIME type of uploaded files need to match their
+    assigned default file extension.
+    When disabled, uploading a PDF file named "test.txt" with allowed "text/plain"
+    MIME types would be accepted.
 
-..  include:: _NoExamples.rst.txt
+`notAllowedMessage`
+    Can contain a string or `LLL:EXT:...` reference that is displayed when
+    a MIME type is not allowed.
+
+`invalidExtensionMessage`
+    Can contain a string or `LLL:EXT:...` reference that is displayed when
+    an uploaded file extension does not match the default MIME-type registered for it.
+
+When using the :php-short:`\TYPO3\CMS\Extbase\Annotation\FileUpload` attribute
+the `MimeTypeValidator` is used internally when defined in the `validation['mimeType']`
+section:
+
+..  literalinclude:: _FileUploadArgument.php
+    :caption: packages/my_extension/Classes/Domain/Model/Dto/SomeDto.php
+
+When you do manual validation in an `initialize*Action` (or you otherwise need to
+make dynamic assignments to the validator options) you can call and
+configure the validator directly:
+
+..  literalinclude:: _FileUploadController.php
+    :caption: packages/my_extension/Classes/Controller/SomeController.php
+
+The example above showcases an "object" like `myArgument` containing
+a property `myPropertyName` that relates to an uploaded file. It is then
+configured with plain PHP API (without using
+the attribute `FileUpload` attribute/annotation mentioned above).
+
+It is important how the
+`$fileHandlingServiceConfiguration->addFileUploadConfiguration()` method
+call replaces the usual Extbase `propertyMappingConfiguration`. To not conflict with
+Extbase's internal property mapping, the `->skipProperties()` call
+takes care of this.
+
+Generally, for better "developer experience", it is suggested to
+use the auto-configuration provided by using the PHP attribute/annotation
+where possible.
 
 ..  _extbase-validator-notempty:
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadArgument.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadArgument.php
@@ -2,21 +2,16 @@
 
 declare(strict_types=1);
 
-namespace MyVendor\MyExtension\Domain\Model;
-
 use TYPO3\CMS\Extbase\Annotation\FileUpload;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
-use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 
-class Blog extends AbstractEntity
+class SomeDto
 {
     #[FileUpload([
         'validation' => [
             'required' => true,
-            'maxFiles' => 1,
-            'fileSize' => ['minimum' => '0K', 'maximum' => '2M'],
             'mimeType' => [
-                'allowedMimeTypes' => ['image/jpeg', 'image/png'],
+                'allowedMimeTypes' => ['image/jpeg'],
                 'ignoreFileExtensionCheck' => false,
                 'notAllowedMessage' => 'LLL:EXT:my_extension/...',
                 'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
@@ -25,6 +20,4 @@ class Blog extends AbstractEntity
         'uploadFolder' => '1:/user_upload/files/',
     ])]
     protected ?FileReference $file = null;
-
-    // getters and setters like usual
 }

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Mvc\Controller\FileUploadConfiguration;
+use TYPO3\CMS\Extbase\Validation\Validator\MimeTypeValidator;
+
+class SomeController extends ActionController
+{
+    public function initializeCreateAction(): void
+    {
+        // As Validators can contain state, do not inject them
+        $mimeTypeValidator = GeneralUtility::makeInstance(MimeTypeValidator::class);
+        $mimeTypeValidator->setOptions([
+            'allowedMimeTypes' => ['image/jpeg'],
+            'ignoreFileExtensionCheck' => false,
+            'notAllowedMessage' => 'LLL:EXT:my_extension/...',
+            'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
+        ]);
+
+        $fileHandlingServiceConfiguration = $this->arguments->getArgument('myArgument')->getFileHandlingServiceConfiguration();
+        $fileHandlingServiceConfiguration->addFileUploadConfiguration(
+            (new FileUploadConfiguration('myPropertyName'))
+                ->setRequired()
+                ->addValidator($mimeTypeValidator)
+                ->setMaxFiles(1)
+                ->setUploadFolder('1:/user_upload/files/'),
+        );
+
+        // Extbase's property mapping is not handling FileUploads, so it must not operate on this property.
+        // When using the FileUpload attribute/annotation, this internally does the same. This is covered
+        // by the `addFileUploadConfiguration()` functionality.
+        $this->arguments->getArgument('myArgument')->getPropertyMappingConfiguration()->skipProperties('myPropertyName');
+    }
+}

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_BlogEnhanced.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_BlogEnhanced.php
@@ -18,7 +18,12 @@ class Blog extends AbstractEntity
             'required' => true,
             'maxFiles' => 1,
             'fileSize' => ['minimum' => '0K', 'maximum' => '2M'],
-            'allowedMimeTypes' => ['image/jpeg'],
+            'mimeType' => [
+                'allowedMimeTypes' => ['image/jpeg'],
+                'ignoreFileExtensionCheck' => false,
+                'notAllowedMessage' => 'LLL:EXT:my_extension/...',
+                'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
+            ],
             'imageDimensions' => ['maxWidth' => 4096, 'maxHeight' => 4096],
         ],
         'uploadFolder' => '1:/user_upload/extbase_single_file/',
@@ -31,7 +36,12 @@ class Blog extends AbstractEntity
         'validation' => [
             'required' => true,
             'fileSize' => ['minimum' => '0K', 'maximum' => '2M'],
-            'allowedMimeTypes' => ['image/jpeg'],
+            'mimeType' => [
+                'allowedMimeTypes' => ['image/jpeg'],
+                'ignoreFileExtensionCheck' => false,
+                'notAllowedMessage' => 'LLL:EXT:my_extension/...',
+                'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
+            ],
         ],
         'uploadFolder' => '1:/user_upload/extbase_multiple_files/',
     ])]


### PR DESCRIPTION
This is a follow-up to the intitial try (https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/5478)

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1149
Releases: main, 13.4