### PR TITLE
add Backend TypoScript to PHP API -  TypoScript

### DIFF
--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -77,7 +77,8 @@ Backend TypoScript
 Anonther means needs to be used than the Frontend method to read the TypoScript of the currently selected page in the backend page module.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
 Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
-:php:`SiteFinder` instead of this solution.
+`SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_
+instead of this solution. 
 
 .. code-block:: php
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -81,6 +81,9 @@ Note that it may be required to enrich the request object. TypoScript parsing is
 instead of this solution. 
 
 .. code-block:: php
+    :caption: EXT:my_extension/OrderBackend.php
+
+    namespace MyDomain\MyExtension\Backend;
 
     use Psr\Http\Message\ServerRequestInterface;
     use TYPO3\CMS\Core\SingletonInterface;

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -74,7 +74,7 @@ from different contexts.
 Backend TypoScript
 ==================
 
-Anonther means needs to be used than the Frontend method to read the TypoScript of the currently selected page in the backend page module.
+Another means needs to be used than the Frontend method to read the TypoScript of the currently selected page in the backend page module.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
 Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
 `SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -66,7 +66,43 @@ setup as array:
 
 .. code-block:: php
 
-        $fullTypoScript = $request->getAttribute('frontend.typoscript')->getSetupArray();
+    $fullTypoScript = $request->getAttribute('frontend.typoscript')->getSetupArray();
 
 Read more about :ref:`Getting the PSR-7 request object <getting-typo3-request-object>`
 from different contexts.
+
+Backend TypoScript
+==================
+
+Anonther means needs to be used than the Frontend method to read the TypoScript of the currently selected page in the backend page module.
+The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
+Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
+:php:`SiteFinder` instead of this solution.
+
+.. code-block:: php
+
+    use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Core\SingletonInterface;
+    use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
+
+    class OrderBackend implements SingletonInterface
+    {
+        private ContainerInterface $container;
+        protected BackendConfigurationManager $concreteConfigurationManager;
+    
+        public function __construct(
+            ContainerInterface $container,
+            BackendConfigurationManager $configurationManager
+        )
+        {
+            $this->container = $container;
+            $this->concreteConfigurationManager = $configurationManager;
+        }
+
+        public function getTypoScript(ServerRequestInterface $request): array
+        {
+             $setup = $this->concreteConfigurationManager->getTypoScriptSetup($request);
+             return $setup;
+        }
+    }
+

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -81,26 +81,40 @@ Note that it may be required to enrich the request object. TypoScript parsing is
 instead of this solution. 
 
 .. code-block:: php
-    :caption: EXT:my_extension/OrderBackend.php
+    :caption: EXT:my_extension/Classes/Backend/OrderController.php
 
     namespace MyDomain\MyExtension\Backend;
 
     use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Core\Database\ConnectionPool;
     use TYPO3\CMS\Core\SingletonInterface;
     use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 
