### PR TITLE
[FEATURE] Rename top-level module "web" to "content"

### DIFF
--- a/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
+++ b/Documentation/ApiOverview/Backend/AccessControl/AccessControlOptions/Index.rst
@@ -58,7 +58,7 @@ Modules
    Not all submodules appear in this list. It is possible to restrict a
    submodule to admin users only. This is the case, in particular, for all
    :guilabel:`Admin Tools` and :guilabel:`System` modules, as well as the
-   :guilabel:`Web > Template` module.
+   :guilabel:`Site Management` modules.
 
    .. note::
 
@@ -129,7 +129,7 @@ Mounts
 ======
 
 TYPO3 CMS natively supports two kinds of hierarchical tree structures:
-the page tree (typically visible in the :guilabel:`Web` module) and the folder
+the page tree (typically visible in the :guilabel:`Content` module) and the folder
 tree (typically visible in the :guilabel:`File` module). Each tree is
 generated based on the *mount points* configured for the current user. So a
 page tree is drawn from the *DB Mounts* which are one or more page ids

--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -36,9 +36,14 @@ backend layouts have been
 
 .. include:: /Images/AutomaticScreenshots/BackendLayouts/PagePropertiesAppearance.rst.txt
 
+..  versionchanged:: 14.0
+    The main module `web` has been renamed to `content`.
+    See `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_
+
+
 The Info module gives an overview of the backend layouts configured or
 inherited from a parent page at
-:guilabel:`Web > Info > Pagetree overview > Type: Layouts`:
+:guilabel:`Content > Info > Pagetree overview > Type: Layouts`:
 
 .. include:: /Images/AutomaticScreenshots/BackendLayouts/PageTreeLayoutOverview.rst.txt
 

--- a/Documentation/ApiOverview/Backend/BackendModules/BackendGUI.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/BackendGUI.rst
@@ -45,8 +45,8 @@ Navigation frame
 
   The current location (i.e. page or frame) is carried over between
   navigation frames when changing modules. This means, for example, that
-  when you move from the :guilabel:`Web > Page` module to the
-  :guilabel:`Web > List` module, the same page stays selected in the page tree.
+  when you move from the :guilabel:`Content > Page` module to the
+  :guilabel:`Content > List` module, the same page stays selected in the page tree.
 
 DocHeader
   This part is always located above the Content area. It will generally

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
@@ -142,7 +142,7 @@ Module configuration options
         The module navigation component. The following are provided by the Core:
 
         :js:`@typo3/backend/tree/page-tree-element`
-            The page tree as used in the :guilabel:`Web` module.
+            The page tree as used in the :guilabel:`Content` module.
 
         :js:`@typo3/backend/tree/file-storage-tree-container`
             The file tree as used in the :guilabel:`Filelist` module.
@@ -152,7 +152,7 @@ Module configuration options
         ..  code-block:: diff
 
             'mymodule' => [
-                'parent' => 'web',
+                'parent' => 'content',
                 ...
             -   'navigationComponent' => '@typo3/backend/page-tree/page-tree-element',
             +   'navigationComponent' => '@typo3/backend/tree/page-tree-element',

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ThirdlevelModules.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ThirdlevelModules.rst
@@ -24,23 +24,23 @@ Example
 =======
 
 Registration of an additional third-level module for the
-:guilabel:`Web > Template` module in the :file:`Configuration/Backend/Modules.php`
+:guilabel:`Content > Info` module in the :file:`Configuration/Backend/Modules.php`
 file of an extension:
 
 .. code-block:: php
    :caption: EXT:my_extension/Configuration/Backend/Modules.php
 
    'web_ts_customts' => [
-       'parent' => 'web_ts',
+       'parent' => 'web_info',
        'access' => 'user',
-       'path' => '/module/web/typoscript/custom-ts',
-       'iconIdentifier' => 'module-custom-ts',
+       'path' => '/module/web/typoscript/custom-info',
+       'iconIdentifier' => 'module-custom-info',
        'labels' => [
            'title' => 'LLL:EXT:extkey/Resources/Private/Language/locallang.xlf:mod_title',
        ],
        'routes' => [
            '_default' => [
-               'target' => CustomTsController::class . '::handleRequest',
+               'target' => CustomInfoController::class . '::handleRequest',
            ],
        ],
        'moduleData' => [

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ToplevelModules.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ToplevelModules.rst
@@ -43,7 +43,7 @@ The following toplevel modules are provided by the Core:
 Register a custom toplevel module
 ==================================
 
-Toplevel modules like :guilabel:`Web` or :guilabel:`File` are registered in the
+Toplevel modules like :guilabel:`Content` or :guilabel:`File` are registered in the
 :file:`Configuration/Backend/Modules.php`. All toplevel modules provided by
 the Core are registered in EXT:core so you can look at
 :file:`typo3/sysext/core/Configuration/Backend/Modules.php` for reference.

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/_ModuleConfiguration/_AliasModule.php
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/_ModuleConfiguration/_AliasModule.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'workspaces_admin' => [
-        'parent' => 'web',
+        'parent' => 'content',
         // ...
         // choose the previous name or an alternative name
         'aliases' => ['web_WorkspacesWorkspaces'],

--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -39,7 +39,7 @@ the access list by this function call:
 
    $GLOBALS['BE_USER']->check('modules', 'web_list');
 
-Here access to the module :guilabel:`Web > List` is checked.
+Here access to the module :guilabel:`Content > List` is checked.
 
 
 .. index::

--- a/Documentation/ApiOverview/ContentElements/Index.rst
+++ b/Documentation/ApiOverview/ContentElements/Index.rst
@@ -30,7 +30,7 @@ Introduction
 
 In TYPO3, Content elements and plugins are both stored as :ref:`database-records`
 in table :sql:`tt_content`. They are usually edited in the backend in module
-:guilabel:`Web > Page`.
+:guilabel:`Content > Page`.
 
 Content elements and plugins are both used to present and manage
 content on a website, but they serve different purposes and have distinct
@@ -79,7 +79,7 @@ A **content element** is a standard unit for managing and displaying content,
 such as text, images, videos, tables, and more.
 
 In the TYPO3 backend, content elements are commonly managed in module
-:guilabel:`Web > Page`.
+:guilabel:`Content > Page`.
 
 From a technical point of view content elements are records stored in the
 database table `tt_content`. Each content

--- a/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
+++ b/Documentation/ApiOverview/Database/DatabaseStructure/Index.rst
@@ -38,7 +38,7 @@ Managed tables
 ==============
 
 Defined in the :ref:`TCA <t3tca:start>` and, by default, editable in the
-:guilabel:`Web > List` module. TYPO3 derives database schemas from the TCA
+:guilabel:`Content > List` module. TYPO3 derives database schemas from the TCA
 configuration. Required fields such as :sql:`uid` and :sql:`pid` are generated
 automatically.
 

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeRecordDownloadIsExecutedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeRecordDownloadIsExecutedEvent.rst
@@ -15,7 +15,7 @@ BeforeRecordDownloadIsExecutedEvent
 
 The event :php:`TYPO3\CMS\Backend\RecordList\Event\BeforeRecordDownloadIsExecutedEvent`
 can be used to modify the result of a download / export initiated via
-the :guilabel:`Web > List` module.
+the :guilabel:`Content > List` module.
 
 The event lets you change both the main part and the header of the data file.
 You can use it to edit data to follow GDPR rules, change or translate data,

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeRecordDownloadPresetsAreDisplayedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeRecordDownloadPresetsAreDisplayedEvent.rst
@@ -10,7 +10,7 @@ BeforeRecordDownloadPresetsAreDisplayedEvent
 
 The event :php:`TYPO3\CMS\Backend\RecordList\Event\BeforeRecordDownloadPresetsAreDisplayedEvent`
 can be used to manipulate the list of available download presets in
-the :guilabel:`Web > List` module.
+the :guilabel:`Content > List` module.
 
 See :confval:`mod.web_list.downloadPresets <t3tsref:mod-web-list-downloadpresets>`
 on how to configure download presets.

--- a/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
@@ -9,7 +9,7 @@ ModifyInfoModuleContentEvent
 
 The PSR-14 event :php:`\TYPO3\CMS\Info\Controller\Event\ModifyInfoModuleContentEvent`
 allows the content above and below the info module to be modified. The content
-added in the event is displayed in each submodule of :guilabel:`Web > Info`.
+added in the event is displayed in each submodule of :guilabel:`Content > Info`.
 
 The event also provides the :php:`getCurrentModule()` method, which
 returns the current requested submodule. It is therefore possible to

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterCompiledCacheableDataForWorkspaceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterCompiledCacheableDataForWorkspaceEvent.rst
@@ -9,7 +9,7 @@ AfterCompiledCacheableDataForWorkspaceEvent
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Workspaces\Event\AfterCompiledCacheableDataForWorkspaceEvent`
-is used in the :guilabel:`Web > Workspaces` module to find all cacheable data of
+is used in the :guilabel:`Content > Workspaces` module to find all cacheable data of
 versions of a workspace.
 
 Example

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterDataGeneratedForWorkspaceEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterDataGeneratedForWorkspaceEvent.rst
@@ -9,7 +9,7 @@ AfterDataGeneratedForWorkspaceEvent
 
 The PSR-14 event
 :php:`\TYPO3\CMS\Workspaces\Event\AfterDataGeneratedForWorkspaceEvent`
