### PR TITLE
Introduce QueryBuilderPaginator

### DIFF
--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -18,11 +18,27 @@ Along with that interface, an abstract paginator class :php:`\TYPO3\CMS\Core\Pag
 is available that implements the base pagination logic for any kind of :php:`Countable` set of
 items while it leaves the processing of items to the concrete paginator class.
 
-Two concrete paginators are available:
+..  contents:: Table of Contents
+    :depth: 2
+    :local:
 
-*  For type :php:`array`: :php:`\TYPO3\CMS\Core\Pagination\ArrayPaginator`
-*  For type :php:`\TYPO3\CMS\Extbase\Persistence\QueryResultInterface`:
-   :php:`\TYPO3\CMS\Extbase\Pagination\QueryResultPaginator`
+Paginators
+==========
+
+..  versionadded:: 14.2
+    The :php-short:`\TYPO3\CMS\Core\Pagination\QueryBuilderPaginator` has been
+    introduced.
+
+Three concrete paginators are available:
+
+*   For type :php:`array`: :php:`\TYPO3\CMS\Core\Pagination\ArrayPaginator`
+*   For type :php:`\TYPO3\CMS\Extbase\Persistence\QueryResultInterface`:
+    :php:`\TYPO3\CMS\Extbase\Pagination\QueryResultPaginator`
+*   For type :php:`\TYPO3\CMS\Core\Database\Query\QueryBuilder`:
+    :php:`\TYPO3\CMS\Core\Pagination\QueryBuilderPaginator`
+
+Example: ArrayPaginator
+-----------------------
 
 Code example for the :php:`ArrayPaginator` in an
 :ref:`Extbase controller <extbase-action-controller>`:
@@ -35,6 +51,32 @@ And the corresponding Fluid template:
 ..  literalinclude:: _ArrayPaginatorExamplePagination.html
     :caption: EXT:my_extension/Resources/Private/Templates/ExamplePagination.html
 
+Example: QueryBuilderPaginator
+------------------------------
+
+The paginated items are fetched only once per page request by storing the result
+internally, avoiding double execution of the database statement.
+
+The total item count is determined robustly using a common table expression
+(CTE) wrapping the passed :ref:`QueryBuilder <database-query-builder>` instance.
+This approach correctly handles advanced queries involving :sql:`UNION`, nested
+CTEs, windowing functions, or grouping.
+
+..  literalinclude:: _QueryBuilderPaginator.php
+    :caption: EXT:my_extension/Controller/ExampleController.php
+
+..  note::
+    The :php-short:`\TYPO3\CMS\Core\Pagination\QueryBuilderPaginator` does
+    **not** handle language overlays. Applying overlays on the result set can
+    lead to unexpected item count differences between pages when some records
+    are hidden after overlay processing. Use
+    :php-short:`\TYPO3\CMS\Extbase\Pagination\QueryResultPaginator` or
+    :php-short:`\TYPO3\CMS\Core\Pagination\ArrayPaginator` when language
+    overlay handling is required.
+
+    The paginator also takes **full control** over `LIMIT` and `OFFSET`
+    and does not respect any existing limit/offset constraints on the passed
+    :php:`QueryBuilder` instance.
 
 Sliding window pagination
 =========================

--- a/Documentation/ApiOverview/Pagination/Index.rst
+++ b/Documentation/ApiOverview/Pagination/Index.rst
@@ -22,6 +22,9 @@ items while it leaves the processing of items to the concrete paginator class.
     :depth: 2
     :local:
 
+
+.. _pagination-paginators:
+
 Paginators
 ==========
 
@@ -37,6 +40,9 @@ Three concrete paginators are available:
 *   For type :php:`\TYPO3\CMS\Core\Database\Query\QueryBuilder`:
     :php:`\TYPO3\CMS\Core\Pagination\QueryBuilderPaginator`
 
+
+.. _pagination-example-array-paginator:
+
 Example: ArrayPaginator
 -----------------------
 
@@ -50,6 +56,9 @@ And the corresponding Fluid template:
 
 ..  literalinclude:: _ArrayPaginatorExamplePagination.html
     :caption: EXT:my_extension/Resources/Private/Templates/ExamplePagination.html
+
+
+.. _pagination-example-query-builder-paginator:
 
 Example: QueryBuilderPaginator
 ------------------------------
@@ -78,6 +87,9 @@ CTEs, windowing functions, or grouping.
     and does not respect any existing limit/offset constraints on the passed
     :php:`QueryBuilder` instance.
 
+
+.. _pagination-sliding-window:
+
 Sliding window pagination
 =========================
 
@@ -89,6 +101,9 @@ shown.
 50 links. Using the `SlidingWindowPagination`, you will get something like
 this `< prev ... 21 22 23 24 ... next >` or `< 1 ... 21 22 23 24 ... 50 >` or
 simple `< 21 22 23 24 >`. Customise the template to suit your needs.
+
+
+.. _pagination-sliding-window-usage:
 
 Usage
 -----

--- a/Documentation/ApiOverview/Pagination/_QueryBuilderPaginator.php
+++ b/Documentation/ApiOverview/Pagination/_QueryBuilderPaginator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Pagination\QueryBuilderPaginator;
+use TYPO3\CMS\Core\Pagination\SimplePagination;
+
+$paginator = new QueryBuilderPaginator(
+    queryBuilder: $queryBuilder,
+    currentPageNumber: $currentPage,
+    itemsPerPage: 10,
+);
+$pagination = new SimplePagination($paginator);
+
+// Retrieve the items for the current page
+$items = $paginator->getPaginatedItems();


### PR DESCRIPTION
Additionally, headers and a TOC has been added as the page is now quite long.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1625
Releases: main, 14.3