### PR TITLE
add hint about installing extensions to Troubleshooting

### DIFF
--- a/Documentation/ApiOverview/Autoloading/Index.rst
+++ b/Documentation/ApiOverview/Autoloading/Index.rst
@@ -61,6 +61,8 @@ information inside your extension's :file:`composer.json`. If you do not provide
 this, the autoloader falls back to the classmap autoloading like in
 non-Composer mode.
 
+..  _autoloading-troubleshooting:
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
Sometimes a class is missing. The user should get a hint how he must solve this problem.