### PR TITLE
Symplify OpenGraph image fallback

### DIFF
--- a/Documentation/ApiOverview/Seo/Configuration/_snippets/_og-fallback.typoscript
+++ b/Documentation/ApiOverview/Seo/Configuration/_snippets/_og-fallback.typoscript
@@ -1,21 +1,21 @@
 page {
   meta {
-    og:image.stdWrap.cObject = TEXT
-    og:image.stdWrap.cObject {
+    og:image.cObject = TEXT
+    og:image.cObject {
       if.isFalse.field = og_image
-      stdWrap.typolink {
-        parameter.stdWrap.cObject = IMG_RESOURCE
-        parameter.stdWrap.cObject.file = EXT:my_site_package/Resources/Public/Backend/OgImage.svg
+      typolink {
+        parameter.cObject = IMG_RESOURCE
+        parameter.cObject.file = EXT:my_site_package/Resources/Public/Backend/OgImage.svg
         returnLast = url
         forceAbsoluteUrl = 1
       }
     }
-    twitter:image.stdWrap.cObject = TEXT
-    twitter:image.stdWrap.cObject {
+    twitter:image.cObject = TEXT
+    twitter:image.cObject {
       if.isFalse.field = twitter_image
-      stdWrap.typolink {
-        parameter.stdWrap.cObject = IMG_RESOURCE
-        parameter.stdWrap.cObject.file = EXT:my_site_package/Resources/Public/Backend/TwitterCardImage.svg
+      typolink {
+        parameter.cObject = IMG_RESOURCE
+        parameter.cObject.file = EXT:my_site_package/Resources/Public/Backend/TwitterCardImage.svg
         returnLast = url
         forceAbsoluteUrl = 1
       }


### PR DESCRIPTION
As `TEXT` and `typolink.parameter` are already stdWrap'able, the `stdWrap` is not necessary at all.

Releases: main, 13.4