### PR TITLE
[fix] add correct value "*" to match all list_type values in addPiFlexFormValue() example

### DIFF
--- a/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
+++ b/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
@@ -21,7 +21,7 @@ ExtensionManagementUtility::addToAllTCAtypes(
 );
 
 ExtensionManagementUtility::addPiFlexFormValue(
-    '',
+    '*',
     'FILE:EXT:myext/Configuration/FlexForms/MyFlexform.xml',
     $ctypeKey,
 );

--- a/Documentation/ApiOverview/FlexForms/_codesnippets/_plain_plugin.php
+++ b/Documentation/ApiOverview/FlexForms/_codesnippets/_plain_plugin.php
@@ -21,7 +21,7 @@ ExtensionManagementUtility::addToAllTCAtypes(
 );
 
 ExtensionManagementUtility::addPiFlexFormValue(
-    '',
+    '*',
     'FILE:EXT:myext/Configuration/FlexForms/MyFlexform.xml',
     $ctypeKey,
 );


### PR DESCRIPTION
The code comment in ExtensionManagementUtlity states
`@param string $piKeyToMatch Plugin key as used in the list_type field. Use the asterisk * to match all list_type values.`

The example sets the value as empty string, which would create an invalid ds structure key, imo.

```
public static function addPiFlexFormValue(string $piKeyToMatch, string $value, string $CTypeToMatch = 'list'): void
    {
        if (is_array($GLOBALS['TCA']['tt_content']['columns']) && is_array($GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'])) {
            $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds'][$piKeyToMatch . ',' . $CTypeToMatch] = $value;
        }
    }
```
https://github.com/TYPO3/typo3/blob/50acdce180c5c1f52884225c8b211507a27dd5bb/typo3/sysext/core/Classes/Utility/ExtensionManagementUtility.php#L945

Edit:
In the main branch the parameter is unused and the function triggers a deprecation message, so the empty string would be correct there. 