### PR TITLE
[FEATURE] Configure default image conversion/preview formats

### DIFF
--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -75,9 +75,9 @@ This variable can be set in one of the following files:
     Map source image extensions to the processing/output format used by
     TYPO3 when images are rendered (for example via `<f:image>`). Keys are
     original file extensions, values are target file extensions. The special key
-    `default` is used for any file extension not explicitly listed.
+    `default` is used file extensions that are not explicitly listed.
 
-    The option can not be configured in the
+    The option cannot be configured in the
     :guilabel:`Admin Tools > Settings > Configure options ...` backend module,
     but only by directly editing file :file:`config/system/additional.php`
     (recommended) or :file:`config/system/settings.php`.


### PR DESCRIPTION
The deprecated methods have never been mentioned

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1380
Releases: main