### PR TITLE
[!!!][TASK] Remove deprecated CacheAction "href" key

### DIFF
--- a/Documentation/404.rst
+++ b/Documentation/404.rst
@@ -19,11 +19,23 @@ TYPO3 v15
 =================================================================================
 
 ..  deprecated:: 14.2
-    `Deprecation: #109295 - DatabaseWriter::setLogTable()/getLogTable() <https://docs.typo3.org/permalink/changelog:deprecation-109295-1742407200>`_
+    See `Deprecation: #109295 - DatabaseWriter::setLogTable()/getLogTable() <https://docs.typo3.org/permalink/changelog:deprecation-109295-1742407200>`_
 
 The `DatabaseWriter <https://docs.typo3.org/permalink/t3coreapi:logging-writers-database>`_
 can only be used with the :sql:`sys_log` table starting with TYPO3 v15.
 
+
+..  _ModifyClearCacheActionsEvent-migration-v14:
+
+CacheAction "href" key removed
+==============================
+
+..  versionchanged:: 14.3
+    The `CacheAction` array key `href` used in cache action definitions
+    provided via the :php-short:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
+    has been deprecated in favor of `endpoint`. The new key name better reflects
+    the purpose of this field, which is used as an AJAX endpoint URL. The value
+    must be a :php:`string`.
 
 ..  _not-found-14:
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -6,13 +6,6 @@
 ModifyClearCacheActionsEvent
 ============================
 
-..  versionchanged:: 14.3
-    The `CacheAction` array key `href` used in cache action definitions
-    provided via the :php-short:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
-    has been deprecated in favor of `endpoint`. The new key name better reflects
-    the purpose of this field, which is used as an AJAX endpoint URL. The value
-    must be a :php:`string`. See :ref:`Migration <ModifyClearCacheActionsEvent-migration-v14>`.
-
 The PSR-14 event :php:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
 is fired in the :php-short:`\TYPO3\CMS\Backend\Backend\ToolbarItems\ClearCacheToolbarItem`
 class and allows extension authors to modify the clear cache actions, shown
@@ -156,25 +149,3 @@ Here is an example of how to use it for a custom cache action:
         'severity' => 'notice',
     ]);
     $event->addCacheActionIdentifier($myIdentifier);
-
-..  _ModifyClearCacheActionsEvent-migration-v14:
-
-Migration: replace key `href` with key `endpoint`
-=================================================
-
-When dropping TYPO3 v13 support replace the :php:`href` key with :php:`endpoint`
-in any `CacheAction` array returned from a
-:php-short:`\TYPO3\CMS\Backend\Backend\Event\ModifyClearCacheActionsEvent`
-listener:
-
-.. code-block:: diff
-
-    $event->addCacheAction([
-        'id' => 'my_custom_cache',
-    -   'href' => $uriBuilder->buildUriFromRoute('ajax_my_cache_clear'),
-    +   'endpoint' => (string)$uriBuilder->buildUriFromRoute('ajax_my_cache_clear'),
-        'iconIdentifier' => 'actions-system-cache-clear',
-        'title' => 'Clear my cache',
-        'description' => 'Optional description',
-        'severity' => 'notice',
-    ]);

--- a/Documentation/CodeSnippets/Events/Core/BootCompletedEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/Core/BootCompletedEvent.rst.txt
@@ -3,7 +3,7 @@
 
 ..  php:class:: BootCompletedEvent
 
-    Executed when TYPO3 has fully booted (after all ext_tables.php files have been processed)
+    Executed when TYPO3 has fully booted
 
     ..  php:method:: isCachingEnabled()
         :returns: `bool`

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "t3docs/blog-example": "dev-main",
         "t3docs/codesnippet": "dev-main",
         "t3docs/examples": "dev-main",
-        "t3docs/site-package": "dev-main",
         "typo3/cms-adminpanel": "dev-main as 14.3",
         "typo3/cms-backend": "dev-main as 14.3",
         "typo3/cms-belog": "dev-main as 14.3",


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1759
Releases: main, 14.3