### PR TITLE
[TASK] Unify extension name in examples

### DIFF
--- a/Documentation/ApiOverview/FeatureToggleApi/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggleApi/Index.rst
@@ -177,7 +177,7 @@ The :ref:`t3viewhelper:typo3-fluid-feature` can be used to check for a feature i
 template:
 
 ..  code-block:: html
-    :caption: EXT:myExtension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
     <f:feature name="unifiedPageTranslationHandling">
        This is being shown if the flag is enabled

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -106,7 +106,7 @@ to render an icon in your view:
 ..  code-block:: html
 
     {namespace core = TYPO3\CMS\Core\ViewHelpers}
-    <core:icon identifier="tx-myext-svgicon" size="small" />
+    <core:icon identifier="tx-myextension-svgicon" size="small" />
 
 This will render the desired icon using an :html:`img` tag. If you prefer having
 the SVG inlined into your HTML (for example, for being able to change colors
@@ -118,7 +118,7 @@ its surrounding element if you use this option.
 
     {namespace core = TYPO3\CMS\Core\ViewHelpers}
     <core:icon
-        identifier="tx-myext-svgicon"
+        identifier="tx-myextension-svgicon"
         size="small"
         alternativeMarkupIdentifier="inline"
     />

--- a/Documentation/ApiOverview/Icon/_IconFactoryExample.php
+++ b/Documentation/ApiOverview/Icon/_IconFactoryExample.php
@@ -16,7 +16,7 @@ final class MyClass
     public function doSomething()
     {
         $icon = $this->iconFactory->getIcon(
-            'tx-myext-action-preview',
+            'tx-myextension-action-preview',
             IconSize::SMALL,
             'overlay-identifier',
         );

--- a/Documentation/ApiOverview/Icon/_Icons.php
+++ b/Documentation/ApiOverview/Icon/_Icons.php
@@ -7,20 +7,20 @@ use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 
 return [
     // Icon identifier
-    'tx-myext-svgicon' => [
+    'tx-myextension-svgicon' => [
         // Icon provider class
         'provider' => SvgIconProvider::class,
         // The source SVG for the SvgIconProvider
         'source' => 'EXT:my_extension/Resources/Public/Icons/mysvg.svg',
     ],
-    'tx-myext-bitmapicon' => [
+    'tx-myextension-bitmapicon' => [
         'provider' => BitmapIconProvider::class,
         // The source bitmap file
         'source' => 'EXT:my_extension/Resources/Public/Icons/mybitmap.png',
         // All icon providers provide the possibility to register an icon that spins
         'spinning' => true,
     ],
-    'tx-myext-anothersvgicon' => [
+    'tx-myextension-anothersvgicon' => [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:my_extension/Resources/Public/Icons/anothersvg.svg',
         // Since TYPO3 v12.0 an extension that provides icons for broader

--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/_CustomLinkHandlers/_GitHubLinkHandler.php
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/_CustomLinkHandlers/_GitHubLinkHandler.php
@@ -69,9 +69,9 @@ final class GitHubLinkHandler implements LinkHandlerInterface
     {
         $this->pageRenderer->loadJavaScriptModule('@vendor/my-extension/GitHubLinkHandler.js');
         $viewFactoryData = new ViewFactoryData(
-            templateRootPaths: ['EXT:myExt/Resources/Private/Templates/LinkBrowser'],
-            partialRootPaths: ['EXT:myExt/Resources/Private/Partials/LinkBrowser'],
-            layoutRootPaths: ['EXT:myExt/Resources/Private/Layouts/LinkBrowser'],
+            templateRootPaths: ['EXT:my_extension/Resources/Private/Templates/LinkBrowser'],
+            partialRootPaths: ['EXT:my_extension/Resources/Private/Partials/LinkBrowser'],
+            layoutRootPaths: ['EXT:my_extension/Resources/Private/Layouts/LinkBrowser'],
             request: $request,
         );
         $view = $this->viewFactory->create($viewFactoryData);

--- a/Documentation/ApiOverview/Localization/LocalizationApi/_LanguageService.rst.txt
+++ b/Documentation/ApiOverview/Localization/LocalizationApi/_LanguageService.rst.txt
@@ -47,7 +47,7 @@
         context)
 
         Example:
-        Label is defined in `EXT:my_ext/Resources/Private/Language/locallang.xlf` as:
+        Label is defined in `EXT:my_extension/Resources/Private/Language/locallang.xlf` as:
 
         ..  code-block:: php
 
@@ -67,7 +67,7 @@
               ->createFromSiteLanguage($language);
             $label = sprintf(
                  $languageService->sL(
-                     'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:downloaded_times'
+                     'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:downloaded_times'
                  ),
                  27,
                  'several'

--- a/Documentation/ApiOverview/Localization/XliffFormat.rst
+++ b/Documentation/ApiOverview/Localization/XliffFormat.rst
@@ -36,7 +36,7 @@ Here is a sample XLIFF file:
 
 ..  literalinclude:: _snippets/_example.xlf
     :language: xml
-    :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
+    :caption: EXT:my_extension/Resources/Private/Language/Modules/<file-name>.xlf
 
 The following attributes should be populated properly in order to get the
 best support in external translation tools:
@@ -79,7 +79,7 @@ This is how the translation of our sample file might look like:
 
 ..  literalinclude:: _snippets/_example2.xlf
     :language: xml
-    :caption: EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf
+    :caption: EXT:my_extension/Resources/Private/Language/Modules/<file-name>.xlf
 
 Only one language can be stored per file, and each translation into another
 language is placed in an additional file.

--- a/Documentation/ApiOverview/Localization/_snippets/_example.xlf
+++ b/Documentation/ApiOverview/Localization/_snippets/_example.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+    <file source-language="en" datatype="plaintext" original="EXT:my_extension/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
         <header/>
         <body>
             <trans-unit id="headerComment">

--- a/Documentation/ApiOverview/Localization/_snippets/_example2.xlf
+++ b/Documentation/ApiOverview/Localization/_snippets/_example2.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_ext/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
+    <file source-language="en" target-language="de" datatype="plaintext" original="EXT:my_extension/Resources/Private/Language/Modules/<file-name>.xlf" date="2020-10-18T18:20:51Z" product-name="my_ext">
         <header/>
         <body>
             <trans-unit id="headerComment" approved="yes">

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -402,7 +402,7 @@ In Fluid, you can now use the defined language key ("language"):
 
 ..  code-block:: html
 
-    <f:translate languageKey="{language}" id="LLL:EXT:my_ext/Resources/Private/Language/emails.xml:subject" />
+    <f:translate languageKey="{language}" id="LLL:EXT:my_extension/Resources/Private/Language/emails.xml:subject" />
 
 ..  _mail-fluid-email-set-request:
 


### PR DESCRIPTION
Unify the extension name of examples to an identical in all places of documentation.

Issue: #6109