### PR TITLE
[TASK] Command: Correct indentation and headlines

### DIFF
--- a/Documentation/ApiOverview/CommandControllers/Index.rst
+++ b/Documentation/ApiOverview/CommandControllers/Index.rst
@@ -1,10 +1,11 @@
 :navigation-title: Commands
-.. include:: /Includes.rst.txt
 
-.. _cli-mode:
-.. _cli-mode-dispatcher:
-.. _cli-mode-command-controllers:
-.. _symfony-console-commands:
+..  include:: /Includes.rst.txt
+
+..  _cli-mode:
+..  _cli-mode-dispatcher:
+..  _cli-mode-command-controllers:
+..  _symfony-console-commands:
 
 ======================
 Console commands (CLI)
@@ -35,49 +36,49 @@ TYPO3 installation.
     may cause problems. Use the :ref:`query builder <database-query-builder>`
     or :ref:`DataHandler <datahandler-basics>` where appropriate.
 
-.. _symfony-console-commands-cli:
+..  _symfony-console-commands-cli:
 
 Run a command from the command line
 ===================================
 
 You can list the available commands by calling:
 
-.. tabs::
+..  tabs::
 
-   .. group-tab:: Composer-based installation
+    ..  group-tab:: Composer-based installation
 
-      .. code-block:: bash
+        ..  code-block:: bash
 
-         vendor/bin/typo3
+            vendor/bin/typo3
 
-   .. group-tab:: Classic mode installation (no Composer)
+    ..  group-tab:: Classic mode installation (no Composer)
 
-      .. code-block:: bash
+        ..  code-block:: bash
 
-         typo3/sysext/core/bin/typo3
+            typo3/sysext/core/bin/typo3
 
 For example, you can clear all caches by calling:
 
-.. include:: /_includes/CliCacheFlush.rst.txt
+..  include:: /_includes/CliCacheFlush.rst.txt
 
 Show help for the command:
 
-.. tabs::
+..  tabs::
 
-   .. group-tab:: Composer-based installation
+    ..  group-tab:: Composer-based installation
 
-      .. code-block:: bash
+        ..  code-block:: bash
 
-         vendor/bin/typo3 cache:flush -h
+            vendor/bin/typo3 cache:flush -h
 
-   .. group-tab:: Classic mode installation (no Composer)
+    ..  group-tab:: Classic mode installation (no Composer)
 
-      .. code-block:: bash
+        ..  code-block:: bash
 
-         typo3/sysext/core/bin/typo3 cache:flush -h
+            typo3/sysext/core/bin/typo3 cache:flush -h
 
 
-.. _symfony-console-commands-scheduler:
+..  _symfony-console-commands-scheduler:
 
 Running the command from the scheduler
 ======================================
@@ -86,8 +87,8 @@ By default, it is possible to run a command from the :doc:`TYPO3 scheduler
 <ext_scheduler:Index>` as well. To do this, select the task :guilabel:`Execute console commands`
 followed by your command in the :guilabel:`Schedulable Command` field.
 
-.. note::
-   You need to save and reopen the task to define command arguments.
+..  note::
+    You need to save and reopen the task to define command arguments.
 
 In order to prevent commands from being set up as scheduler tasks,
 see :ref:`deactivating-the-command-in-scheduler`.
@@ -100,6 +101,7 @@ for details on how to create commands.
 
 DataHandler usage
 =================
+
 Using the :ref:`DataHandler <datahandler-basics>` in a CLI command requires
 backend authentication.
 See :ref:`dataHandler-cli-command` for more information.

--- a/Documentation/ApiOverview/CommandControllers/ListCommands.rst
+++ b/Documentation/ApiOverview/CommandControllers/ListCommands.rst
@@ -1,4 +1,5 @@
 :navigation-title: List Core commands
+
 ..  include:: /Includes.rst.txt
 
 ..  _symfony-console-commands-list:

