### PR TITLE
[TASK] Add contextualizing paragraph to Classic Mode TYPO3 Installation

### DIFF
--- a/Documentation/Administration/Installation/ClassicMode/Index.rst
+++ b/Documentation/Administration/Installation/ClassicMode/Index.rst
@@ -10,6 +10,8 @@
 Classic mode TYPO3 installation (No Composer required)
 ======================================================
 
+This installation method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org>`_ via a regular backend module. It is ideal for managed hosting, automated updates by the hosting provider, and simpler setups. It is also well-suited for beginners, due to the GUI-based extension handling. Consider `installing TYPO3 with Composer <https://docs.typo3.org/permalink/t3coreapi:installation-composer>`_, if you value flexibility in dependency management, integration with version control, and easier environment automation. `Migrating a TYPO3 project to Composer <https://docs.typo3.org/permalink/t3coreapi:migratetocomposer>`_ is possible later, but takes effort and means restructuring the project.
+
 There are two installation methods for a Classic mode TYPO3 installation.
 If you have shell (SSH) access we recommend using `wget and
 symlinks <https://docs.typo3.org/permalink/t3coreapi:classic-symlink-installation>`_.

--- a/Documentation/Administration/Installation/ClassicMode/Index.rst
+++ b/Documentation/Administration/Installation/ClassicMode/Index.rst
@@ -10,7 +10,16 @@
 Classic mode TYPO3 installation (No Composer required)
 ======================================================
 
-This installation method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org>`_ via a regular backend module. It is ideal for managed hosting, automated updates by the hosting provider, and simpler setups. It is also well-suited for beginners, due to the GUI-based extension handling. Consider :ref:`installing TYPO3 with Composer <installation-composer>`, if you value flexibility in dependency management, integration with version control, and easier environment automation. :ref:`Migrating a TYPO3 project to Composer <migratetocomposer>` is possible later, but takes effort and means restructuring the project.
+This installation method includes access to the `TYPO3 Extension Repository (TER)
+<https://extensions.typo3.org>`_ via a regular backend module. It is ideal for
+managed hosting, automated updates by the hosting provider, and simpler setups.
+It is also well suited for beginners due to the GUI-based extension handling.
+
+Consider :ref:`installing TYPO3 with Composer <installation-composer>` if you
+value flexibility in dependency management, integration with version control,
+and easier environment automation. :ref:`Migrating a TYPO3 project to Composer
+<migratetocomposer>` is possible later, but it requires effort and involves
+restructuring the project.
 
 There are two installation methods for a Classic mode TYPO3 installation.
 If you have shell (SSH) access we recommend using `wget and

--- a/Documentation/Administration/Installation/ClassicMode/Index.rst
+++ b/Documentation/Administration/Installation/ClassicMode/Index.rst
@@ -10,7 +10,7 @@
 Classic mode TYPO3 installation (No Composer required)
 ======================================================
 
-This installation method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org>`_ via a regular backend module. It is ideal for managed hosting, automated updates by the hosting provider, and simpler setups. It is also well-suited for beginners, due to the GUI-based extension handling. Consider `installing TYPO3 with Composer <https://docs.typo3.org/permalink/t3coreapi:installation-composer>`_, if you value flexibility in dependency management, integration with version control, and easier environment automation. `Migrating a TYPO3 project to Composer <https://docs.typo3.org/permalink/t3coreapi:migratetocomposer>`_ is possible later, but takes effort and means restructuring the project.
+This installation method includes access to the `TYPO3 Extension Repository (TER) <https://extensions.typo3.org>`_ via a regular backend module. It is ideal for managed hosting, automated updates by the hosting provider, and simpler setups. It is also well-suited for beginners, due to the GUI-based extension handling. Consider :ref:`installing TYPO3 with Composer <installation-composer>`, if you value flexibility in dependency management, integration with version control, and easier environment automation. :ref:`Migrating a TYPO3 project to Composer <migratetocomposer>` is possible later, but takes effort and means restructuring the project.
 
 There are two installation methods for a Classic mode TYPO3 installation.
 If you have shell (SSH) access we recommend using `wget and


### PR DESCRIPTION
This contextualization is otherwise given in the Installation Overview (https://docs.typo3.org/permalink/t3coreapi:installation-index), but is not available to users landing on this page directly.