### PR TITLE
[BUGFIX] Use correct `report` disposition name

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -65,7 +65,7 @@ the feature flags:
     (for report-only mode)
 
 needs to be enabled, **or** the site-specific :file:`csp.yaml` configuration
-file needs to set the `enforce` or `reporting` disposition like this:
+file needs to set the `enforce` or `report` disposition like this:
 
 ..  literalinclude:: _csp_enforce.yaml
     :language: yaml

--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_enforce.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_enforce.yaml
@@ -11,7 +11,7 @@ enforce:
 # alternatively (or additionally!), reporting can be set too,
 # for example when testing stricter rules than above
 # (note the missing 'assets.example.com')
-# reporting:
+# report:
 #   inheritDefault: true
 #   mutations:
 #    - mode: "append"


### PR DESCRIPTION
Use the correct `report` disposition name (instead of `reporting`).

URL: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/ContentSecurityPolicy/Index.html