### PR TITLE
Update TypeConverter.rst

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Controller/TypeConverter.rst
@@ -50,7 +50,7 @@ The registration and configuration of a type converter is done in the extension'
           - name: extbase.type_converter
             priority: 10
             target: \DateTime
-            sources: int,string
+            sources: integer,string
 
 For conversions of Extbase controller action parameters into Extbase domain
 model objects the incoming data is usually a numeric type, but in case of an update
@@ -67,4 +67,4 @@ Thus the configuration should list :php:`array` as one of its sources:
           - name: extbase.type_converter
             priority: 10
             target: MyVendor\MyExtension\Domain\Model\MyCustomModel
-            sources: int,string,array
+            sources: integer,string,array


### PR DESCRIPTION
Take a look at the registration of the IntegerConverter in  typo3/cms-extbase/Configuration/Services.yaml.
It uses the string "integer" instead of "int". 
Registering your own TypeConverter with a source or target type of "int" does not work.