### PR TITLE
[BUGFIX] Make project installable with symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
     "require-dev": {
         "ergebnis/composer-normalize": "~2.51.0",
         "friendsofphp/php-cs-fixer": "^3.46",
-        "garvinhicking/clinspector-gadget": "^0.1.1",
-        "symfony/yaml": "^7.0",
+        "garvinhicking/clinspector-gadget": "^0.1.7",
         "t3docs/codesnippet": "dev-main",
         "typo3/cms-adminpanel": "dev-main as 14.3",
         "typo3/cms-backend": "dev-main as 14.3",


### PR DESCRIPTION
TYPO3 dev-main expects symfony 8 now

Releases: main