### PR TITLE
[BUGFIX] wrong codesnippet in SEL docs

### DIFF
--- a/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
+++ b/Documentation/ApiOverview/SymfonyExpressionLanguage/Index.rst
@@ -89,7 +89,7 @@ Additional functions
 Additional functions can be provided with another class that has to be
 registered in the provider:
 
-..  literalinclude:: _codesnippets/_CustomConditionFunctionsProvider.php
+..  literalinclude:: _codesnippets/_CustomTypoScriptConditionProvider.php
     :caption: EXT:my_extension/Classes/ExpressionLanguage/CustomTypoScriptConditionProvider.php
 
 The (artificial) implementation below calls some external URL based on given variables:


### PR DESCRIPTION
Corrected an incorrectly rendered code example in the Symfony Expression Language (SEL) documentation under Additional functions to ensure accurate and readable output.

Releases: main, 13.4