### PR TITLE
[BUGFIX] Mention necessary `crowdin_branch_name` configuration

### DIFF
--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/ExtensionIntegration.rst
@@ -171,6 +171,12 @@ Step-by-step instructions for GitHub
                     ..  literalinclude:: _codesnippets/_crowdin.yaml
                         :caption: EXT:my_extension/.github/workflows/crowdin.yaml
 
+                    ..  important::
+
+                        Make sure to configure a Crowdin branch name using the
+                        `crowdin_branch_name` configuration option of the GitHub
+                        action. Otherwise, translations are delivered incomplete
+                        by TYPO3's Crowdin Bridge.
 
                     ..  seealso::
 

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/_codesnippets/_crowdin.yaml
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/_codesnippets/_crowdin.yaml
@@ -20,6 +20,7 @@ jobs:
           config: '.crowdin.yaml'
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          crowdin_branch_name: 'main'
           upload_sources: true
           upload_translations: false
           download_sources: false


### PR DESCRIPTION
The `crowdin_branch_name` GitHub action configuration must be set, otherwise Crowdin Bridge fails to properly export translation files.

Releases: main, 13.4, 12.4