### PR TITLE
Fix duplicate T3DataStructure tag

### DIFF
--- a/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
@@ -29,7 +29,7 @@ must be arrays.)
     This is the root element of a T3DataStructure. It may contain tags
     `<meta>` and `<ROOT>` or `<sheets>`
 
-..  confval:: <T3DataStructure>
+..  confval:: <meta>
     :name: t3datastructure-meta
     :type: array
 


### PR DESCRIPTION
This should be "meta". See also v12 documentation of the page.

Releases: main, 13.4