### PR TITLE
Remove links to TSFE|ContentObjectRenderer

### DIFF
--- a/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
+++ b/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
@@ -412,7 +412,7 @@ for a list of available attributes.
 Using stdWrap / fetching the current ContentObject in a ViewHelper implementation
 ---------------------------------------------------------------------------------
 
-You can `access the ContentObjectRenderer <https://docs.typo3.org/permalink/t3coreapi:tsfe-contentobjectrenderer>`_
+You can access the :php-short:`\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer`
 from the :php-short:`\Psr\Http\Message\ServerRequestInterface`:
 
 ..  code-block:: php

--- a/Documentation/ApiOverview/RequestLifeCycle/FrontendRequest.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/FrontendRequest.rst
@@ -34,7 +34,7 @@ Limitations when there is no frontend request
 When executing code **outside** of a frontend request (for example, in a CLI
 command), this context is missing:
 
-*   The `ContentObjectRenderer (cObj) <https://docs.typo3.org/permalink/t3coreapi:tsfe-contentobjectrenderer>`_
+*   The :php-short:`\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer` (cObj)
     can be instantiated manually, but it will
     not have a populated `data` array because there is no `tt_content` record.
     As a result, TypoScript properties like `field = my_field` or `data = my_data`


### PR DESCRIPTION
There is no real benefit to linking to the TSFE | ContentObjectRenderer section. The TSFE page will be removed later as this class is not available anymore in TYPO3 v14. This is a preparation for removal the TSFE page.

See: https://docs.typo3.org/m/typo3/reference-coreapi/13.4/en-us/ApiOverview/TSFE/Index.html#tsfe_ContentObjectRenderer

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1396
Releases: main