### PR TITLE
fix errors in note for ExpressionBuilder::as

### DIFF
--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -186,9 +186,11 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
 
 ..  note::
 
-    Some :php:`ExpressionBuilder` methods (like :php:`select()` and :php:`from()`) provide an argument to directly add
-    the expression alias to reduce nesting. This new method can be used for
-    custom expressions and avoids recurring conditional quoting and alias appending.
+    The :php:`QueryBuilder` method :php:`from()` provides a second argument to directly add
+    the expression alias and the method :php:`select()` can have it by adding the :php:` AS ` keyword 
+    to improve readability. 
+    This new method can be used for custom expressions and avoids recurring conditional 
+    quoting and alias appending.
 
 ..  literalinclude:: _RepositoryAs.php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -190,7 +190,8 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
     the expression alias and the method :php:`select()` can have it by adding the :sql:`AS` keyword 
     to improve readability. 
     This new method can be used for custom expressions and avoids recurring conditional 
-    quoting and alias appending.
+    the expression alias to reduce nesting. This new method can be used for
+    custom expressions and avoids recurring conditional quoting and alias appending.
 
 ..  literalinclude:: _RepositoryAs.php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -187,8 +187,6 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
 ..  note::
 
     The :php-short:`\TYPO3\CMS\Core\Database\Query\QueryBuilder` method :php:`from()` provides a second argument to directly add
-    the expression alias and the method :php:`select()` can have it by adding the :sql:`AS` keyword 
-    to improve readability. 
     the expression alias to reduce nesting. This new method can be used for
     custom expressions and avoids recurring conditional quoting and alias appending.
 

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -189,7 +189,6 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
     The :php-short:`\TYPO3\CMS\Core\Database\Query\QueryBuilder` method :php:`from()` provides a second argument to directly add
     the expression alias and the method :php:`select()` can have it by adding the :sql:`AS` keyword 
     to improve readability. 
-    This new method can be used for custom expressions and avoids recurring conditional 
     the expression alias to reduce nesting. This new method can be used for
     custom expressions and avoids recurring conditional quoting and alias appending.
 

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -186,7 +186,7 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
 
 ..  note::
 
-    The :php:`QueryBuilder` method :php:`from()` provides a second argument to directly add
+    The :php-short:`\TYPO3\CMS\Core\Database\Query\QueryBuilder` method :php:`from()` provides a second argument to directly add
     the expression alias and the method :php:`select()` can have it by adding the :sql:`AS` keyword 
     to improve readability. 
     This new method can be used for custom expressions and avoids recurring conditional 

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -186,7 +186,7 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
 
 ..  note::
 
-    The :php-short:`\TYPO3\CMS\Core\Database\Query\QueryBuilder` method :php:`from()` provides a second argument to directly add
+    Some :php-short:`\TYPO3\CMS\Core\Database\Query\QueryBuilder` methods (like :php:`select()` and :php:`from()`) provide an argument to directly add
     the expression alias to reduce nesting. This new method can be used for
     custom expressions and avoids recurring conditional quoting and alias appending.
 

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -187,7 +187,7 @@ Creates a statement to append a field alias to a value, identifier or sub-expres
 ..  note::
 
     The :php:`QueryBuilder` method :php:`from()` provides a second argument to directly add
-    the expression alias and the method :php:`select()` can have it by adding the :php:` AS ` keyword 
+    the expression alias and the method :php:`select()` can have it by adding the :sql:`AS` keyword 
     to improve readability. 
     This new method can be used for custom expressions and avoids recurring conditional 
     quoting and alias appending.


### PR DESCRIPTION
The ExpressionBuilder class has neither a for nor a select method. It is the QueryBuilder instead. And the Select has no alias parameter. 

I cannot understand what is meant with the reducing of nesting by using an alias.