### PR TITLE
[fix] Add flexform to extbase plugin example

### DIFF
--- a/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
+++ b/Documentation/ApiOverview/FlexForms/_codesnippets/_extbase_plugin.php
@@ -10,7 +10,6 @@ $ctypeKey = ExtensionUtility::registerPlugin(
     'my-extension-icon',
     'plugins',
     'Plugin description',
-    'FILE:EXT:my_extension/Configuration/FlexForms/MyFlexform.xml',
 );
 
 ExtensionManagementUtility::addToAllTCAtypes(
@@ -18,4 +17,10 @@ ExtensionManagementUtility::addToAllTCAtypes(
     '--div--;Configuration,pi_flexform,',
     $ctypeKey,
     'after:subheader',
+);
+
+ExtensionManagementUtility::addPiFlexFormValue(
+    '',
+    'FILE:EXT:myext/Configuration/FlexForms/MyFlexform.xml',
+    $ctypeKey,
 );


### PR DESCRIPTION
This PR fixes the example on how to add a Flexform to an extbase plugin.

There is no parameter for the flexform path in ExtensionUtility:registerPlugin(). It always has been
```
\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
    $pluginSignature, // or since TYPO3 12 $cTypeKey
    'FILE:EXT:example/Configuration/FlexForms/Registration.xml'
);
```


Source:
[Feature: #82809](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-82809-MakeExtensionUtilityregisterPluginMethodReturnPluginSignature.html)
[11.5 API](https://api.typo3.org/11.5/classes/TYPO3-CMS-Extbase-Utility-ExtensionUtility.html#method_registerPlugin)
[12.4 API](https://api.typo3.org/12.4/classes/TYPO3-CMS-Extbase-Utility-ExtensionUtility.html#method_registerPlugin)
[13.4 API](https://api.typo3.org/13.4/classes/TYPO3-CMS-Extbase-Utility-ExtensionUtility.html#method_registerPlugin)