### PR TITLE
Add hint about templateName

### DIFF
--- a/Documentation/ApiOverview/ContentElements/MigrationListType.rst
+++ b/Documentation/ApiOverview/ContentElements/MigrationListType.rst
@@ -144,6 +144,8 @@ element "list" anymore:
 ..  literalinclude:: _Migration/_typoscript.diff
     :caption: EXT:my_extension/Configuration/Sets/MyPluginSet/setup.typoscript (diff)
 
+ Attention: :typoscript:`templateName = Generic` is a requirment. 
+
 ..  _plugins-list-type-migration-core-plugin-migration:
 
 3.  Provide an upgrade wizard for automatic content migration for TYPO3 v13.4 and v12.4

--- a/Documentation/ApiOverview/ContentElements/MigrationListType.rst
+++ b/Documentation/ApiOverview/ContentElements/MigrationListType.rst
@@ -144,7 +144,7 @@ element "list" anymore:
 ..  literalinclude:: _Migration/_typoscript.diff
     :caption: EXT:my_extension/Configuration/Sets/MyPluginSet/setup.typoscript (diff)
 
- Attention: :typoscript:`templateName = Generic` is a requirment. 
+ Attention: :typoscript:`templateName = Generic` is a requirement. 
 
 ..  _plugins-list-type-migration-core-plugin-migration:
 


### PR DESCRIPTION
It is unclear which parts of the example TypoScript are necessary. templateName = Generic
It won't work without it.
The rest of the example is not needed in most cases outside of Extbase/Fluid.