### PR TITLE
Adjust middleware position where cache instruction request is set

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.rst
@@ -16,15 +16,17 @@ The :php:`frontend.cache.instruction` frontend request attribute can be used by
 :ref:`middlewares <request-handling>` to disable :ref:`cache <caching>`
 mechanics of frontend rendering.
 
-In early middlewares before :code:`typo3/cms-frontend/tsfe`, the attribute may
-or may not exist already. A safe way to interact with it is like this:
+In early middlewares before :code:`typo3/cms-frontend/page-argument-validator`,
+the attribute may or may not exist already. A safe way to interact with it is
+like this:
 
 ..  literalinclude:: _FrontendCacheInstruction/_MyEarlyMiddleware.php
     :language: php
     :caption: EXT:my_extension/Classes/Middleware/MyEarlyMiddleware.php
 
-Extension with middlewares or other code after :code:`typo3/cms-frontend/tsfe`
-can assume the attribute to be set already. Usage example:
+Extension with middlewares or other code after
+:code:`typo3/cms-frontend/page-argument-validator` can assume the attribute to
+be set already. Usage example:
 
 ..  literalinclude:: _FrontendCacheInstruction/_MyLaterMiddleware.php
     :language: php


### PR DESCRIPTION
See: https://github.com/TYPO3/typo3/blob/main/typo3/sysext/frontend/Classes/Middleware/PageArgumentValidator.php#L49
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1396

Releases: main