### PR TITLE
quoteIdentifier is internally called on table names

### DIFF
--- a/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
@@ -1435,7 +1435,7 @@ Remarks:
     turned off and an explicit call to :php:`->quoteIdentifier()` must be added.
 
 *   Internally, :php:`->quoteIdentifier()` is automatically called on all method
-    arguments that must be a field name. For instance, :php:`->quoteIdentifier()`
+    arguments that must be a field name or a table name. For instance, :php:`->quoteIdentifier()`
     is called for all arguments of :ref:`->select() <database-query-builder-select>`.
 
 *   :php:`->quoteIdentifiers()` (mind the plural) can be used to quote multiple


### PR DESCRIPTION
13.4.17/typo3/sysext/core/Classes/Database/Query/QueryBuilder.php

Every table name has internally a quoteIdentifier around it. No extra quoteIdentifier must be used.