### PR TITLE
add link to simple example for  repository design pattern

### DIFF
--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Repository.rst
@@ -8,7 +8,8 @@
 Repository
 ==========
 
-A basic repository can be quite a short class. The shortest possible
+A basic `repository <https://designpatternsphp.readthedocs.io/en/latest/More/Repository/README.html>`_  
+can be quite a short class. The shortest possible
 repository is an empty class inheriting from
 :php:`TYPO3\CMS\Extbase\Persistence\Repository`:
 

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/Repository.rst
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/Repository.rst
@@ -8,7 +8,7 @@
 Repository
 ==========
 
-A basic `repository <https://designpatternsphp.readthedocs.io/en/latest/More/Repository/README.html>`_  
+A basic `repository <https://docs.typo3.org/permalink/t3coreapi:extbase-domain-repository>`_
 can be quite a short class. The shortest possible
 repository is an empty class inheriting from
 :php:`TYPO3\CMS\Extbase\Persistence\Repository`:


### PR DESCRIPTION
It makes it clearer to see on an external example what the repository class is meant for.