-is used in the :guilabel:`Web > Workspaces` module to find all data of versions
+is used in the :guilabel:`Content > Workspaces` module to find all data of versions
 of a workspace.
 
 Example

--- a/Documentation/ApiOverview/Events/Events/Workspaces/GetVersionedDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/GetVersionedDataEvent.rst
@@ -8,7 +8,7 @@ GetVersionedDataEvent
 =====================
 
 The PSR-14 event :php:`\TYPO3\CMS\Workspaces\Event\GetVersionedDataEvent`
-is used in the :guilabel:`Web > Workspaces` module to find all data of versions
+is used in the :guilabel:`Content > Workspaces` module to find all data of versions
 of a workspace. In comparison to :ref:`AfterDataGeneratedForWorkspaceEvent`,
 this one contains the cleaned / prepared data with an optional limit applied
 depending on the view.

--- a/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
@@ -9,7 +9,7 @@ ModifyVersionDifferencesEvent
 
 The PSR-14 event :php:`\TYPO3\CMS\Workspaces\Event\ModifyVersionDifferencesEvent`
 can be used to modify the version differences data, used for the display in the
-:guilabel:`Web > Workspaces` backend module. Those data can be accessed
+:guilabel:`Content > Workspaces` backend module. Those data can be accessed
 with the :php:`getVersionDifferences()` method and updated using the
 :php:`setVersionDifferences(array $versionDifferences)` method.
 

