### PR TITLE
Add typo3temp as shared and fix symlink

### DIFF
--- a/Documentation/Administration/Deployment/AutomatedDeployment/Index.rst
+++ b/Documentation/Administration/Deployment/AutomatedDeployment/Index.rst
@@ -51,7 +51,8 @@ This is an example directory structure of a "symlink-switching" TYPO3 installati
             *   :path:`public` (webserver root, via releases/current/public)
 
                 *   :path:`typo3conf`
-                *   :path:`fileadmin -> ../../../shared/fileadmin` (symlink)
+                *   :path:`fileadmin -> ../../../shared/public/fileadmin` (symlink)
+                *   :path:`typo3temp -> ../../../shared/public/typo3temp` (symlink)
                 *   :file:`index.php`
 
             *   :path:`var`


### PR DESCRIPTION
* Add `public/typo3temp` as shared folder as it prevents missing assets after deployment
* Add `public` to the shared links of fileadmin and typo3temp