### PR TITLE
[BUGFIX] Example for v13 had parameter introduced in v14

### DIFF
--- a/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
+++ b/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
@@ -10,7 +10,6 @@ $ctypeKey = ExtensionUtility::registerPlugin(
     'my-extension-icon',
     'plugins',
     'Plugin description',
-    'FILE:EXT:my_extension/Configuration/FlexForms/MyFlexform.xml',
 );
 
 ExtensionManagementUtility::addToAllTCAtypes(


### PR DESCRIPTION
The parameter `flexForm` for `registerPlugin` was added in 14.0. The code of the example was not valid for 13.4.

References:
https://docs.typo3.org/c/typo3/cms-core/main/en-us//Changelog/14.0/Feature-107047-FlexFormEnhancements.html#feature-107047-flexform-enhancements-direct-plugin-registration-and-raw-tca-support https://review.typo3.org/c/Packages/TYPO3.CMS/+/87161 https://forge.typo3.org/issues/107047