### PR TITLE
[TASK] Normalize formatting of all XLF files

### DIFF
--- a/Documentation/CodingGuidelines/CglXliff/Index.rst
+++ b/Documentation/CodingGuidelines/CglXliff/Index.rst
@@ -17,7 +17,7 @@ XLIFF coding guidelines
 Language files are typically stored in `XLIFF <https://en.wikipedia.org/wiki/XLIFF>`__
 files. XLIFF is based on XML.
 
-..  content:: Table of contents
+..  contents:: Table of contents
 
 ..  seealso::
 


### PR DESCRIPTION
XLIFF files are now indented with 2 spaces

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1516
Releases: main