### PR TITLE
Adjust link to components page in TYPO3 Explained

### DIFF
--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -240,10 +240,9 @@ import can be done in the template or the partial.
 
 *optional*
 
-Since Fluid version 4.3 components were introduced. Components are custom HTML-like
-tags based on Fluid templates. Like partials they provide a good code reuseability.
-Get more informations about components and see how they can be implemented in the
-article `Components <https://docs.typo3.org/permalink/fluid:components>`_.
+Since Fluid version 4.3 components were introduced. :ref:`Components <using_fluid_components>`
+are custom HTML-like tags based on Fluid templates. Like partials they provide a
+good code reuseability.
 
 ..  _fluid-theme-example:
 


### PR DESCRIPTION
Now, components are explained in TYPO3 Explained, so the link can be adjusted to point to this manual instead of Fluid manual.

Releases: main