### PR TITLE
Document label references

### DIFF
--- a/Documentation/ApiOverview/Localization/Index.rst
+++ b/Documentation/ApiOverview/Localization/Index.rst
@@ -18,40 +18,42 @@
 Localization: Translating labels in TYPO3
 ==========================================
 
-In TYPO3, two main types of texts require translation:
+In TYPO3, two types of texts require translation:
 
-Interface labels and messages
-    Texts shown in the frontend or backend,
-    usually stored in the file system in `XLIFF format
-    <https://docs.typo3.org/permalink/t3coreapi:xliff>`_, for example in
-    :file:`locallang.xlf`.
-Localized content
-    Translated editorial content, such as localized
-    database records or language-specific files (e.g. PDF versions).
+Labels and messages
+    Short texts shown in the frontend or backend,
+    usually stored in `XLIFF format
+    <https://docs.typo3.org/permalink/t3coreapi:xliff>`_ in the file system,
+    for example, :file:`locallang.xlf`.
+Content
+    Editorial content, such as localized
+    database records and language-specific files (for example, PDF versions).
 
 This section covers the first type: *labels and messages*.
 For translating editorial content, see the `Localized content
 <https://docs.typo3.org/permalink/t3translate:localized-content>`_ chapter in
 the Frontend Localization Guide.
 
-TYPO3 uses translatable strings for nearly all backend labels, enabling a fully
-localizable user interface. All text uses UTF-8 encoding.
+TYPO3 uses translatable strings for backend labels, so that the
+backend is fully localizable. All text uses UTF-8 encoding.
 
-The default language is American English (en_US). The TYPO3 Core ships only
-with English labels, and extensions should do the same.
+The default language is American English (en_US). The TYPO3 Core ships
+with English labels only, and extensions should do the same.
 
 All label files use the :ref:`XLIFF format <xliff>` and are typically stored in
 :file:`Resources/Private/Language/`. (Older extensions may still use legacy
 paths.)
 
-This chapter explains the XLIFF format, TYPO3-specific details, and tools for
+This chapter explains the XLIFF format specific to TYPO3 and tools for
 managing translations.
 
 ..  toctree::
     :titlesonly:
 
-    Labels
+    Labels/Index
     Languages
     ManagingTranslations
     TranslationServer/Index
     LocalizationApi/Index
+    XliffApi
+    XliffFormat

--- a/Documentation/ApiOverview/Localization/Labels/Index.rst
+++ b/Documentation/ApiOverview/Localization/Labels/Index.rst
@@ -7,10 +7,10 @@
 Label references / LLL strings
 ==============================
 
-In many places throughout TYPO3, you can provide a string prefixed with
-`LLL:` to reference a label in the current language.
+Strings prefixed with `LLL:` are found in many places in TYPO3. They are "label
+references" - references to labels that will be translated into the current language.
 
-The general format of such a string is:
+The general format of a label reference is:
 
 ..  code-block:: text
 
@@ -22,7 +22,7 @@ For example:
 
     LLL:EXT:my_extension/Resources/Private/Language/locallang_db.xlf:mytable.myfield
 
-When a different language is required or a language file has been
+If a different language is set or a language file is
 `overridden <https://docs.typo3.org/permalink/t3coreapi:xliff-translating-custom>`_,
 the path is automatically adjusted.
 
@@ -33,20 +33,20 @@ the path is automatically adjusted.
 File paths in label references
 ==============================
 
-Localized labels are stored in files using the
+Localized labels are stored in files with
 `XLIFF format <https://docs.typo3.org/permalink/t3coreapi:xliff>`_.
 Most XLIFF files are located in
 :folder:`EXT:my_extension/Resources/Private/Language/` and its subfolders.
 
-Some specific cases use different locations:
+In some cases the locations are different:
 
-*   **Site sets** – Localization files for site set definitions are stored within
-    the set folder, for example:
+*   **Site sets** – Localization files for site set definitions are stored in
+    the site set folder, for example:
     :file:`EXT:my_extension/Configuration/Sets/MySet/labels.xlf`
-*   **Content blocks** – Third-party extensions may define their own structure.
+*   **Content blocks** – Third-party extensions can define their own structure.
     For example, the extension
     :composer:`friendsoftypo3/content-blocks` stores labels alongside the
-    content block definition:
+    content block definitions:
     :file:`EXT:my_extension/Configuration/Sets/MySet/labels.xlf`
 
 ..  _label-reference-resolve:
@@ -56,17 +56,17 @@ Resolving localized labels
 
 In many cases, such as the
 `label of a TCA field <https://docs.typo3.org/permalink/t3tca:confval-columns-label>`_,
-you can use a label reference directly, and TYPO3 resolves it automatically.
+you can use a label reference, and TYPO3 will resolve it.
 
-If label references are not resolved automatically, you can do it manually:
+If label references are not resolved, you can do it manually:
 
 ..  _label-reference-resolve-fluid:
 
 Fluid: Using the f:translate ViewHelper
 ---------------------------------------
 
-To insert translations in Fluid templates, use the
-:ref:`f:translate <t3viewhelper:typo3-fluid-translate>` ViewHelper.
+Use the :ref:`f:translate <t3viewhelper:typo3-fluid-translate>` ViewHelper to
+insert translated strings in Fluid templates.
 
 ..  code-block:: html
     :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
@@ -94,8 +94,8 @@ fetch translations from a language file and render them in the current language.
         data = LLL : EXT:blog_example/Resources/Private/Language/locallang.xlf:blog.list
     }
 
-Make sure to leave spaces around the colon following `LLL`, as required by
-general getText syntax.
+Make sure to leave spaces around the colon following `LLL` (as required by
+general getText syntax).
 
 See also:
 `Output localized strings with TypoScript
@@ -106,24 +106,24 @@ See also:
 PHP: Using the LanguageService
 ------------------------------
 
-In PHP, localized labels can be retrieved via
+In PHP localized labels can be retrieved via the
 :php-short:`\TYPO3\CMS\Core\Localization\LanguageService`, which can be created
-using :php-short:`\TYPO3\CMS\Core\Localization\LanguageServiceFactory`.
+using the :php-short:`\TYPO3\CMS\Core\Localization\LanguageServiceFactory`.
 
 The recommended way to determine the correct
 :php-short:`LanguageService` instance depends on context:
 
-*   **Frontend:** use the language from the current request object
+*   **Frontend:** use the language in the current request object
     (:php-short:`Psr\Http\Message\ServerRequestInterface`) or the default site
     language.
 *   **Backend:** use the language of the logged-in backend user.
-*   **CLI:** determine the language programmatically, depending on your use case
+*   **CLI:** determine the language programmatically depending on your use case
     (for example, when sending emails via scheduler tasks).
 
 For more details, see
 `Localization in PHP <https://docs.typo3.org/permalink/t3coreapi:extension-localization-php>`_.
 
-Once you have the correct LanguageService instance, resolve labels like this:
+Once you have the correct LanguageService instance, you can resolve labels as follows:
 
 ..  code-block:: php
 


### PR DESCRIPTION
In preparation for documenting translation domain (https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1370)

Releases: main, 13.4