--- a/Documentation/ApiOverview/CommandControllers/Tutorial.rst
+++ b/Documentation/ApiOverview/CommandControllers/Tutorial.rst
@@ -1,19 +1,17 @@
-.. include:: /Includes.rst.txt
+:navigation-title: Create a command
 
-.. _console-command-tutorial:
+..  include:: /Includes.rst.txt
+..  _console-command-tutorial:
 
-========
-Tutorial
-========
-
-Create a console command from scratch
-=====================================
+===============================================
+Tutorial: Create a console command from scratch
+===============================================
 
 A console command is always situated in an extension. If you want to create
 one, :ref:`kickstart a custom extension <extension-kickstart>` or use your
 sitepackage extension.
 
-.. _console-command-tutorial-create:
+..  _console-command-tutorial-create:
 
 Creating a basic command
 ========================
@@ -27,7 +25,7 @@ created by different means.
 This command can be found in the
 `Examples extension <https://github.com/TYPO3-Documentation/t3docs-examples>`__.
 
-.. _console-command-tutorial-registration-services:
+..  _console-command-tutorial-registration-services:
 
 1. Register the command
 -----------------------
@@ -74,8 +72,8 @@ The following attributes are available:
     Give a short description. It will be displayed in the list of commands and
     the help information of the command.
 
-.. _deactivating-the-command-in-scheduler:
-.. _schedulable:
+..  _deactivating-the-command-in-scheduler:
+..  _schedulable:
 
 :yaml:`schedulable`
     By default, a command can be used in the :doc:`scheduler
@@ -116,7 +114,7 @@ The following two methods should be overridden by your class:
     return the constants
     :php:`Command::SUCCESS` or :php:`Command::FAILURE`.
 
-.. seealso::
+..  seealso::
 
    A detailed description and an example can be found in
    `the Symfony Command Documentation <https://symfony.com/doc/current/console.html>`_.
@@ -126,17 +124,17 @@ The following two methods should be overridden by your class:
 
 The above example can be run via command line:
 
-.. tabs::
+..  tabs::
 
-   .. group-tab:: Composer-based installation
+   ..  group-tab:: Composer-based installation
 
-      .. code-block:: bash
+      ..  code-block:: bash
 
          vendor/bin/typo3 examples:dosomething
 
-   .. group-tab:: Classic mode installation (no Composer)
+   ..  group-tab:: Classic mode installation (no Composer)
 
-      .. code-block:: bash
+      ..  code-block:: bash
 
          typo3/sysext/core/bin/typo3 examples:dosomething
 
@@ -146,7 +144,7 @@ succeeded.
 ..  note::
     If a newly created or changed command is not found, clear the cache:
 
-    .. code-block:: bash
+    ..  code-block:: bash
 
         vendor/bin/typo3 cache:flush
 
@@ -198,17 +196,17 @@ Add an optional argument and an optional option to your command:
 This command takes one optional argument :php:`wizardName` and one optional option,
 which can be passed on the command line:
 
-.. tabs::
+..  tabs::
 
-   .. group-tab:: Composer-based installation
+   ..  group-tab:: Composer-based installation
 
-      .. code-block:: bash
+      ..  code-block:: bash
 
          vendor/bin/typo3 examples:createwizard [-b] [wizardName]
 
-   .. group-tab:: Classic mode installation (No Composer)
+   ..  group-tab:: Classic mode installation (No Composer)
 
-      .. code-block:: bash
+      ..  code-block:: bash
 
          typo3/sysext/core/bin/typo3 examples:createwizard [-b] [wizardName]
 
@@ -224,7 +222,7 @@ User interaction on the console
 You can create a :php:`SymfonyStyle` console user interface from the
 :php:`$input` and :php:`$output` parameters to the :php:`execute()` function:
 
-.. code-block:: php
+..  code-block:: php
     :caption: EXT:examples/Classes/Command/CreateWizardCommand.php
 
     use Symfony\Component\Console\Style\SymfonyStyle;


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/5896
Releases: main, 13.4, 12.4