### PR TITLE
[DOCS] Clarify security concerns for `newAction`

### DIFF
--- a/Documentation/CodeSnippets/Extbase/Annotation/IgnoreValidation.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Annotation/IgnoreValidation.rst.txt
@@ -11,13 +11,13 @@
    class BlogController extends AbstractController
    {
        /**
-        * Displays a form for creating a new blog
+        * Displays a form for editing an existing blog
         *
-        * @IgnoreValidation("newBlog")
+        * @IgnoreValidation("blog")
         */
-       public function newAction(?Blog $newBlog = null): ResponseInterface
+       public function editAction(Blog $blog): ResponseInterface
        {
-           $this->view->assign('newBlog', $newBlog);
+           $this->view->assign('blog', $blog);
            $this->view->assign(
                'administrators',
                $this->administratorRepository->findAll()

--- a/Documentation/CodeSnippets/Extbase/Controllers/BlogControllerNew.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/Controllers/BlogControllerNew.rst.txt
@@ -5,6 +5,7 @@
     :caption: Class T3docs\\BlogExample\\Controller\\BlogController
 
     use Psr\Http\Message\ResponseInterface;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
     use T3docs\BlogExample\Domain\Model\Blog;
 
     class BlogController extends AbstractController
@@ -12,10 +13,10 @@
         /**
          * Displays a form for creating a new blog
          */
-        public function newAction(?Blog $newBlog = null): ResponseInterface
+        public function newAction(): ResponseInterface
         {
             $this->view->assignMultiple([
-                'newBlog' => $newBlog,
+                'newBlog' => GeneralUtility::makeInstance(Blog::class),
                 'administrators' => $this->administratorRepository->findAll(),
             ]);
             return $this->htmlResponse();

--- a/Documentation/CodeSnippets/Extbase/View/HtmlResponse.rst.txt
+++ b/Documentation/CodeSnippets/Extbase/View/HtmlResponse.rst.txt
@@ -3,9 +3,10 @@
 
 ..  code-block:: php
     :caption: Class T3docs\\BlogExample\\Controller\\BlogController
-    :emphasize-lines: 18
+    :emphasize-lines: 19
 
     use Psr\Http\Message\ResponseInterface;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
     use T3docs\BlogExample\Domain\Model\Blog;
 
     class BlogController extends AbstractController
@@ -13,10 +14,10 @@
         /**
          * Displays a form for creating a new blog
          */
-        public function newAction(?Blog $newBlog = null): ResponseInterface
+        public function newAction(): ResponseInterface
         {
             $this->view->assignMultiple([
-                'newBlog' => $newBlog,
+                'newBlog' => GeneralUtility::makeInstance(Blog::class),
                 'administrators' => $this->administratorRepository->findAll(),
             ]);
             return $this->htmlResponse();

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Annotations.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Annotations.rst
@@ -69,6 +69,10 @@ Read more about this on https://usetypo3.com/dtos-in-extbase/ or see a
 :abbr:`CRUD (Create, Read, Update, Delete)` example for this on
 https://github.com/garvinhicking/gh_validationdummy/
 
+..  warning::
+    `IgnoreValidation()` must not be used for domain models supporting
+    extbase file uploads, because this leads to a property mapping error.
+
 ..  _extbase-annotation-orm:
 
 ORM (object relational model) annotations

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/ActionController.rst
@@ -36,14 +36,6 @@ parameters as this is necessary for the validation.
 
 ..  include:: /CodeSnippets/Extbase/Controllers/BlogControllerNew.rst.txt
 
-The validation of domain object can be explicitly disabled by the annotation
-:php:`@TYPO3\CMS\Extbase\Annotation\IgnoreValidation`. This might be necessary
-in actions that show forms or create domain objects.
-
-Default values can, as usual in PHP, just be indicated in the method signature.
-In the above case, the default value of the parameter :php:`$newBlog` is set to
-:php:`NULL`.
-
 If the action should render the view you can return :php:`$this->htmlResponse()`
 as a shortcut for taking care of creating the response yourself.
 
@@ -60,6 +52,18 @@ development system with activated debugging.
     :php:`initializeAction()`, :php:`initializeDoSomethingAction()` and
     :php:`errorAction()` have special meanings in initialization and error handling
     and are no Extbase actions.
+
+..  danger::
+    An action where a new object is constructed (e.g. `newAction`) does usually
+    not need the argument as action property.
+
+    `public function newAction(?Blog $blog = null)` may be a security
+    vulnerability, if no access checks are performed, since an attacker can
+    provide any blog UID and view the data of the record in the form.
+
+    It is also not required to use the `IgnoreValidation` attribute in order
+    for validation to work properly. Extbase takes care of assigning data
+    to the form in case of validation failures.
 
 ..  _extbase_class_hierarchy-define_initialization_code:
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Index.rst
@@ -121,7 +121,8 @@ The following rules validate each controller argument:
 
 *  If there is set an annotation
    :php:`\TYPO3\CMS\Extbase\Annotation\IgnoreValidation` for the argument,
-   no validation is done.
+   no validation is done. This option must not be used when working with
+   extbase file upload, because it leads to a property mapping error.
 
 *  Validators added in the annotation of the action are applied.
 

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_Annotations/_IgnoreValidation.php
@@ -11,20 +11,22 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 final class BlogController extends ActionController
 {
-    #[IgnoreValidation(['argumentName' => 'newBlog'])]
-    public function newAction(?Blog $newBlog = null): ResponseInterface
+    #[IgnoreValidation(['argumentName' => 'blog'])]
+    public function editAction(Blog $blog): ResponseInterface
     {
         // Do something
+        $this->view->assign('blog', $blog);
         return $this->htmlResponse();
     }
 
     /**
      * Use annotations instead for compatibility with TYPO3 v11:
-     * @IgnoreValidation("newBlog")
+     * @IgnoreValidation("blog")
      */
-    public function newAction2(?Blog $newBlog = null): ResponseInterface
+    public function editAction2(Blog $blog): ResponseInterface
     {
         // Do something
+        $this->view->assign('blog', $blog);
         return $this->htmlResponse();
     }
 }


### PR DESCRIPTION
This change adds a clarification for typical errors that might lead to a security vulnerability in
actions, where new objects are created.

Existing code snippets are adapted properly.

additionally, wrong usages of `IgnoreValidation`
are removed from code snippets.,