### PR TITLE
[BUGFIX] Migrate old href cache actions to endpoint

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -2,13 +2,19 @@
 ..  index:: Events; ModifyClearCacheActionsEvent
 ..  _ModifyClearCacheActionsEvent:
 
-
 ============================
 ModifyClearCacheActionsEvent
 ============================
 
+..  versionchanged:: 14.3
+    The `CacheAction` array key `href` used in cache action definitions
+    provided via the :php-short:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
+    has been deprecated in favor of `endpoint`. The new key name better reflects
+    the purpose of this field, which is used as an AJAX endpoint URL. The value
+    must be a :php:`string`. See :ref:`Migration <ModifyClearCacheActionsEvent-migration-v14>`.
+
 The PSR-14 event :php:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
-is fired in the :php:`\TYPO3\CMS\Backend\Backend\ToolbarItems\ClearCacheToolbarItem`
+is fired in the :php-short:`\TYPO3\CMS\Backend\Backend\ToolbarItems\ClearCacheToolbarItem`
 class and allows extension authors to modify the clear cache actions, shown
 in the TYPO3 backend top toolbar.
 
@@ -17,6 +23,10 @@ actions, as well as to add new actions. Therefore, the event also
 contains, next to the usual "getter" and "setter" methods, the convenience
 method :php:`add()` for the :php:`cacheActions` and
 :php:`cacheActionIdentifiers` arrays.
+
+..  contents::
+
+..  _ModifyClearCacheActionsEvent-example:
 
 Example
 =======
@@ -27,7 +37,89 @@ Example
 
 ..  include:: /_includes/EventsAttributeAdded.rst.txt
 
+The response returned by the AJAX endpoint should look like this:
+
+.. code-block:: php
+
+   use TYPO3\CMS\Core\Http\JsonResponse;
+
+   // Success
+   return new JsonResponse([
+       'success' => true,
+       'title'   => $languageService->sL('myext.messages:notification.success.title'),
+       'message' => $languageService->sL('myext.messages:notification.success.message'),
+   ]);
+
+   // Failure
+   return new JsonResponse([
+       'success' => false,
+       'title'   => $languageService->sL('myext.messages:notification.error.title'),
+       'message' => $languageService->sL('myext.messages:notification.error.message'),
+   ]);
+
+..  _ModifyClearCacheActionsEvent-api:
+
+API
+===
+
+..  include:: /CodeSnippets/Events/Backend/ModifyClearCacheActionsEvent.rst.txt
+
+..  _ModifyClearCacheActionsEvent-api-add-cache-action:
+
+addCacheAction
+--------------
+
 The cache action array element consists of the following keys and values:
+
+..  confval:: id
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-id
+    :required: true
+    :type: string
+
+    Contains an existing cache id like `pages` or `all` or one registered via
+    the :ref:`addCacheActionIdentifier <ModifyClearCacheActionsEvent-api-add-cache-identifier>`.
+
+..  confval:: title
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-title
+    :required: true
+    :type: string or LLL reference
+
+    The title displayed in the clear cache menu.
+
+..  confval:: endpoint
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-endpoint
+    :required: true
+    :type: string
+
+    The AJAX endpoint. AJAX endpoints registered as custom cache actions via
+    :php:`ModifyClearCacheActionsEvent` should return a JSON response containing
+    `success`, `title`, and `message` fields.
+
+    The clear-cache toolbar treats a missing or non-:php:`false` :php:`success`
+    value as a successful operation and falls back to generic notification labels
+    when :php:`title` or :php:`message` are absent. Providing explicit values,
+    however, gives users meaningful, context-specific feedback and ensures error
+    conditions are surfaced correctly.
+
+..  confval:: iconIdentifier
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-iconIdentifier
+    :required: true
+    :type: string
+
+    An icon to be displayed in the clear cache menu
+
+..  confval:: description
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-description
+    :type: string or LLL reference
+
+    The description displayed in the clear cache menu.
+
+..  confval:: severity
+    :name: ModifyClearCacheActionsEvent-api-add-cache-action-severity
+    :type: string or LLL reference
+
+    The key :php:`severity` can contain one of these strings: `notice`, `info`,
+    `success`, `warning`, `error`.
 
 ..  code-block:: php
     :caption: Example cache action array
@@ -35,17 +127,21 @@ The cache action array element consists of the following keys and values:
     $event->addCacheAction([
         // Required keys:
         'id' => 'pages',
-        'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesTitle',
-        'href' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
+        'title' => 'core.cache:group.pages.label',
+        'endpoint' => (string)$uriBuilder->buildUriFromRoute('tce_db', ['cacheCmd' => 'pages']),
         'iconIdentifier' => 'actions-system-cache-clear-impact-low',
         // Optional, recommended keys:
-        'description' => 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:flushPageCachesDescription',
+        'description' => 'core.cache:group.pages.description',
         'severity' => 'success',
     ]);
 
-The key :php:`severity` can contain one of these strings: `notice, info, success, warning, error`.
+..  _ModifyClearCacheActionsEvent-api-add-cache-identifier:
 
-The cache identifier array is a numerical array in which the array value corresponds to the registered `id` of the cache action array.
+addCacheActionIdentifier
+------------------------
+
+The cache identifier array is a numerical array in which the array value
+corresponds to the registered `id` of the cache action array.
 Here is an example of how to use it for a custom cache action:
 
 ..  code-block:: php
