### PR TITLE
[DOCS] Correct reason for request independence in BaseVariants conditions

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -136,9 +136,10 @@ exception:
 
 ..  note::
     For request-dependent base variants (for example matching the current
-    host or request parameters), use a dedicated extension such as
-    :composer:`b13/host-variants`, or register your own condition or function
-    provider that injects the request into the expression language context.
+    host or request parameters), or to use ``traverse()`` on custom data,
+    use a dedicated extension such as :composer:`b13/host-variants`, or
+    register your own condition or function provider that injects the
+    needed variables into the expression language context.
 
 The following request-independent functions are available:
 

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -111,7 +111,7 @@ Functions
 
 Functions from
 :t3src:`core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php`
-are available, as long as they are request-independant (due to caching reasons). For
+are available, as long as they are request-independent (due to caching reasons). For
 request-dependant conditions/functions, have a look at :composer:`b13/host-variants`
 to see how to add custom condition/function providers to suit your needs.
 

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -109,16 +109,30 @@ Properties
 Functions
 =========
 
-Functions from
-:t3src:`core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php`
-are available, as long as they are request-independent (due to caching reasons). For
-request-dependent conditions/functions, have a look at :composer:`b13/host-variants`
-to see how to add custom condition/function providers to suit your needs.
+The functions provided by
+:php-short:`\TYPO3\CMS\Core\ExpressionLanguage\FunctionsProvider\DefaultFunctionsProvider`
+can be used in base variant conditions, **as long as they do not depend on
+the current request**.
 
-That means, specifically you can **not** use the `ip()` or `traverse(request...)`
-conditions in the handling of base variants.
+Base variant conditions are evaluated while the site configuration is loaded
+and the :php-short:`\TYPO3\CMS\Core\Site\Entity\Site` object is built. In that
+``site`` context the expression language does not receive a request, so the
+``request`` variable is unavailable. Among the built-in functions this affects
+only ``ip()``, which reads the client IP from the request and fails with an
+exception:
 
-Some examples:
+..  code-block:: none
+
+    #1686745105 RuntimeException
+    Using expression language function "ip(devIp)" in a context without request.
+
+..  note::
+    For request-dependent base variants (for example matching the current
+    host or request parameters), use a dedicated extension such as
+    :composer:`b13/host-variants`, or register your own condition or function
+    provider that injects the request into the expression language context.
+
+The following request-independent functions are available:
 
 ..  option:: compatVersion
 

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -112,7 +112,7 @@ Functions
 Functions from
 :t3src:`core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php`
 are available, as long as they are request-independent (due to caching reasons). For
-request-dependant conditions/functions, have a look at :composer:`b13/host-variants`
+request-dependent conditions/functions, have a look at :composer:`b13/host-variants`
 to see how to add custom condition/function providers to suit your needs.
 
 That means, specifically you can **not** use the `ip()` or `traverse(request...)`

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -126,6 +126,14 @@ exception:
     #1686745105 RuntimeException
     Using expression language function "ip(devIp)" in a context without request.
 
+..  versionchanged:: 13.0
+    Until TYPO3 v12, request-dependent functions such as ``ip()`` did work in
+    base variant conditions: their implementation read the client address
+    directly from the server environment, independent of a request object.
+    This request-less fallback was deprecated in v12.3 and removed in v13.0,
+    which is why such conditions now fail with the exception shown above. See
+    `Breaking: #100963 <https://docs.typo3.org/permalink/changelog:breaking-100963-1686129084>`__.
+
 ..  note::
     For request-dependent base variants (for example matching the current
     host or request parameters), use a dedicated extension such as

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -109,17 +109,16 @@ Properties
 Functions
 =========
 
-All functions from
+Functions from
 :t3src:`core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php`
-are available:
+are available, as long as they are request-independant (due to caching reasons). For
+request-dependant conditions/functions, have a look at :composer:`b13/host-variants`
+to see how to add custom condition/function providers to suit your needs.
 