--- a/Documentation/ApiOverview/Events/Events/Workspaces/SortVersionedDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/SortVersionedDataEvent.rst
@@ -8,7 +8,7 @@ SortVersionedDataEvent
 ======================
 
 The PSR-14 event :php:`\TYPO3\CMS\Workspaces\Event\SortVersionedDataEvent` is
-used in the :guilabel:`Web > Workspaces` module after sorting all data for
+used in the :guilabel:`Content > Workspaces` module after sorting all data for
 versions of a workspace.
 
 Example

--- a/Documentation/ApiOverview/Fal/Administration/Storages.rst
+++ b/Documentation/ApiOverview/Fal/Administration/Storages.rst
@@ -7,7 +7,7 @@ File storages
 =============
 
 :ref:`File storages <fal-architecture-components-storage>` can be administered
-through the :guilabel:`Web > List` module. They have a few properties which
+through the :guilabel:`Content > List` module. They have a few properties which
 deserve further explanation.
 
 ..  include:: /Images/AutomaticScreenshots/Fal/AdministrationFileStorageAccessTab.rst.txt

--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Target.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Target.rst
@@ -9,7 +9,7 @@ Target
 ======
 
 The :php:`target` backend request attribute provides the target action of a
-backend route. For instance, the target of the :guilabel:`Web > List` module
+backend route. For instance, the target of the :guilabel:`Content > List` module
 is set to :php:`TYPO3\CMS\Recordlist\Controller\RecordListController::mainAction`.
 
 Example:

