### PR TITLE
[TASK] Declare TypoScriptFrontendController deprecated

### DIFF
--- a/Documentation/404.rst
+++ b/Documentation/404.rst
@@ -78,6 +78,7 @@ TYPO3 v14
 ..  _tsfe-baseurl:
 ..  _using-the-typoscriptfrontendcontroller:
 ..  _typo3-request-attribute-frontend-controller:
+..  _assets-TypoScriptFrontendController:
 
 TypoScriptFrontendController and $GLOBALS['TSFE'] removed
 =========================================================

--- a/Documentation/ApiOverview/Assets/Index.rst
+++ b/Documentation/ApiOverview/Assets/Index.rst
@@ -4,7 +4,6 @@
     ! Assets
     PageRenderer
 ..  _assets-introduction:
-..  _assets-TypoScriptFrontendController:
 ..  _assets:
 
 ===============================

--- a/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Introduction/Index.rst
@@ -20,9 +20,8 @@ FormEngine
     by some controller.
 
 Frontend rendering
-    :php:`TYPO3\CMS\Frontend\...`: Renders the website frontend. The frontend rendering, usually based on
-    :php:`TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController` uses :code:`TypoScript` and / or :code:`Fluid`
-    to process and render database content into the frontend.
+    :php:`TYPO3\CMS\Frontend\...`: Renders the website frontend. The frontend rendering
+    uses `TypoScript` and / or `Fluid` to process and render database content into the frontend.
 
 The glue between these three pillars is :ref:`TCA (Table Configuration Array) <t3tca:tca-what-is>`: It defines how
 database tables are constructed, which localization or workspace facilities exist, how it should be displayed in the

--- a/Documentation/ApiOverview/LockingApi/Index.rst
+++ b/Documentation/ApiOverview/LockingApi/Index.rst
@@ -199,14 +199,6 @@ Acquire and use an exclusive, non-blocking lock:
    }
 
 
-.. index::  pair: Locking; Core
-
-Usage in the Core
-=================
-
-The locking API is used in the Core for caching, see :php:`TypoScriptFrontendController`.
-
-
 .. index::  pair: Locking; Extensions
 
 .. _use-locking-api-in-extensions:
@@ -268,8 +260,8 @@ first choice for most locking operations in TYPO3.
 Multiple servers & Cache locking
 --------------------------------
 
-Since the Core uses the locking API for some cache operations (see for
-example :php:`TypoScriptFrontendController`), make sure that you correctly
+Since the Core uses the locking API for some cache operations, make sure that
+you correctly
 setup your caching and locking if you share your TYPO3 instance on multiple
 servers for load balancing or high availability.
 


### PR DESCRIPTION
Last remains removed

resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1680
releases: main, 14.3