### PR TITLE
[TASK] Bump reusable-backport.yml pin to stop backport self-retrigger loop

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   backport:
-    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@161f3bed5308099b67674e3e9d5a735e02500b24
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@559a564fa27c3a930386e383c47ea1067d810c97
     with:
       label_pattern: "^backport (.+)$"
     secrets:


### PR DESCRIPTION
## Problem

The backport bot posted duplicate comments across multiple workflow runs on #6655.

Two things stacked up; only the second is fixed here:

1. **The backport genuinely failed** — the merge commit does not cherry-pick cleanly onto `14.3`. Out of scope; needs a manual cherry-pick.
2. **The workflow re-triggered itself** — this produced the *duplicate* comments and is what this PR fixes.

## Root cause

`backport.yml` triggers on `pull_request_target: [closed, labeled]` and was pinned to `reusable-backport.yml@161f3bed` (2026-06-02). That pinned version adds a `backport-done` / `backport-failed` label on completion. Adding a label fires the `labeled` event, and that version's `if` only checked:

```yaml
contains(toJson(github.event.pull_request.labels), 'backport')
```

`backport-failed` matches the substring → the workflow runs again → another pair of comments.

The fix — exclude the success/failure labels from the trigger — was already merged upstream in [`46ed94fb`](https://github.com/TYPO3-Documentation/.github/commit/46ed94fb), but the stale SHA pin meant it never reached this repo.

## Fix

Bump the pin from `161f3bed` to the current head [`559a564f`](https://github.com/TYPO3-Documentation/.github/commit/559a564f), which contains that fix. The only other change in that range is zizmor-ignore annotations — no behavioral difference.

## Not covered

The actual `14.3` backport of #6655 still needs a manual cherry-pick (real content conflict), per the bot's instructions on that PR.
