### PR TITLE
Update backend user object documentation

### DIFF
--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -14,7 +14,7 @@ as the global variable :php:`$GLOBALS['BE_USER']` only in backend contexts. This
 and is an instance of the class :php:`\TYPO3\CMS\Core\Authentication\BackendUserAuthentication`
 (which extends :php:`\TYPO3\CMS\Core\Authentication\AbstractUserAuthentication`).
 
-When working with middlewares in the frontend or with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
+When working with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
 In addition, you can call :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication()` 
 to load the language of the CLI user set in the backend so that ViewHelpers
 (like :php:`f:translate()`) used in the CLI resolve to the correct language.

--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -14,7 +14,7 @@ as the global variable :php:`$GLOBALS['BE_USER']` only in backend contexts. This
 and is an instance of the class :php:`\TYPO3\CMS\Core\Authentication\BackendUserAuthentication`
 (which extends :php:`\TYPO3\CMS\Core\Authentication\AbstractUserAuthentication`).
 
-When working in the frontend or with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
+When working with middlewares in the frontend or with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
 In addition, you can call :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication()` 
 to load the language of the CLI user set in the backend so that view helpers 
 (like :php:`f:translate()`) used in the CLI resolve to the correct language.

--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -16,7 +16,7 @@ and is an instance of the class :php:`\TYPO3\CMS\Core\Authentication\BackendUser
 
 When working with middlewares in the frontend or with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
 In addition, you can call :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication()` 
-to load the language of the CLI user set in the backend so that view helpers 
+to load the language of the CLI user set in the backend so that ViewHelpers
 (like :php:`f:translate()`) used in the CLI resolve to the correct language.
 
 .. index:: Backend user; Access

--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -8,13 +8,16 @@
 Backend user object
 ===================
 
-The backend user of a session is always available in extensions
-as the global variable :php:`$GLOBALS['BE_USER']`. The object is created in
+The backend user of a session is by default available in extensions
+as the global variable :php:`$GLOBALS['BE_USER']` only in backend contexts. This object is created in
 :php:`\TYPO3\CMS\Backend\Middleware\BackendUserAuthenticator` middleware for a standard web request
 and is an instance of the class :php:`\TYPO3\CMS\Core\Authentication\BackendUserAuthentication`
 (which extends :php:`\TYPO3\CMS\Core\Authentication\AbstractUserAuthentication`).
 
-When working with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. In addition, you can call :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication()` to load the language of the CLI user set in the backend so that view helpers (like :php:`f:translate()`) used in the CLI resolve to the correct language.
+When working in the frontend or with CLI and commands you might initialize the backend user object with :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendUser()`. 
+In addition, you can call :php:`\TYPO3\CMS\Core\Core\Bootstrap::initializeBackendAuthentication()` 
+to load the language of the CLI user set in the backend so that view helpers 
+(like :php:`f:translate()`) used in the CLI resolve to the correct language.
 
 .. index:: Backend user; Access
 .. _be-user-check:

--- a/Documentation/ApiOverview/Backend/BackendUserObject.rst
+++ b/Documentation/ApiOverview/Backend/BackendUserObject.rst
@@ -240,3 +240,14 @@ the :php:`$GLOBALS['BE_USER']->uc` array. This will return the current state of
    :caption: EXT:some_extension/Classes/Controller/SomeModuleController.php
 
    $GLOBALS['BE_USER']->uc['emailMeAtLogin']
+
+You can read the configured language of the backend user:
+
+.. code-block:: php
+   :caption: Read the language to be used in the backend
+
+   $backendLanguage = $GLOBALS['BE_USER']->uc['lang'] ?? 'en';
+
+
+
+


### PR DESCRIPTION
Clarify availability of backend user object in different contexts. The backend user object might not be available by default outside of backend contexts.