-    class OrderBackend implements SingletonInterface
+    class OrderController implements SingletonInterface
     {
-        private ContainerInterface $container;
+        protected ConnectionPool $connectionPool;
+        private   ContainerInterface $container;
         protected BackendConfigurationManager $concreteConfigurationManager;
     
         public function __construct(
+            ConnectionPool $connectionPool,
             ContainerInterface $container,
             BackendConfigurationManager $configurationManager
         )
         {
+            $this->connectionPool = $connectionPool;
             $this->container = $container;
             $this->concreteConfigurationManager = $configurationManager;
+        }
+
+        public function main(
+            string $content,
+            array $conf,
+            ServerRequestInterface $request,
+        ) : string {
+            $setup = $this->getTypoScript($request);
+            $foo = $setup['my_extension']['bar'] ?? '';
+            return '<div>Foo Setup: ' . $foo . '</div>';
         }
 
         public function getTypoScript(ServerRequestInterface $request): array

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -71,14 +71,17 @@ setup as array:
 Read more about :ref:`Getting the PSR-7 request object <getting-typo3-request-object>`
 from different contexts.
 
+.. _typoscript-backend-access_frontend_typoscript:
+
 Backend TypoScript
 ==================
 
-Another means needs to be used than the Frontend method to read the TypoScript of the currently selected page in the backend page module.
+Another means needs to be used to read the Frontend TypoScript of the currently selected page in the backend page module.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
 Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
 `SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_
-instead of this solution. 
+instead of this solution. For backend module configuration you should use 
+`Backend TypoScript / TSconfig <https://docs.typo3.org/permalink/t3tsref:about-tsconfig>`_ instead of Frontend TypoScript. 
 
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Backend/OrderController.php

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -77,6 +77,8 @@ Backend TypoScript
 ==================
 
 Another means needs to be used to read the Frontend TypoScript of the currently selected page in the backend page module.
+This is needed in a case where some Frontend classes need to be called as well by from the Backend. E.g. a shop administrator
+is allowed to resend an order email with a new modified bill after the customer has cancelled one item from his order.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
 Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
 `SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -195,20 +195,24 @@ Example for :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
         public function __construct(
             private SiteFinder $siteFinder
         ) {}
+    }
     
-        public function getMyGeneralWarningText(int $pageId): string
-        {
+    public function getMyGeneralWarningText(int $pageId): string
+    {
+        $warningText = 'Warning!';
+        
+        try {
             // Find the site object by traversing the rootline upwards from the given page ID
             $site = $this->siteFinder->getSiteByPageId($pageId);
-            $warningText = 'Warning!';
             
-            // Ensure $site is not null before proceeding
             if ($site instanceof Site) {
-                // Access configuration attributes or custom site settings
+                // Safely access the attribute and catch potential InvalidArgumentException if the key does not exist
                 $warningText = $site->getAttribute('myGeneralWarningText') ?? $warningText;
             }
-
-            return warningText;
+        } catch (SiteNotFoundException|\InvalidArgumentException) {
+            // Fallback to the default warning text if the site is missing or the attribute key is invalid
         }
+
+        return $warningText;
     }
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -94,21 +94,12 @@ instead of this solution. For backend module configuration you should use
     use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 
     class OrderController implements SingletonInterface
-    {
-        protected ConnectionPool $connectionPool;
-        private   ContainerInterface $container;
-        protected BackendConfigurationManager $concreteConfigurationManager;
-    
+    {    
         public function __construct(
-            ConnectionPool $connectionPool,
-            ContainerInterface $container,
-            BackendConfigurationManager $configurationManager
-        )
-        {
-            $this->connectionPool = $connectionPool;
-            $this->container = $container;
-            $this->concreteConfigurationManager = $configurationManager;
-        }
+            protected ConnectionPool $connectionPool,
+            protected ContainerInterface $container,
+            protected BackendConfigurationManager $concreteConfigurationManager
+        ) {}
 
         public function main(
             string $content,

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -125,148 +125,58 @@ This is an example TypoScript Configuration Manager:
 
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Backend/TypoScriptConfigurationManager.php
-    namespace MyDomain\MyExtension\Backend;
 
-    use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
-    use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
-    use TYPO3\CMS\Core\Database\ConnectionPool;
-    use TYPO3\CMS\Core\Site\Entity\NullSite;
-    use TYPO3\CMS\Core\Site\Set\SetRegistry;
-    use TYPO3\CMS\Core\Site\SiteFinder;
-    use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
-    use TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory;
-    use TYPO3\CMS\Core\TypoScript\TypoScriptService;
-    use TYPO3\CMS\Core\Utility\GeneralUtility;
-    use TYPO3\CMS\Core\Utility\RootlineUtility;
+<?php
 
+declare(strict_types=1);
 
-    final readonly class TypoScriptConfigurationManager
+namespace MyDomain\MyExtension\Backend;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Site\Entity\NullSite;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\TypoScript\TypoScriptFactory;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
+
+final readonly class TypoScriptConfigurationManager
+{
+    public function __construct(
+        private TypoScriptFactory $typoScriptFactory,
+        private TypoScriptService $typoScriptService,
+    ) {}
+
+    /**
+     * Returns TypoScript Setup array from the current environment.
+     *
+     * @param ServerRequestInterface $request The current server request
+     * @return array The clean, nested TypoScript setup array
+     */
+    public function getTypoScriptSetup(ServerRequestInterface $request): array
     {
-        public function __construct(
-            #[Autowire(service: 'cache.typoscript')]
-            private PhpFrontend $typoScriptCache,
-            #[Autowire(service: 'cache.runtime')]
-            private FrontendInterface $runtimeCache,
-            private SysTemplateRepository $sysTemplateRepository,
-            private SiteFinder $siteFinder,
-            private FrontendTypoScriptFactory $frontendTypoScriptFactory,
-            private ConnectionPool $connectionPool,
-            private SetRegistry $setRegistry,
-        ) {}
+        // 1. Try to get TypoScript from the request attribute (works if rendered via frontend/preview)
+        $typoScript = $request->getAttribute('frontend.typoscript');
 
-
-        /**
-        * Returns TypoScript Setup array from current Environment.
-        *
-        * @return array the raw TypoScript setup
-        */
-        public function getTypoScriptSetup(ServerRequestInterface $request): array
-        {
-            $currentPageId = $this->getCurrentPageId($request);
-
-            $cacheIdentifier = 'mydomain-backend-typoscript-pageIda-' . $currentPageId;
-            $setupArray = $this->runtimeCache->get($cacheIdentifier);
-            if (is_array($setupArray)) {
-                return $setupArray;
-            }
-
-            $site = $request->getAttribute('site');
-            if (($site === null || $site instanceof NullSite) && $currentPageId > 0) {
-                try {
-                    $site = $this->siteFinder->getSiteByPageId($currentPageId);
-                } catch (SiteNotFoundException) {
-                    // Keep null / NullSite when no site could be determined for whatever reason.
-                }
-            }
-            if ($site === null) {
-                // If still no site object, have NullSite (usually pid 0).
-                $site = new NullSite();
-            }
-
-            $rootLine = [];
-            $sysTemplateRows = [];
-            if ($currentPageId > 0) {
-                $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $currentPageId)->get();
-                // When the site acts as a TypoScript root, limit sys_template lookup to
-                // pages within this site by truncating the rootline at the site root page.
-                // This mirrors the frontend behavior and prevents sys_template records from
-                // parent sites from leaking into the backend TypoScript evaluation.
-                // @see \TYPO3\CMS\Frontend\Page\PageInformationFactory::setSysTemplateRows()
-                $rootLineForSysTemplates = $rootLine;
-                if ($site instanceof Site && $site->isTypoScriptRoot()) {
-                    $rootLineForSysTemplates = [];
-                    foreach ($rootLine as $index => $rootlinePage) {
-                        $rootLineForSysTemplates[$index] = $rootlinePage;
-                        if ((int)($rootlinePage['uid'] ?? 0) === $site->getRootPageId()) {
-                            break;
-                        }
-                    }
-                }
-                $sysTemplateRows = $this->sysTemplateRepository->getSysTemplateRowsByRootline($rootLineForSysTemplates, $request);
-                ksort($rootLine);
-            }
-            $sets = $site instanceof Site ? $this->setRegistry->getSets(...$site->getSets()) : [];
-            if (empty($sysTemplateRows) && $sets === []) {
-                // If no page with sys_template rows or site sets could be derived, we
-                // "fake" a row to trigger inclusion of 'global' TypoScript only.
-                $sysTemplateFakeRow = [
-                    'uid' => 0,
-                    'pid' => 0,
-                    'title' => 'Fake sys_template row to force global TypoScript loading',
-                    'root' => 1,
-                    'clear' => 3,
-                    'include_static_file' => '',
-                    'basedOn' => '',
-                    'includeStaticAfterBasedOn' => 0,
-                    'static_file_mode' => false,
-                    'constants' => '',
-                    'config' => '',
-                    'deleted' => 0,
-                    'hidden' => 0,
-                    'starttime' => 0,
-                    'endtime' => 0,
-                    'sorting' => 0,
-                ];
-                $sysTemplateRows[] = $sysTemplateFakeRow;
-            }
-
-            $expressionMatcherVariables = [
-                'request' => $request,
-                'pageId' => $currentPageId,
-                'page' => !empty($rootLine) ? $rootLine[array_key_first($rootLine)] : [],
-                'fullRootLine' => $rootLine,
-                'site' => $site,
-            ];
-
-            $typoScript = $this->frontendTypoScriptFactory->createSettingsAndSetupConditions($site, $sysTemplateRows, $expressionMatcherVariables, $this->typoScriptCache);
-            $typoScript = $this->frontendTypoScriptFactory->createSetupConfigOrFullSetup(true, $typoScript, $site, $sysTemplateRows, $expressionMatcherVariables, '0', $this->typoScriptCache, null);
-            // Retrieve the TypoScript setup array containing trailing dots
-            $setupArray = $typoScript->getSetupArray();
-            $this->runtimeCache->set($cacheIdentifier, $setupArray);
-            
-            // Instantiate the TypoScriptService
-            $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
-
-            // Convert the TypoScript array to a plain nested array (removing trailing dots)
-            $plainArray = $typoScriptService->convertTypoScriptArrayToPlainArray($setupArray);
-
-            return $plainArray;
+        if ($typoScript !== null) {
+            return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
         }
 
-        /**
-        * Get page id from the request, accessing POST / GET 'id'
-        */
-        private function getCurrentPageId(ServerRequestInterface $request): int
-        {
-            $id = 0;
-            $potentialId = $request->getParsedBody()['id'] ?? $request->getQueryParams()['id'] ?? 0;
-            if (MathUtility::canBeInterpretedAsInteger($potentialId) && $potentialId > 0) {
-                $id = (int)$potentialId;
-            }
-            return $id;
+        // 2. Fallback for the pure Backend context (FormEngine) using the public TypoScriptFactory
+        $site = $request->getAttribute('site');
+        if ($site === null || $site instanceof NullSite) {
+            return [];
         }
+
+        if ($site instanceof Site) {
+            // Build the TypoScript registry object based on the current active Site and its Site Sets
+            $typoScript = $this->typoScriptFactory->createFromSite($site);
+            return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
+        }
+
+        return [];
     }
-
+}
 
 Example for :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -125,7 +125,6 @@ This is an example TypoScript Configuration Manager:
 
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Backend/TypoScriptConfigurationManager.php
-
     namespace MyDomain\MyExtension\Backend;
 
     use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
@@ -136,6 +135,8 @@ This is an example TypoScript Configuration Manager:
     use TYPO3\CMS\Core\Site\SiteFinder;
     use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
     use TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory;
+    use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 
@@ -239,9 +240,17 @@ This is an example TypoScript Configuration Manager:
 
             $typoScript = $this->frontendTypoScriptFactory->createSettingsAndSetupConditions($site, $sysTemplateRows, $expressionMatcherVariables, $this->typoScriptCache);
             $typoScript = $this->frontendTypoScriptFactory->createSetupConfigOrFullSetup(true, $typoScript, $site, $sysTemplateRows, $expressionMatcherVariables, '0', $this->typoScriptCache, null);
+            // Retrieve the TypoScript setup array containing trailing dots
             $setupArray = $typoScript->getSetupArray();
             $this->runtimeCache->set($cacheIdentifier, $setupArray);
-            return $setupArray;
+            
+            // Instantiate the TypoScriptService
+            $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+
+            // Convert the TypoScript array to a plain nested array (removing trailing dots)
+            $plainArray = $typoScriptService->convertTypoScriptArrayToPlainArray($setupArray);
+
+            return $plainArray;
         }
 
         /**
@@ -257,7 +266,6 @@ This is an example TypoScript Configuration Manager:
             return $id;
         }
     }
-
 
 
 Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -127,7 +127,7 @@ instead of this solution. For backend module configuration you should use
         }
     }
 
-Here an example for a :class:`SiteFinder` 
+Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Service/SiteConfigurationService.php

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -62,7 +62,7 @@ the frontend parsing chain, this part will evolve in the future and further API 
 evolve allowing extensions to parse TypoScript more easily.
 
 However, extension controllers that need the parsed TypoScript can access the parsed
-setup as array:
+setup as array (including trailing dots):
 
 .. code-block:: php
 
@@ -275,6 +275,7 @@ Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 
     namespace MyVendor\MyExtension\Service;
 
+    use Psr\Http\Message\ServerRequestInterface;
     use TYPO3\CMS\Core\Site\SiteFinder;
     use TYPO3\CMS\Core\Site\Entity\Site;
     
@@ -289,9 +290,15 @@ Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
         {
             // Find the site object by traversing the rootline upwards from the given page ID
             $site = $this->siteFinder->getSiteByPageId($pageId);
+            $warningText = 'Warning!';
             
-            // Access configuration attributes or custom site settings
-            return $site->getAttribute('myGeneralWarningText') ?? 'Warning!';
+            // Ensure $site is not null before proceeding
+            if ($site instanceof Site) {
+                // Access configuration attributes or custom site settings
+                $warningText = $site->getAttribute('myGeneralWarningText') ?? $warningText;
+            }
+
+            return warningText;
         }
     }
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -137,8 +137,6 @@ use TYPO3\CMS\Core\Site\Entity\NullSite;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\TypoScript\TypoScriptFactory;
 use TYPO3\CMS\Core\TypoScript\TypoScriptService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\MathUtility;
 
 final readonly class TypoScriptConfigurationManager
 {

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -88,12 +88,16 @@ instead of this solution. For backend module configuration you should use
 
     namespace MyDomain\MyExtension\Backend;
 
+    use Psr\Http\Message\ResponseInterface;
     use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Backend\Attribute\AsController;
     use TYPO3\CMS\Core\Database\ConnectionPool;
+    use TYPO3\CMS\Core\Http\HtmlResponse;
     use TYPO3\CMS\Core\SingletonInterface;
     use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 
-    class OrderController implements SingletonInterface
+    #[AsController]
+    final readonly class OrderController implements SingletonInterface
     {    
         public function __construct(
             protected ConnectionPool $connectionPool,
@@ -101,14 +105,11 @@ instead of this solution. For backend module configuration you should use
             protected BackendConfigurationManager $concreteConfigurationManager
         ) {}
 
-        public function main(
-            string $content,
-            array $conf,
-            ServerRequestInterface $request,
-        ) : string {
+        public function handleRequest(ServerRequestInterface $request): ResponseInterface
+        {
             $setup = $this->getTypoScript($request);
             $foo = $setup['my_extension']['bar'] ?? '';
-            return '<div>Foo Setup: ' . $foo . '</div>';
+            return new HtmlResponse('<div>Foo Setup: ' . $foo . '</div>');
         }
 
         public function getTypoScript(ServerRequestInterface $request): array

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -126,55 +126,53 @@ This is an example TypoScript Configuration Manager:
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Backend/TypoScriptConfigurationManager.php
 
-<?php
-
-declare(strict_types=1);
-
-namespace MyDomain\MyExtension\Backend;
-
-use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Core\Site\Entity\NullSite;
-use TYPO3\CMS\Core\Site\Entity\Site;
-use TYPO3\CMS\Core\TypoScript\TypoScriptFactory;
-use TYPO3\CMS\Core\TypoScript\TypoScriptService;
-
-final readonly class TypoScriptConfigurationManager
-{
-    public function __construct(
-        private TypoScriptFactory $typoScriptFactory,
-        private TypoScriptService $typoScriptService,
-    ) {}
-
-    /**
-     * Returns TypoScript Setup array from the current environment.
-     *
-     * @param ServerRequestInterface $request The current server request
-     * @return array The clean, nested TypoScript setup array
-     */
-    public function getTypoScriptSetup(ServerRequestInterface $request): array
+    declare(strict_types=1);
+    
+    namespace MyDomain\MyExtension\Backend;
+    
+    use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Core\Site\Entity\NullSite;
+    use TYPO3\CMS\Core\Site\Entity\Site;
+    use TYPO3\CMS\Core\TypoScript\TypoScriptFactory;
+    use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+    
+    final readonly class TypoScriptConfigurationManager
     {
-        // 1. Try to get TypoScript from the request attribute (works if rendered via frontend/preview)
-        $typoScript = $request->getAttribute('frontend.typoscript');
-
-        if ($typoScript !== null) {
-            return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
-        }
-
-        // 2. Fallback for the pure Backend context (FormEngine) using the public TypoScriptFactory
-        $site = $request->getAttribute('site');
-        if ($site === null || $site instanceof NullSite) {
+        public function __construct(
+            private TypoScriptFactory $typoScriptFactory,
+            private TypoScriptService $typoScriptService,
+        ) {}
+    
+        /**
+         * Returns TypoScript Setup array from the current environment.
+         *
+         * @param ServerRequestInterface $request The current server request
+         * @return array The clean, nested TypoScript setup array
+         */
+        public function getTypoScriptSetup(ServerRequestInterface $request): array
+        {
+            // 1. Try to get TypoScript from the request attribute (works if rendered via frontend/preview)
+            $typoScript = $request->getAttribute('frontend.typoscript');
+    
+            if ($typoScript !== null) {
+                return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
+            }
+    
+            // 2. Fallback for the pure Backend context (FormEngine) using the public TypoScriptFactory
+            $site = $request->getAttribute('site');
+            if ($site === null || $site instanceof NullSite) {
+                return [];
+            }
+    
+            if ($site instanceof Site) {
+                // Build the TypoScript registry object based on the current active Site and its Site Sets
+                $typoScript = $this->typoScriptFactory->createFromSite($site);
+                return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
+            }
+    
             return [];
         }
-
-        if ($site instanceof Site) {
-            // Build the TypoScript registry object based on the current active Site and its Site Sets
-            $typoScript = $this->typoScriptFactory->createFromSite($site);
-            return $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScript->getSetupArray());
-        }
-
-        return [];
     }
-}
 
 Example for :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -80,7 +80,7 @@ Another means needs to be used to read the Frontend TypoScript of the currently 
 This is needed in a case where some Frontend classes need to be called as well by from the Backend. E.g. a shop administrator
 is allowed to resend an order email with a new modified bill after the customer has cancelled one item from his order.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
-Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider unsing the
+Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider using the
 `SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_
 instead of this solution. For backend module configuration you should use 
 `Backend TypoScript / TSconfig <https://docs.typo3.org/permalink/t3tsref:about-tsconfig>`_ instead of Frontend TypoScript. 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -77,12 +77,13 @@ Backend TypoScript
 ==================
 
 Another means needs to be used to read the Frontend TypoScript of the currently selected page in the backend page module.
-This is needed in a case where some Frontend classes need to be called as well by from the Backend. E.g. a shop administrator
+This is needed in the case some Frontend classes need to be called as well from the Backend. E.g. a shop administrator
 is allowed to resend an order email with a new modified bill after the customer has cancelled one item from his order.
 The needed TYPO3 internal object of the :php:`Extbase` class :php:`BackendConfigurationManager` can be obtained by means of Dependency Injection. 
 Note that it may be required to enrich the request object. TypoScript parsing is time consuming. Consider using the
-`SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_
-instead of this solution. For backend module configuration you should use 
+`SiteFinder class <https://docs.typo3.org/permalink/t3coreapi:sitehandling-sitefinder-object>`_ 
+and site configuration attributes instead of this solution. 
+For backend module configuration you should use 
 `Backend TypoScript / TSconfig <https://docs.typo3.org/permalink/t3tsref:about-tsconfig>`_ instead of Frontend TypoScript. 
 
 .. code-block:: php
@@ -101,8 +102,8 @@ instead of this solution. For backend module configuration you should use
     final readonly class OrderController
     {    
         public function __construct(
-            protected ConnectionPool $connectionPool,
-            protected TypoScriptConfigurationManager $concreteConfigurationManager
+            private ConnectionPool $connectionPool,
+            private TypoScriptConfigurationManager $concreteConfigurationManager
         ) {}
 
         public function handleRequest(ServerRequestInterface $request): ResponseInterface
@@ -267,7 +268,7 @@ This is an example TypoScript Configuration Manager:
     }
 
 
-Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
+Example for :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 
 .. code-block:: php
     :caption: EXT:my_extension/Classes/Service/SiteConfigurationService.php

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -95,11 +95,10 @@ instead of this solution. For backend module configuration you should use
     use TYPO3\CMS\Backend\Attribute\AsController;
     use TYPO3\CMS\Core\Database\ConnectionPool;
     use TYPO3\CMS\Core\Http\HtmlResponse;
-    use TYPO3\CMS\Core\SingletonInterface;
     use MyDomain\MyExtension\Backend\TypoScriptConfigurationManager;
 
     #[AsController]
-    final readonly class OrderController implements SingletonInterface
+    final readonly class OrderController
     {    
         public function __construct(
             protected ConnectionPool $connectionPool,

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -127,3 +127,30 @@ instead of this solution. For backend module configuration you should use
         }
     }
 
+Here an example for a :class:`SiteFinder` 
+
+.. code-block:: php
+    :caption: EXT:my_extension/Classes/Service/SiteConfigurationService.php
+
+    namespace MyVendor\MyExtension\Service;
+
+    use TYPO3\CMS\Core\Site\SiteFinder;
+    use TYPO3\CMS\Core\Site\Entity\Site;
+    
+    readonly class SiteConfigurationService
+    {
+        // Inject the SiteFinder via constructor injection
+        public function __construct(
+            private SiteFinder $siteFinder
+        ) {}
+    
+        public function getMyGeneralWarningText(int $pageId): string
+        {
+            // Find the site object by traversing the rootline upwards from the given page ID
+            $site = $this->siteFinder->getSiteByPageId($pageId);
+            
+            // Access configuration attributes or custom site settings
+            return $site->getAttribute('myGeneralWarningText') ?? 'Warning!';
+        }
+    }
+

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -101,7 +101,6 @@ instead of this solution. For backend module configuration you should use
     {    
         public function __construct(
             protected ConnectionPool $connectionPool,
-            protected ContainerInterface $container,
             protected BackendConfigurationManager $concreteConfigurationManager
         ) {}
 

--- a/Documentation/Configuration/TypoScript/PhpApi/Index.rst
+++ b/Documentation/Configuration/TypoScript/PhpApi/Index.rst
@@ -96,14 +96,14 @@ instead of this solution. For backend module configuration you should use
     use TYPO3\CMS\Core\Database\ConnectionPool;
     use TYPO3\CMS\Core\Http\HtmlResponse;
     use TYPO3\CMS\Core\SingletonInterface;
-    use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
+    use MyDomain\MyExtension\Backend\TypoScriptConfigurationManager;
 
     #[AsController]
     final readonly class OrderController implements SingletonInterface
     {    
         public function __construct(
             protected ConnectionPool $connectionPool,
-            protected BackendConfigurationManager $concreteConfigurationManager
+            protected TypoScriptConfigurationManager $concreteConfigurationManager
         ) {}
 
         public function handleRequest(ServerRequestInterface $request): ResponseInterface
@@ -119,6 +119,146 @@ instead of this solution. For backend module configuration you should use
              return $setup;
         }
     }
+
+
+This is an example TypoScript Configuration Manager:
+
+.. code-block:: php
+    :caption: EXT:my_extension/Classes/Backend/TypoScriptConfigurationManager.php
+
+    namespace MyDomain\MyExtension\Backend;
+
+    use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
+    use TYPO3\CMS\Core\Cache\Frontend\PhpFrontend;
+    use TYPO3\CMS\Core\Database\ConnectionPool;
+    use TYPO3\CMS\Core\Site\Entity\NullSite;
+    use TYPO3\CMS\Core\Site\Set\SetRegistry;
+    use TYPO3\CMS\Core\Site\SiteFinder;
+    use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
+    use TYPO3\CMS\Core\TypoScript\FrontendTypoScriptFactory;
+    use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+
+    final readonly class TypoScriptConfigurationManager
+    {
+        public function __construct(
+            #[Autowire(service: 'cache.typoscript')]
+            private PhpFrontend $typoScriptCache,
+            #[Autowire(service: 'cache.runtime')]
+            private FrontendInterface $runtimeCache,
+            private SysTemplateRepository $sysTemplateRepository,
+            private SiteFinder $siteFinder,
+            private FrontendTypoScriptFactory $frontendTypoScriptFactory,
+            private ConnectionPool $connectionPool,
+            private SetRegistry $setRegistry,
+        ) {}
+
+
+        /**
+        * Returns TypoScript Setup array from current Environment.
+        *
+        * @return array the raw TypoScript setup
+        */
+        public function getTypoScriptSetup(ServerRequestInterface $request): array
+        {
+            $currentPageId = $this->getCurrentPageId($request);
+
+            $cacheIdentifier = 'mydomain-backend-typoscript-pageIda-' . $currentPageId;
+            $setupArray = $this->runtimeCache->get($cacheIdentifier);
+            if (is_array($setupArray)) {
+                return $setupArray;
+            }
+
+            $site = $request->getAttribute('site');
+            if (($site === null || $site instanceof NullSite) && $currentPageId > 0) {
+                try {
+                    $site = $this->siteFinder->getSiteByPageId($currentPageId);
+                } catch (SiteNotFoundException) {
+                    // Keep null / NullSite when no site could be determined for whatever reason.
+                }
+            }
+            if ($site === null) {
+                // If still no site object, have NullSite (usually pid 0).
+                $site = new NullSite();
+            }
+
+            $rootLine = [];
+            $sysTemplateRows = [];
+            if ($currentPageId > 0) {
+                $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $currentPageId)->get();
+                // When the site acts as a TypoScript root, limit sys_template lookup to
+                // pages within this site by truncating the rootline at the site root page.
+                // This mirrors the frontend behavior and prevents sys_template records from
+                // parent sites from leaking into the backend TypoScript evaluation.
+                // @see \TYPO3\CMS\Frontend\Page\PageInformationFactory::setSysTemplateRows()
+                $rootLineForSysTemplates = $rootLine;
+                if ($site instanceof Site && $site->isTypoScriptRoot()) {
+                    $rootLineForSysTemplates = [];
+                    foreach ($rootLine as $index => $rootlinePage) {
+                        $rootLineForSysTemplates[$index] = $rootlinePage;
+                        if ((int)($rootlinePage['uid'] ?? 0) === $site->getRootPageId()) {
+                            break;
+                        }
+                    }
+                }
+                $sysTemplateRows = $this->sysTemplateRepository->getSysTemplateRowsByRootline($rootLineForSysTemplates, $request);
+                ksort($rootLine);
+            }
+            $sets = $site instanceof Site ? $this->setRegistry->getSets(...$site->getSets()) : [];
+            if (empty($sysTemplateRows) && $sets === []) {
+                // If no page with sys_template rows or site sets could be derived, we
+                // "fake" a row to trigger inclusion of 'global' TypoScript only.
+                $sysTemplateFakeRow = [
+                    'uid' => 0,
+                    'pid' => 0,
+                    'title' => 'Fake sys_template row to force global TypoScript loading',
+                    'root' => 1,
+                    'clear' => 3,
+                    'include_static_file' => '',
+                    'basedOn' => '',
+                    'includeStaticAfterBasedOn' => 0,
+                    'static_file_mode' => false,
+                    'constants' => '',
+                    'config' => '',
+                    'deleted' => 0,
+                    'hidden' => 0,
+                    'starttime' => 0,
+                    'endtime' => 0,
+                    'sorting' => 0,
+                ];
+                $sysTemplateRows[] = $sysTemplateFakeRow;
+            }
+
+            $expressionMatcherVariables = [
+                'request' => $request,
+                'pageId' => $currentPageId,
+                'page' => !empty($rootLine) ? $rootLine[array_key_first($rootLine)] : [],
+                'fullRootLine' => $rootLine,
+                'site' => $site,
+            ];
+
+            $typoScript = $this->frontendTypoScriptFactory->createSettingsAndSetupConditions($site, $sysTemplateRows, $expressionMatcherVariables, $this->typoScriptCache);
+            $typoScript = $this->frontendTypoScriptFactory->createSetupConfigOrFullSetup(true, $typoScript, $site, $sysTemplateRows, $expressionMatcherVariables, '0', $this->typoScriptCache, null);
+            $setupArray = $typoScript->getSetupArray();
+            $this->runtimeCache->set($cacheIdentifier, $setupArray);
+            return $setupArray;
+        }
+
+        /**
+        * Get page id from the request, accessing POST / GET 'id'
+        */
+        private function getCurrentPageId(ServerRequestInterface $request): int
+        {
+            $id = 0;
+            $potentialId = $request->getParsedBody()['id'] ?? $request->getQueryParams()['id'] ?? 0;
+            if (MathUtility::canBeInterpretedAsInteger($potentialId) && $potentialId > 0) {
+                $id = (int)$potentialId;
+            }
+            return $id;
+        }
+    }
+
+
 
 Here an example for a :php-short:`\TYPO3\CMS\Core\Site\SiteFinder` :
 


### PR DESCRIPTION
Added explanation for Backend TypoScript usage and provided code example.

Originally from Stefan Bürk at

https://stackoverflow.com/questions/79650912/getting-typoscript-from-backend-non-controller