### PR TITLE
[DOCS] Fix example for retrieving nonce with PHP

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -691,12 +691,15 @@ The nonce can be retrieved via the
 
 ..  code-block:: php
 
-    // use TYPO3\CMS\Core\Domain\ConsumableString
+    // use TYPO3\CMS\Core\Security\ContentSecurityPolicy\ConsumableNonce
+    // use TYPO3\CMS\Core\Security\ContentSecurityPolicy\Directive
 
-    /** @var ConsumableString|null $nonceAttribute */
+    /** @var ConsumableNonce|null $nonceAttribute */
     $nonceAttribute = $this->request->getAttribute('nonce');
-    if ($nonceAttribute instanceof ConsumableString) {
-        $nonce = $nonceAttribute->consume();
+    if ($nonceAttribute instanceof ConsumableNonce) {
+        $nonce = $nonceAttribute->consumeInline(Directive::ScriptSrcElem); // inline script
+        // or
+        $nonce = $nonceAttribute->consumeStatic(Directive::StyleSrcElem);  // static style
     }
 
 In a Fluid template


### PR DESCRIPTION
Since commit https://git.typo3.org/typo3/typo3/-/commit/80f74700c14c4f40a083127a39c2e536a83a6de8 the `ConsumableNonce` no longer extends `ConsumableString` rendering the old example invalid.