### PR TITLE
[BUGFIX] Remove use of deprecated method in example

### DIFF
--- a/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
+++ b/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
@@ -19,9 +19,3 @@ ExtensionManagementUtility::addToAllTCAtypes(
     $ctypeKey,
     'after:subheader',
 );
-
-ExtensionManagementUtility::addPiFlexFormValue(
-    '',
-    'FILE:EXT:myext/Configuration/FlexForms/MyFlexform.xml',
-    $ctypeKey,
-);


### PR DESCRIPTION
The FlexForm was already added with the new `registerPlugin` parameter, so adding it again with the `addPiFlexFormValue` method is superfluous.

References:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Feature-107047-FlexFormEnhancements.html#impact

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Deprecation-107047-ExtensionManagementUtilityAddPiFlexFormValue.html