### PR TITLE
[TASK] Add example for ModifyDefaultConstraintsForDatabaseQueryEvent

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Core/Domain/ModifyDefaultConstraintsForDatabaseQueryEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/ModifyDefaultConstraintsForDatabaseQueryEvent.rst
@@ -25,7 +25,23 @@ to modify them via the :php:`getConstraints()` and
 Example
 =======
 
-..  include:: /_includes/EventsContributeNote.rst.txt
+The following example adds an additional restriction based on a custom TCA
+`enablecolumns` entry. Assume a table stores a "purchased amount" range
+per record (`purchased_amount_from` / `purchased_amount_to`), and
+only records whose range contains the current customer's purchased amount
+should be selected — for every query TYPO3 builds for that table, without
+having to repeat the condition manually.
+
+Declare the custom `enablecolumns` entry in the table's TCA:
+
+..  literalinclude:: _ModifyDefaultConstraintsForDatabaseQueryEvent/_tca.php
+    :caption: EXT:my_extension/Configuration/TCA/tx_myextension_domain_model_product.php
+
+Add a listener that turns this into a query constraint whenever the event
+fires for that table:
+
+..  literalinclude:: _ModifyDefaultConstraintsForDatabaseQueryEvent/_PurchasedAmountRestrictionListener.php
+    :caption: EXT:my_extension/Classes/EventListener/PurchasedAmountRestrictionListener.php
 
 ..  _modify-default-constraints-for-database-query-event-api:
 

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/ModifyDefaultConstraintsForDatabaseQueryEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/ModifyDefaultConstraintsForDatabaseQueryEvent.rst
@@ -22,8 +22,8 @@ to modify them via the :php:`getConstraints()` and
 
 ..  _modify-default-constraints-for-database-query-event-example:
 
-Example
-=======
+Example: Restrict queries using a custom `enablecolumns` entry
+==============================================================
 
 The following example adds an additional restriction based on a custom TCA
 `enablecolumns` entry. Assume a table stores a "purchased amount" range

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/_ModifyDefaultConstraintsForDatabaseQueryEvent/_PurchasedAmountRestrictionListener.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/_ModifyDefaultConstraintsForDatabaseQueryEvent/_PurchasedAmountRestrictionListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\EventListener;
+
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Domain\Event\ModifyDefaultConstraintsForDatabaseQueryEvent;
+
+#[AsEventListener(
+    identifier: 'my-extension/purchased-amount-restriction',
+)]
+final readonly class PurchasedAmountRestrictionListener
+{
+    public function __invoke(ModifyDefaultConstraintsForDatabaseQueryEvent $event): void
+    {
+        $table = $event->getTable();
+        $enableColumns = $GLOBALS['TCA'][$table]['ctrl']['enablecolumns']['purchasedamount'] ?? null;
+        if ($enableColumns === null) {
+            return;
+        }
+
+        [$fromField, $toField] = explode(',', $enableColumns);
+        // strictly typed as float, so it is safe to use directly below
+        // without a bound query parameter
+        $purchasedAmount = $this->getCurrentCustomerPurchasedAmount();
+
+        $expressionBuilder = $event->getExpressionBuilder();
+        $event->setConstraints(array_merge(
+            $event->getConstraints(),
+            [
+                'purchasedamount' => $expressionBuilder->and(
+                    $expressionBuilder->lte($table . '.' . $fromField, $purchasedAmount),
+                    $expressionBuilder->gte($table . '.' . $toField, $purchasedAmount),
+                ),
+            ],
+        ));
+    }
+
+    private function getCurrentCustomerPurchasedAmount(): float
+    {
+        // Your own business logic to determine the value to filter by,
+        // for example reading it from the current frontend user session.
+        return 0.0;
+    }
+}

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/_ModifyDefaultConstraintsForDatabaseQueryEvent/_tca.php
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/_ModifyDefaultConstraintsForDatabaseQueryEvent/_tca.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'ctrl' => [
+        //...
+        'enablecolumns' => [
+            'disabled' => 'hidden',
+            'starttime' => 'starttime',
+            'endtime' => 'endtime',
+            'purchasedamount' => 'purchased_amount_from,purchased_amount_to',
+        ],
+    ],
+    //...
+];


### PR DESCRIPTION
Adds a worked example: a custom TCA enablecolumns entry restricting records to a "purchased amount" range, enforced via an event listener that adds the corresponding constraint using the event's own ExpressionBuilder.

Based on an example contributed by Davide Alghi in the issue, adapted to house style (PHP attribute-based listener registration, generic MyVendor\MyExtension naming, using $event->getExpressionBuilder() directly instead of instantiating a new QueryBuilder).

Resolves: #6503
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3, 13.4