### PR TITLE
[DOCS] Document Fluid versions for TYPO3 versions

### DIFF
--- a/Documentation/ApiOverview/Fluid/Index.rst
+++ b/Documentation/ApiOverview/Fluid/Index.rst
@@ -18,6 +18,7 @@ Fluid is a templating engine commonly used within TYPO3.
     UsingFluidInTypo3
     DevelopCustomViewhelper
     ViewHelper reference <https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/>
+    Versions
 
 ..  _fluid-syntax:
 ..  _fluid-variables-reserved:

--- a/Documentation/ApiOverview/Fluid/Versions.rst
+++ b/Documentation/ApiOverview/Fluid/Versions.rst
@@ -13,15 +13,15 @@ on your project's update schedule and the release dates of TYPO3 versions.
 +-----------------+---------------------------------+
 | TYPO3 version   | Fluid version                   |
 +=================+=================================+
-| TYPO3 14        | Fluid 5.x                       |
+| TYPO3 v14       | Fluid 5.x                       |
 +-----------------+---------------------------------+
-| TYPO3 13        | Fluid 4.x                       |
+| TYPO3 v13       | Fluid 4.x                       |
 +-----------------+---------------------------------+
-| TYPO3 12        | Fluid 2.x                       |
+| TYPO3 v12       | Fluid 2.x                       |
 +-----------------+---------------------------------+
-| TYPO3 11        | Fluid 2.7.2                     |
-|                 | (2.x for composer-based setups) |
+| TYPO3 v11       | Fluid 2.7.2                     |
+|                 | (2.x for Composer-based setups) |
 +-----------------+---------------------------------+
 
 An overview of all available Fluid versions is available
-`on packagist <https://packagist.org/packages/typo3fluid/fluid>`_.
+`on Packagist <https://packagist.org/packages/typo3fluid/fluid>`_.

--- a/Documentation/ApiOverview/Fluid/Versions.rst
+++ b/Documentation/ApiOverview/Fluid/Versions.rst
@@ -1,0 +1,27 @@
+..  include:: /Includes.rst.txt
+..  _fluid-versions:
+
+==============
+Fluid Versions
+==============
+
+Each major TYPO3 version uses a specific Fluid major version. Usually, your
+project will always use the latest minor/patch-level version of that Fluid
+version. However the versions can be out-of-sync for short periods depending
+on your project's update schedule and the release dates of TYPO3 versions.
+
++-----------------+---------------------------------+
+| TYPO3 version   | Fluid version                   |
++=================+=================================+
+| TYPO3 14        | Fluid 5.x                       |
++-----------------+---------------------------------+
+| TYPO3 13        | Fluid 4.x                       |
++-----------------+---------------------------------+
+| TYPO3 12        | Fluid 2.x                       |
++-----------------+---------------------------------+
+| TYPO3 11        | Fluid 2.7.2                     |
+|                 | (2.x for composer-based setups) |
++-----------------+---------------------------------+
+
+An overview of all available Fluid versions is available
+`on packagist <https://packagist.org/packages/typo3fluid/fluid>`_.


### PR DESCRIPTION
Original patch: https://github.com/TYPO3/Fluid/pull/1248

Releases: main, 13.4, 12.4