### PR TITLE
Mark frontend.controller request attribute page as orphan

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendController.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 ..  include:: /Includes.rst.txt
 
 ..  index::
@@ -8,26 +10,11 @@
 Frontend controller
 ===================
 
-..  deprecated:: 13.4
+..  versionchanged:: 14.0
     The class :php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController`
-    and its global instance :php:`$GLOBALS['TSFE']` have been marked as
-    deprecated. The class will be removed with TYPO3 v14.
+    was removed with TYPO3 v14.
 
-    Use the :ref:`frontend.page.information <typo3-request-attribute-frontend-page-information>`
-    request attribute for page-related properties.
+Migration
+=========
 
-The :php:`frontend.controller` frontend request attribute provides access to the
-:php:`\TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController` object.
-
-Example:
-
-..  code-block:: php
-
-    $frontendController = $request->getAttribute('frontend.controller');
-    $rootline = $frontendController->rootLine;  // Mind the capital "L"
-
-..  attention::
-    In former TYPO3 versions you have to retrieve the
-    :php:`TypoScriptFrontendController` via the global variable
-    :php:`$GLOBALS['TSFE']`. This should be avoided now, instead use the request
-    attribute.
+See `Migration in the changelog <https://docs.typo3.org/permalink/changelog:Changelog/14.0/Breaking-107831-RemovedTypoScriptFrontendController>`_


### PR DESCRIPTION
It is set as orphan, so a user gets this information instead of a 404 page when switching the version number in the docs.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1396
Releases: main