### PR TITLE
[DOCS] Drop old sqlDebug configuration option

### DIFF
--- a/Documentation/Administration/SystemSettings/ProductionSettings/Index.rst
+++ b/Documentation/Administration/SystemSettings/ProductionSettings/Index.rst
@@ -18,7 +18,6 @@ To ensure a secure installation of TYPO3 on a production server, the following s
       :caption: config/system/additional.php | typo3conf/system/additional.php
 
       $GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors'] = '0';
-      $GLOBALS['TYPO3_CONF_VARS']['SYS']['sqlDebug'] = '0';
       $GLOBALS['TYPO3_CONF_VARS']['FE']['debug'] = '0';
       $GLOBALS['TYPO3_CONF_VARS']['BE']['debug'] = '0';
 


### PR DESCRIPTION
Remove $GLOBALS['TYPO3_CONF_VARS']['SYS']['sqlDebug'] = '0'; cause it is removed since TYPO3 v9. See https://docs.typo3.org/permalink/changelog:breaking-82421