### PR TITLE
Fix hidden extbase note

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Reference/Domain/Model/Index.rst
@@ -137,7 +137,8 @@ to avoid data mapping errors.
 Nullable and `Union types <https://docs.typo3.org/permalink/t3coreapi:extbase-model-properties-union-types>`_
 are also supported.
 
-..  note:: Typed properties are strongly encouraged in all new TYPO3 extensions.
+..  note::
+    Typed properties are strongly encouraged in all new TYPO3 extensions.
 
 ..  _extbase-model-properties-default-values:
 


### PR DESCRIPTION
The note at the end of section "Typed vs. untyped properties in Extbase models" is hidden, due to missing line-break.