@@ -54,16 +150,33 @@ Here is an example of how to use it for a custom cache action:
     $myIdentifier = 'myExtensionCustomStorageCache';
     $event->addCacheAction([
         'id' => $myIdentifier,
-        'title' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:CacheActionTitle',
+        'title' => 'my_extension.cache:label',
         // Note to register your own route, this is an example
-        'href' => (string)$uriBuilder->buildUriFromRoute('ajax_' . $myIdentifier . '_purge'),
+        'endpoint' => (string)$uriBuilder->buildUriFromRoute('ajax_' . $myIdentifier . '_purge'),
         'iconIdentifier' => 'actions-system-cache-clear-impact-low',
-        'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:CacheActionDescription',
+        'description' => 'my_extension.cache:description',
         'severity' => 'notice',
     ]);
     $event->addCacheActionIdentifier($myIdentifier);
 
-API
-===
+..  _ModifyClearCacheActionsEvent-migration-v14:
 
-..  include:: /CodeSnippets/Events/Backend/ModifyClearCacheActionsEvent.rst.txt
+Migration: replace key `href` with key `endpoint`
+=================================================
+
+When dropping TYPO3 v13 support replace the :php:`href` key with :php:`endpoint`
+in any `CacheAction` array returned from a
+:php-short:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
+listener:
+
+.. code-block:: diff
+
+    $event->addCacheAction([
+        'id' => 'my_custom_cache',
+    -   'href' => $uriBuilder->buildUriFromRoute('ajax_my_cache_clear'),
+    +   'endpoint' => (string)$uriBuilder->buildUriFromRoute('ajax_my_cache_clear'),
+        'iconIdentifier' => 'actions-system-cache-clear',
+        'title' => 'Clear my cache',
+        'description' => 'Optional description',
+        'severity' => 'notice',
+    ]);

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MyVendor\MyExtension\Backend\EventListener;
 
 use TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
 
 #[AsEventListener(
@@ -12,8 +13,24 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 )]
 final readonly class MyEventListener
 {
+    public function __construct(private UriBuilder $uriBuilder)
+    {
+    }
+
     public function __invoke(ModifyClearCacheActionsEvent $event): void
     {
-        // do magic here
+        $event->addCacheAction([
+            // Required keys:
+            'id' => 'pages',
+            'title' => 'core.cache:group.pages.label',
+            'endpoint' => (string)$this->uriBuilder->buildUriFromRoute(
+                'tce_db',
+                ['cacheCmd' => 'pages']
+            ),
+            'iconIdentifier' => 'actions-system-cache-clear-impact-low',
+            // Optional, recommended keys:
+            'description' => 'core.cache:group.pages.description',
+            'severity' => 'success',
+        ]);
     }
 }

--- a/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_ModifyClearCacheActionsEvent/_MyEventListener.php
@@ -13,9 +13,7 @@ use TYPO3\CMS\Core\Attribute\AsEventListener;
 )]
 final readonly class MyEventListener
 {
-    public function __construct(private UriBuilder $uriBuilder)
-    {
-    }
+    public function __construct(private UriBuilder $uriBuilder) {}
 
     public function __invoke(ModifyClearCacheActionsEvent $event): void
     {
@@ -25,7 +23,7 @@ final readonly class MyEventListener
             'title' => 'core.cache:group.pages.label',
             'endpoint' => (string)$this->uriBuilder->buildUriFromRoute(
                 'tce_db',
-                ['cacheCmd' => 'pages']
+                ['cacheCmd' => 'pages'],
             ),
             'iconIdentifier' => 'actions-system-cache-clear-impact-low',
             // Optional, recommended keys:

--- a/Documentation/CodeSnippets/Events/Backend/CustomFileSelectorsEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/Backend/CustomFileSelectorsEvent.rst.txt
@@ -3,45 +3,37 @@
 
 ..  php:class:: CustomFileSelectorsEvent
 
-    To modify the selectors that add files, the following methods are available:
+    Listeners to this Event will be able to add custom file selectors to a
+    TCA type="file" field in FormEngine
 
     ..  php:method:: getSelectors()
+        :returns: `array`
 
-        Get all selectors
+    ..  php:method:: setSelectors(array $selectors)
 
-    ..  php:method:: setSelectors()
-
-        Set all selectors
+        :param $selectors: the selectors
 
     ..  php:method:: getJavascriptModules()
+        :returns: `array`
 
-        Get all JavaScript modules
+    ..  php:method:: setJavascriptModules(array $javascriptModules)
 
-    ..  php:method:: setJavascriptModules()
-
-        Set all JavaScript modules
+        :param $javascriptModules: the javascriptModules
 
     ..  php:method:: getTableName()
-
-        Get table name of the current record
+        :returns: `string`
 
     ..  php:method:: getFieldName()
-
-        Get field name of the element
+        :returns: `string`
 
     ..  php:method:: getDatabaseRow()
-
-        Get raw database row
+        :returns: `array`
 
     ..  php:method:: getFieldConfig()
-
-        Get TCA configuration of the current field
+        :returns: `array`
 
     ..  php:method:: getFileExtensionFilter()
-
-        Get the allowed & disallowed file extensions
+        :returns: `\TYPO3\CMS\Core\Resource\Filter\FileExtensionFilter`
 
     ..  php:method:: getFormFieldIdentifier()
-
-        Get DOM object-id used in the form
-
+        :returns: `string`


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1688
Releases: main