### PR TITLE
Configure icon of custom CE as Typeicon

### DIFF
--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_icon.diff
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_icon.diff
@@ -10,3 +10,4 @@
      'textmedia',
      'after',
  );
++$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes'][$key] = 'examples-icon-basic';


### PR DESCRIPTION
Currently, the icon is only added to the select item and is therefore only visible when editing the record. In backend previews, however, TYPO3 reverts to the default icon. By additionally registering the same icon in the `typeicon_classes`, the icon is also used in BE previews.