### PR TITLE
Fix backslashes in whole file

### DIFF
--- a/Documentation/Administration/Installation/ClassicMode/Windows.rst
+++ b/Documentation/Administration/Installation/ClassicMode/Windows.rst
@@ -66,9 +66,9 @@ After creating the symlinks, your directory structure should look like this:
 
 ..  directory-tree::
 
-    *   :path:`typo3_src-13.4.y\\`
+    *   :path:`typo3_src-13.4.y`
 
-    *   :path:`public\\`
+    *   :path:`public`
 
         *   :path:`typo3_src -> ..\\typo3_src-13.4.y\\`
 

--- a/Documentation/Administration/Installation/ClassicMode/Windows.rst
+++ b/Documentation/Administration/Installation/ClassicMode/Windows.rst
@@ -45,7 +45,7 @@ Use the Windows command shell (cmd.exe) with administrator rights to create the
 following symlinks in your document root:
 
 ..  code-block:: bash
-    :caption: C:\path\to\your\site\
+    :caption: C:\\path\\to\\your\\site\\
 
     mklink /d typo3_src ..\typo3_src-13.4.y
     mklink /d typo3 typo3_src\typo3
@@ -66,10 +66,14 @@ After creating the symlinks, your directory structure should look like this:
 
 ..  directory-tree::
 
-    *   :path:`typo3_src-13.4.y\`
-    *   :path:`public\`
-        *   :path:`typo3_src -> ..\typo3_src-13.4.y\`
+    *   :path:`typo3_src-13.4.y\\`
+
+    *   :path:`public\\`
+
+        *   :path:`typo3_src -> ..\\typo3_src-13.4.y\\`
+
         *   :path:`typo3 -> typo3_src\\typo3\\`
+
         *   :file:`index.php -> typo3_src\index.php`
 
 ..  _classic-symlink-installation-completion:


### PR DESCRIPTION
Resolves: Warning: Attempt to read property "value" on null in /opt/guides/vendor/phpdocumentor/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php on line 81
Releases: main, 13.4

The error itself was triggered by the caption with one backslash in front of nothing after "site"
```rst
..  code-block:: bash
    :caption: C:\path\to\your\site\

    mklink /d typo3_src ..\typo3_src-13.4.y
    mklink /d typo3 typo3_src\typo3
    mklink index.php typo3_src\index.php
```