### PR TITLE
add hint about select fields to Domain Model Object

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Index.rst
@@ -18,6 +18,9 @@ information.
 The :path:`Classes/Domain/` folder contains the domain logic of your Extbase
 extension. This is where you model real-world concepts in your application
 and define how they behave.
+The Domain Model Object in the :path:`Classes/Domain/Model/` folder defines which 
+table fields are available for a database table. These must correspond to the fields in
+the TCA. All database select queries base on a Domain Model Object will have only these select fields.
 
 While Domain-Driven Design (DDD) suggests putting business-related services in
 the Domain layer, in most TYPO3 extensions you will actually see service

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Index.rst
@@ -18,9 +18,19 @@ information.
 The :path:`Classes/Domain/` folder contains the domain logic of your Extbase
 extension. This is where you model real-world concepts in your application
 and define how they behave.
+
 The Domain Model Object in the :path:`Classes/Domain/Model/` folder defines which 
 table fields are available for a database table. These must correspond to the fields in
-the TCA. All database select queries base on a Domain Model Object will have only these select fields.
+the TCA. 
+
+Queries in `Extbase repositories  <https://docs.typo3.org/permalink/t3coreapi:extbase-repository>`_
+made with the Extbase (:php:`\TYPO3\CMS\Extbase\Persistence\QueryInterface`) are limited to 
+the fields defined in the model, while `DBAL <https://docs.typo3.org/permalink/t3coreapi:doctrine-dbal>`_
+queries based on the `Query builder  <https://docs.typo3.org/permalink/t3coreapi:database-query-builder>`_
+are only limited to fields defined in the TCA.
+
+An Extbase model is a subset of the fields contained in the 
+`Record object  <https://docs.typo3.org/permalink/t3coreapi:record-objects>`_ of the connected table.
 
 While Domain-Driven Design (DDD) suggests putting business-related services in
 the Domain layer, in most TYPO3 extensions you will actually see service


### PR DESCRIPTION
There is no documentation if you switch from SQL queries of a database table to its Domain Model Object. Where must the select fields of a SQL query be added?