### PR TITLE
Update ModifyClearCacheActionsEvent.rst

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -53,7 +53,7 @@ Here is an example on how to utilize it for a custom cache action:
 
     $myIdentifier = 'myExtensionCustomStorageCache';
     $event->addCacheAction([
-        'id' => 'customStorageCache',
+        'id' => $myIdentifier,
         'title' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:CacheActionTitle',
         // Note to register your own route, this is an example
         'href' => (string)$uriBuilder->buildUriFromRoute('ajax_' . $myIdentifier . '_purge'),

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -33,22 +33,35 @@ The cache action array element consists of the following keys and values:
     :caption: Example cache action array
 
     $event->addCacheAction([
-        // Mandatory keys:
+        // Required keys:
         'id' => 'pages',
         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesTitle',
         'href' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
         'iconIdentifier' => 'actions-system-cache-clear-impact-low',
         // Optional, recommended keys:
         'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
-        'severity' => 'warning',
+        'severity' => 'success',
     ]);
 
 The key :php:`severity` can contain one of these strings: `notice, info, success, warning, error`.
 
-The cache identifier array is a numerical array in which the array value corresponds to the registered `id` of the cache action array:
+The cache identifier array is a numerical array in which the array value corresponds to the registered `id` of the cache action array.
+Here is an example on how to utilize it for a custom cache action:
 
 ..  code-block:: php
-    :caption: Example cache action array
+    :caption: Example cache action array combined with a cache identifier array
+
+    $myIdentifier = 'myExtensionCustomStorageCache';
+    $event->addCacheAction([
+        'id' => 'customStorageCache',
+        'title' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:CacheActionTitle',
+        // Note to register your own route, this is an example
+        'href' => (string)$uriBuilder->buildUriFromRoute('ajax_' . $myIdentifier . '_purge'),
+        'iconIdentifier' => 'actions-system-cache-clear-impact-low',
+        'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:CacheActionDescription',
+        'severity' => 'notice',
+    ]);
+    $event->addCacheActionIdentifier($myIdentifier);
 
 API
 ===

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -46,7 +46,7 @@ The cache action array element consists of the following keys and values:
 The key :php:`severity` can contain one of these strings: `notice, info, success, warning, error`.
 
 The cache identifier array is a numerical array in which the array value corresponds to the registered `id` of the cache action array.
-Here is an example on how to utilize it for a custom cache action:
+Here is an example of how to use it for a custom cache action:
 
 ..  code-block:: php
     :caption: Example cache action array combined with a cache identifier array

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -32,14 +32,23 @@ The cache action array element consists of the following keys and values:
 ..  code-block:: php
     :caption: Example cache action array
 
-    [
+    $event->addCacheAction([
+        // Mandatory keys:
         'id' => 'pages',
         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesTitle',
-        'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
         'href' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
-        'iconIdentifier' => 'actions-system-cache-clear-impact-low'
-    ]
+        'iconIdentifier' => 'actions-system-cache-clear-impact-low',
+        // Optional, recommended keys:
+        'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
+        'severity' => 'warning',
+    ]);
 
+The key :php:`severity` can contain one of these strings: `notice, info, success, warning, error`.
+
+The cache identifier array is a numerical array in which the array value corresponds to the registered `id` of the cache action array:
+
+..  code-block:: php
+    :caption: Example cache action array
 
 API
 ===


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/75658 a new array key "severity" was introduced (with TYPO3 v12) which is not yet documented, as became obvious in https://review.typo3.org/c/Packages/TYPO3.CMS/+/90205/comment/2e133b79_0b0520aa/

This patch documents the severity key and also tries to clarify the action's method/working more specifically.