### PR TITLE
Fix some inconsistencies in template root path and content element key

### DIFF
--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -243,7 +243,7 @@ Extended example: Extend tt_content and use data processing
 You can find the complete example in the  TYPO3 Documentation Team extension
 :composer:`t3docs/examples`. The steps for
 creating a simple new content element as above need to be repeated. We use the
-key *examples_newcontentcsv* in this example.
+key *myextension_newcontentcsv* in this example.
 
 We want to output comma separated values (CSV) stored in the field bodytext.
 As different programs use different separators to store CSV we want to make


### PR DESCRIPTION
This PR fixes an inconsistency in the content element key referenced in the documentation and also updates the configured template root path to match the path that would be generated via the official Site Package Builder.