### PR TITLE
Querybuilder: Mention the class name

### DIFF
--- a/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
@@ -10,6 +10,7 @@ Query builder
     :depth: 1
     :local:
 
+Class name: :php:`TYPO3\CMS\Core\Database\Query\QueryBuilder`.
 The query builder provides a set of methods to create queries
 programmatically.
 

--- a/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
@@ -10,8 +10,7 @@ Query builder
     :depth: 1
     :local:
 
-Class name: :php:`TYPO3\CMS\Core\Database\Query\QueryBuilder`.
-The query builder provides a set of methods to create queries
+The :php-short:`TYPO3\CMS\Core\Database\Query\QueryBuilder` provides a set of methods to create queries
 programmatically.
 
 This chapter provides examples of the most common queries.


### PR DESCRIPTION
If the documentation talks about the query builder, then it is helpful to see its full namespace class name:

TYPO3\CMS\Core\Database\Query\QueryBuilder