-..  option:: ip
+That means, specifically you can **not** use the `ip()` or `traverse(request...)`
+conditions in the handling of base variants.
 
-    :type: string
-    :Example: `ip("203.0.113.*")`
-
-    Match an IP address, value or regex, wildcards possible.
-    Special value: `devIp` for matching `devIpMask`.
+Some examples:
 
 ..  option:: compatVersion
 
@@ -160,13 +159,3 @@ are available:
 
     Check whether a feature (":ref:`feature toggle <feature-toggles>`") is
     enabled in TYPO3.
-
-..  option:: traverse
-
-    :type: array|string
-    :Example: `traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0`
-
-    This function has two parameters:
-
-    *   first parameter is the array to traverse
-    *   second parameter is the path to traverse


### PR DESCRIPTION
## What & why

Follow-up to #5670 by @garvinhicking — this branch is **based on his commits**, so his (and @brotkrueml's co-authored) work is preserved in the history.

The documentation for base variant conditions currently claims that *all* functions from `DefaultFunctionsProvider` are available. Request-dependent functions such as `ip()` are **not** available there and fail with:

```
#1686745105 RuntimeException
Using expression language function "ip(devIp)" in a context without request.
```

(reported in [forge #106696](https://forge.typo3.org/issues/106696)).

### Root cause (verified in core)

Base variant conditions are evaluated in `Site::resolveBaseWithVariants()`, which builds the expression language resolver for the `site` context **without a request variable**:

```php
// typo3/sysext/core/Classes/Site/Entity/Site.php
$expressionLanguageResolver = GeneralUtility::makeInstance(Resolver::class, 'site', []);
```

`DefaultProvider` only supplies `applicationContext`, `typo3`, `date` and `features` — there is no `request`, so `ip()` (which requires a `RequestWrapper`) throws. This happens when the `Site` object is built — **not** because of caching, which an earlier revision of #5670 stated (thanks @froemken for the correction).

### What this changes on top of #5670

- Replace the incorrect *"due to caching reasons"* explanation with the real cause (no `request` in the `site` expression language context).
- Show the actual exception (`#1686745105`) so the page is found when searching for the error message.
- Link the class via `:php-short:` instead of a raw `:t3src:` file link (as requested by @linawolf / @franzholz in the review of #5670).
- Reword the intro of the available-functions list ("Some examples:" → "The following request-independent functions are available:").
- The `ip` and request-based `traverse` examples stay removed (as in #5670).

## Rendered before / after

<table>
<tr>
<th width="50%">Before (current <code>main</code>)</th>
<th width="50%">After (this PR)</th>
</tr>
<tr>
<td><a href="https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Reference-CoreApi/pr-assets/assets/basevariants-before.png"><img src="https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Reference-CoreApi/pr-assets/assets/basevariants-before.png" alt="Functions section before the fix" width="100%"></a></td>
<td><a href="https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Reference-CoreApi/pr-assets/assets/basevariants-after-changed.png"><img src="https://raw.githubusercontent.com/CybotTM/TYPO3CMS-Reference-CoreApi/pr-assets/assets/basevariants-after-changed.png" alt="Functions section after the fix" width="100%"></a></td>
</tr>
</table>

<sub>Click a thumbnail to open the full-resolution render.</sub>

## Decision required

Before merging, please decide whether this should be **documented** (this PR) or **fixed in the core** instead: there is an unresolved discussion in #5670 whether the `site` expression language context should receive a `RequestWrapper` (@froemken's proposal), which would make `ip()` usable again. As of core `main` the limitation still exists, so this PR documents the current behaviour — if the core starts passing the request, this section should be reverted.

## Checklist

- [x] Renders without warnings — `render-guides … --fail-on-log` exits `0`
- [x] Authorship of #5670 preserved (commits by @garvinhicking, co-author @brotkrueml)