--- a/Documentation/ApiOverview/Workspaces/Index.rst
+++ b/Documentation/ApiOverview/Workspaces/Index.rst
@@ -345,8 +345,8 @@ You can restrict access to backend modules by setting the value of the
     :caption: EXT:my_extension/Configuration/Backend/Modules.php
 
     return [
-        'web_examples' => [
-            'parent' => 'web',
+        'content_examples' => [
+            'parent' => 'content',
             // Only available in live workspace
             'workspaces' => 'live',
             // ... other configuration

--- a/Documentation/Configuration/Modules/PageProperties/Index.rst
+++ b/Documentation/Configuration/Modules/PageProperties/Index.rst
@@ -11,7 +11,7 @@ If the user has the correct permissions, settings for a page (and in some
 cases all subpages) can be made in the page properties:
 
 ..  figure:: /Images/ManualScreenshots/Backend/PageProperties.png
-    :alt: Screenshot demonstrating the location of the "Edit page properties" button in the header of the "Web > Page" module
+    :alt: Screenshot demonstrating the location of the "Edit page properties" button in the header of the "Content > Page" module
 
     In the "Page" or "List" module click on "Edit page properties"
 

--- a/Documentation/ExtensionArchitecture/BestPractises/NamingConventions.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/NamingConventions.rst
@@ -303,12 +303,16 @@ Example usage:
 
     return [
         // Submodule key
-        'web_productmanagement' => [
-            // Main module key (use existing main module 'web' here)
-            'parent' => 'web',
+        'content_productmanagement' => [
+            // Main module key (use existing main module 'content' here)
+            'parent' => 'content',
             // ...
         ],
     ];
+
+..  versionchanged:: 14.0
+    The main module `web` has been renamed to `content`.
+    See `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_
 
 For more details have a look into the :ref:`backend-modules-configuration`
 chapter.

--- a/Documentation/ExtensionArchitecture/Extbase/Reference/FileUpload.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/FileUpload.rst
@@ -34,7 +34,7 @@ and the TCA definition:
     :caption: EXT:my_extension/Configuration/TCA/tx_myextension_domain_model_blog.php
 
 Once this is set up, you can create/edit records through the TYPO3
-backend (for example via :guilabel:`Web > List`), attach a single or
+backend (for example via :guilabel:`Content > List`), attach a single or
 multiple files in it. Then using a normal
 controller and Fluid template, you can display an image.
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Modules.rst.txt
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Modules.rst.txt
@@ -27,7 +27,7 @@
      */
     return [
         'web_examples' => [
-            'parent' => 'web',
+            'parent' => 'content',
             'position' => ['after' => 'web_info'],
             'access' => 'user',
             'workspaces' => 'live',

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Model.rst
@@ -167,7 +167,7 @@ Now the edit form for tea records will look like this:
 
     The complete input form for a tea record.
 
-The list of teas in the module :guilabel:`Web -> List` looks like this:
+The list of teas in the module :guilabel:`Content -> List` looks like this:
 
 
 ..  figure:: /Images/ManualScreenshots/ExtensionArchitecture/Tutorials/Tea/TeaList.png

--- a/Documentation/Images/AutomaticScreenshots/AccessControl/BackendUserAdmin.rst.txt
+++ b/Documentation/Images/AutomaticScreenshots/AccessControl/BackendUserAdmin.rst.txt
@@ -3,4 +3,4 @@
 .. figure:: /Images/AutomaticScreenshots/AccessControl/BackendUserAdmin.png
    :class: with-shadow
 
-   In Web > List view, the different icon for admin users
+   In :guilabel:`Content > List` view, the different icon for admin users

--- a/Documentation/Security/GuidelinesEditors/Index.rst
+++ b/Documentation/Security/GuidelinesEditors/Index.rst
@@ -111,8 +111,8 @@ additional configuration steps. If you, as an editor, should have an
 account with administrator privileges, it is often an indication of a
 misconfiguration.
 
-As an indicator, if you see a *Template* entry under the :guilabel:`Web`
-:ref:`Module menu <backend-modules-structure>` or a section :guilabel:`Admin Tools`,
+As an indicator, if you see a section :guilabel:`System`
+or even a section :guilabel:`Admin Tools` in the :ref:`Module menu <backend-modules-structure>` ,
 you definitely have the wrong permissions as an editor and you
 should get in touch with the system provider to solve this issue.
 


### PR DESCRIPTION
Did not exchange the screenshots yet, there will be more changes like this.

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1373
Releases: main