### PR TITLE
Update outdated executeFrontendRequest() mention

### DIFF
--- a/Documentation/Testing/FunctionalTesting/Index.rst
+++ b/Documentation/Testing/FunctionalTesting/Index.rst
@@ -178,6 +178,6 @@ To prepare a frontend test, the system can be instructed to load a set of
 This instructs the system to load the :file:`Basic.typoscript` as TypoScript
 file for the frontend page with uid 1.
 
-A frontend request can be executed calling :php:`$this->executeFrontendRequest()`. It will
+A frontend request can be executed calling :php:`$this->executeFrontendSubRequest()`. It will
 return a Response object to be further worked on, for instance it is possible to verify
 if the body :php:`->getBody()` contains some string.


### PR DESCRIPTION
The mention of `executeFrontendRequest()` is quite outdated. Since TYPO3 v11 `executeFrontendSubRequest()` should be used. `executeFrontendRequest()` has been removed with testing framework version 8.0.0.

See: https://github.com/TYPO3/testing-framework/commit/fea312cd38238bd1dbd19828ebcf34f2374e7f93#diff-8cfe230a7b65db0044a7b32148784e47da3e6521474a51d16ceaba06636b1363L1227-L1231

Releases: main, 13.4, 12.4