### PR TITLE
[!!!][TASK] Remove deprecated EXT:setup backward compat layer

### DIFF
--- a/Documentation/404.rst
+++ b/Documentation/404.rst
@@ -52,6 +52,19 @@ CacheAction "href" key removed
     must be a :php:`string`.
 
 
+..  _AddUserSettingsJavaScriptModulesEvent-api-13:
+..  _AddJavaScriptModulesEvent:
+
+AddJavaScriptModulesEvent renamed to AddUserSettingsJavaScriptModulesEvent
+==========================================================================
+
+..  versionchanged:: 14.3
+    See `Deprecation: #109517 - PSR-14 event \TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent <https://docs.typo3.org/permalink/changelog:deprecation-109517-1744105201>`_.
+
+The event :php:`TYPO3\CMS\Backend\Event\AddUserSettingsJavaScriptModulesEvent`
+was moved from `TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent`
+as the system extension `setup` was integrated into :composer:`typo3/cms-backend`.
+
 ..  _eventlist-install:
 
 ModifyLanguagePackRemoteBaseUrlEvent and ModifyLanguagePacksEvent moved to EXT:core

--- a/Documentation/ApiOverview/Events/Events/Backend/AddUserSettingsJavaScriptModulesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AddUserSettingsJavaScriptModulesEvent.rst
@@ -1,15 +1,10 @@
 ..  include:: /Includes.rst.txt
 ..  index:: Events; AddUserSettingsJavaScriptModulesEvent
-..  _AddJavaScriptModulesEvent:
 ..  _AddUserSettingsJavaScriptModulesEvent:
 
 =====================================
 AddUserSettingsJavaScriptModulesEvent
 =====================================
-
-..  versionchanged:: 14.3
-    This event was moved from :php:`TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent`
-    as the system extension `setup` was integrated into :composer:`typo3/cms-backend`.
 
 JavaScript events in custom user settings configuration options should not be
 placed as inline JavaScript. Instead, use a dedicated JavaScript module to
@@ -31,32 +26,3 @@ API
 ===
 
 ..  include:: /CodeSnippets/Events/Backend/AddUserSettingsJavaScriptModulesEvent.rst.txt
-
-..  _AddUserSettingsJavaScriptModulesEvent-api-13:
-
-Migration from AddJavaScriptModulesEvent to AddUserSettingsJavaScriptModulesEvent
-=================================================================================
-
-When dropping TYPO3 v13 support, switch to using the new location of the event:
-
-..  code-block:: diff
-
-    + use TYPO3\CMS\Backend\Event\AddUserSettingsJavaScriptModulesEvent;
-      use TYPO3\CMS\Core\Attribute\AsEventListener;
-    - use TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent;
-
-      final class SetupModuleListener
-      {
-          #[AsEventListener('my-extension/setup-module-listener')]
-        - public function __invoke(AddJavaScriptModulesEvent $event): void
-        + public function __invoke(AddUserSettingsJavaScriptModulesEvent $event): void
-          {
-              $event->addJavaScriptModule('@my-extension/setupModule/some-file.js');
-          }
-      }
-
-If you need to support TYPO3 v13 and v14 only listen to the legacy event
-:php:`TYPO3\CMS\Setup\Event\AddJavaScriptModulesEvent`.
-
-For better dual version compatibility, no deprecation is emitted
-when using the legacy event location.

--- a/Documentation/ApiOverview/Localization/_snippets/_gsw_CH.locallang_1.2.xlf
+++ b/Documentation/ApiOverview/Localization/_snippets/_gsw_CH.locallang_1.2.xlf
@@ -3,7 +3,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="gsw_CH"
     datatype="plaintext"
-    original="EXT:setup/Resources/Private/Language/locallang.xlf">
+    original="EXT:backend/Resources/Private/Language/locallang.xlf">
         <body>
             <trans-unit id="lang_gsw_CH" approved="yes">
                 <source>Swiss German</source>


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1766
Releases: main