### PR TITLE
Add note about executeStatement return value

### DIFF
--- a/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
@@ -404,6 +404,8 @@ Remarks:
 
 *   :php:`->update()` ignores :php:`->join()` and :php:`->setMaxResults()`.
 
+*   :php:`->executeStatement()` returns the number of affected rows.
+
 *   The API does not magically add `deleted = 0` or other restrictions, as is
     currently the case with :ref:`select
     <database-query-builder-select-restrictions>`, for example.


### PR DESCRIPTION
executeStatement returns the number of affected rows. This number is needed in some cases.