### PR TITLE
[TASK] Rename job to fix-whitespace and update action version

### DIFF
--- a/.github/workflows/apply-precommit.yml
+++ b/.github/workflows/apply-precommit.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  fix-whitespace:
     if: github.repository_owner == 'TYPO3-documentation'
     permissions:
       contents: read
@@ -16,9 +16,9 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
- Renamed the job from `lint` to `fix-whitespace`.
- Updated `actions/create-github-app-token` to use a specific commit hash.