### PR TITLE
[DOCS] Enhance example code for foreign_table_where

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/UseSiteInTCA.rst
+++ b/Documentation/ApiOverview/SiteHandling/UseSiteInTCA.rst
@@ -29,6 +29,6 @@ Example:
 
     // ...
     'fieldConfiguration' => [
-        'foreign_table_where' => ' AND ({#sys_category}.uid = ###SITE:rootPageId### OR {#sys_category}.pid = ###SITE:mySetting.categoryPid###) ORDER BY sys_category.title ASC',
+        'foreign_table_where' => ' AND ({#sys_category}.pid = ###SITE:rootPageId### OR {#sys_category}.pid = ###SITE:mySetting.categoryPid###) ORDER BY sys_category.title ASC',
     ],
     // ...


### PR DESCRIPTION
The example code adds a where condition, where the category UID is equal to the rootPageId of the site. This constraint is however pretty uncommon and I think the example should use category PID instead.