### PR TITLE
Update ergebnis/composer-normalize to version 2.51

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "typo3/cms-core": "dev-main as 14.3"
     },
     "require-dev": {
-        "ergebnis/composer-normalize": "~2.44.0",
+        "ergebnis/composer-normalize": "~2.51.0",
         "friendsofphp/php-cs-fixer": "^3.46",
         "garvinhicking/clinspector-gadget": "^0.1.1",
         "symfony/yaml": "^7.0",


### PR DESCRIPTION
This version supports PHP 8.5, the previous version 2.44 not.

Releases: main, 13.4