### PR TITLE
[TASK] Update FileUpload docs to mention FileExtension(MimeTypeConsistency)Validators

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadController.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Validation/Validators/_FileUploadController.php
@@ -6,6 +6,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Mvc\Controller\FileUploadConfiguration;
 use TYPO3\CMS\Extbase\Validation\Validator\MimeTypeValidator;
+use TYPO3\CMS\Extbase\Validation\Validator\FileExtensionValidator;
 
 class SomeController extends ActionController
 {
@@ -20,11 +21,17 @@ class SomeController extends ActionController
             'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
         ]);
 
+        $fileExtensionValidator = GeneralUtility::makeInstance(FileExtensionValidator::class);
+        $fileExtensionValidator->setOptions([
+            'allowedFileExtensions' => ['jpg', 'jpeg'],
+        ]);
+
         $fileHandlingServiceConfiguration = $this->arguments->getArgument('myArgument')->getFileHandlingServiceConfiguration();
         $fileHandlingServiceConfiguration->addFileUploadConfiguration(
             (new FileUploadConfiguration('myPropertyName'))
                 ->setRequired()
                 ->addValidator($mimeTypeValidator)
+                ->addValidator($fileExtensionValidator)
                 ->setMaxFiles(1)
                 ->setUploadFolder('1:/user_upload/files/'),
         );

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_BlogExcerpt.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/_FileUpload/_BlogExcerpt.php
@@ -21,6 +21,7 @@ class Blog extends AbstractEntity
                 'notAllowedMessage' => 'LLL:EXT:my_extension/...',
                 'invalidExtensionMessage' => 'LLL:EXT:my_extension/...',
             ],
+            'fileExtension' => ['allowedFileExtensions' => ['jpg', 'jpeg', 'png']],
         ],
         'uploadFolder' => '1:/user_upload/files/',
     ])]


### PR DESCRIPTION
_Only merge backport when 13.4.18 is released._

Closes https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1296 
Closes https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1300