### PR TITLE
ConsumableNonce does not inherit from ConsumableString anymore

### DIFF
--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Nonce.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/Nonce.rst
@@ -21,10 +21,16 @@ One can retrieve the nonce like this:
 
 ..  code-block:: php
 
-    // use TYPO3\CMS\Core\Domain\ConsumableString
+    // use TYPO3\CMS\Core\Security\ContentSecurityPolicy\ConsumableNonce
 
-    /** @var ConsumableString|null $nonce */
+    /** @var ConsumableNonce|null $nonce */
     $nonceAttribute = $this->request->getAttribute('nonce');
-    if ($nonceAttribute instanceof ConsumableString) {
-        $nonce = $nonceAttribute->consume();
+    if ($nonceAttribute instanceof ConsumableNonce) {
+        $nonce->consumeInline(Directive::ScriptSrcElem); // inline script
+        $nonce->consumeStatic(Directive::StyleSrcElem);  // static style
     }
+
+..  versionchanged:: 13.4.20
+    Since TYPO3 v13.4.20 the :php-short:`\TYPO3\CMS\Core\Security\ContentSecurityPolicy\ConsumableNonce`
+    class does not inherit from :php-short:`\TYPO3\CMS\Core\Domain\ConsumableString`
+    anymore.


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1420
Resolves: #6278
Releases: main, 13.4