### PR TITLE
[TASK] Update plugin icon reference and add example for custom icon r…

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/QuickStart/Index.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/QuickStart/Index.rst
@@ -218,6 +218,20 @@ content element in the backend:
 ..  literalinclude:: _snippets/_tt_content.php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/tt_content.php
 
+The icon argument passed to :php:`registerPlugin()` must be a
+:ref:`registered icon identifier <icon-registration>`, not a raw
+`EXT:` path — the example above uses TYPO3's built-in default
+plugin icon (`content-plugin`).
+
+Registering a custom icon is optional. If you want one, register it in
+:file:`Configuration/Icons.php`:
+
+..  literalinclude:: _snippets/_Icons.php
+    :caption: EXT:my_extension/Configuration/Icons.php
+
+and reference its identifier (`my-extension-conference-list`)
+instead of `content-plugin` in the :php:`registerPlugin()` call above.
+
 ..  seealso::
 
     :ref:`extbase-registration-frontend-plugin`

--- a/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_Icons.php
+++ b/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_Icons.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+return [
+    'my-extension-conference-list' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:my_extension/Resources/Public/Icons/Extension.svg',
+    ],
+];

--- a/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_tt_content.php
+++ b/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_tt_content.php
@@ -10,5 +10,5 @@ ExtensionUtility::registerPlugin(
     'MyExtension',
     'ConferenceList',
     'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:plugin.conferencelist.title',
-    'EXT:my_extension/Resources/Public/Icons/Extension.svg',
+    'content-plugin',
 );


### PR DESCRIPTION
…egistration

Adapt `registerPlugin()` icon argument to use a registered icon identifier instead of a raw file path. Provide documentation and example for custom icon registration in `Icons.php`.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/6564 Releases: main, 14.3
(cherry picked from commit 5d99efef65612c21b4703d3a4cb68dc1f413c548)