### PR TITLE
Fix DataHandler tt_content.categories format

### DIFF
--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -523,11 +523,7 @@ one new system category:
     $data['tt_content']['NEWbe68s587'] = [
         'header' => 'Look ma, categories!',
         'pid' => 45,
-        'categories' => [
-            1,
-            2,
-            'NEW9823be87', // You can also use placeholders here
-        ],
+        'categories' => '1,2,NEW9823be87', // category uids are listed in a comma-separated string. You can also use placeholders here.
     ];
 
 ..  note::


### PR DESCRIPTION
Hello,

After using the documentation trying to attach categories to pages and contents on TYPO3 v13, I encountered an issue where the categories wouldn't attach at all even though I followed correctly the DataHandler documentation. Turns out the pages.categories as well as tt_content.categories expects a comma-separated uid string, and not an array.

So I took the liberty to fix the documentation in that regard. I hope it's okay.

Feel free to get back to me if anything else need to be changed, or if I need to go on another process to proceed.

In advance, thank you!
