### PR TITLE
Using cache docs could emphasize that public:true is necessary for GU:makeInstance()

### DIFF
--- a/Documentation/ApiOverview/CachingFramework/Developer/_Services_autowiring.yaml
+++ b/Documentation/ApiOverview/CachingFramework/Developer/_Services_autowiring.yaml
@@ -3,5 +3,6 @@ services:
   # and the configuration of the cache from above
 
   MyVendor\MyExtension\MyClass:
+    public: true
     arguments:
       $cache: '@cache.myext_mycache'


### PR DESCRIPTION
As constructor dependency injection services need to be public it makes sense to reflect that in the visible example which is probably used via copy-and-paste.