### PR TITLE
[TASK] Clarify Install Tool backend access per Application Context

### DIFF
--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -152,9 +152,27 @@ install tool password`.
 Accessing the Install Tool in the backend
 -----------------------------------------
 
-The System Maintainer role allows for selected backend users to access the
-:guilabel:`Admin Tools` components from within the backend without further
-security measures.
+The `System Maintainer <https://docs.typo3.org/permalink/t3coreapi:confval-globals-typo3-conf-vars-sys-systemmaintainers>`_
+role allows for selected backend users to access the
+:guilabel:`Admin Tools` components from within the backend.
+
+The behavior depends on the current `Application Context <https://docs.typo3.org/permalink/t3coreapi:application-context>`_:
+
+* **Development context:**
+  All backend users with administrator privileges can access the
+  :guilabel:`Admin Tools` directly without further security measures.
+
+* **Testing context:**
+  All backend users with administrator privileges can see the
+  :guilabel:`Admin Tools` in the backend. However, an additional
+  authentication step ("sudo mode") is required. The user must re-enter
+  either their own backend password or the Install Tool password.
+
+* **Production context:**
+  Only users listed as `System Maintainers <https://docs.typo3.org/permalink/t3coreapi:confval-globals-typo3-conf-vars-sys-systemmaintainers>`_
+  can access the :guilabel:`Admin Tools`. In addition, an extra authentication
+  step ("sudo mode") is required. The user must re-enter either their own
+  backend password or the Install Tool password before being granted access.
 
 The number of system maintainers should be as low as possible to mitigate
 the risks of corrupted accounts.


### PR DESCRIPTION
Clarify the differences in accessing the Install Tool in the backend depending on the current Application Context:

- **Development**: Admin users (with or without System Maintainer role) can access the Admin Tools without further security measures.

- **Testing**: Admin users (with or without System Maintainer role) can see the Admin Tools, but must re-authenticate (backend password or Install Tool password).

- **Production**: Only System Maintainers can access the Admin Tools and must always re-authenticate.

This makes the documentation consistent with the actual behavior and avoids confusion about "further security measures".