### PR TITLE
Correct typo in unit tests section

### DIFF
--- a/Documentation/Testing/ExtensionTesting.rst
+++ b/Documentation/Testing/ExtensionTesting.rst
@@ -129,7 +129,7 @@ configurations and settings and everything done during
 
 ..  note::
 
-    Rule of dumb: Unit tests are isolated tests not using real services.
+    Rule of thumb: Unit tests are isolated tests not using real services.
 
 See also :ref:`Writing unit tests <testing-writing-unit>`
 


### PR DESCRIPTION
Correct "rule of dumb" to "rule of thumb"