### PR TITLE
[TASK] Use PHP 8.5 in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.2'
-          - '8.3'
-          - '8.4'
           - '8.5'
     steps:
       - name: Checkout
@@ -32,7 +29,7 @@ jobs:
     name: Quality
     runs-on: ubuntu-latest
     env:
-      php: '8.2'
+      php: '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10


### PR DESCRIPTION
TYPO3 raised its minimum [PHP version to 8.5](https://github.com/TYPO3/typo3/commit/195d480f4418f000d972115b501c2934edcb28fe).

This needs to be reflected in the workflow execution.