### PR TITLE
[TASK] Add example for rendering HTML content in a modal

### DIFF
--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/Modals.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/Modals.rst
@@ -197,3 +197,32 @@ a modal dialog are also able to use the new option by adding the
 
 ..  literalinclude:: _Modals/_StaticBackdrop.fluid.html
     :language: html
+
+..  _modules-modals-html-content:
+
+Rendering HTML content in a modal
+----------------------------------
+
+Plain string content, as used in the examples above, is HTML-escaped before
+being rendered.
+
+To render real HTML, pass a `lit` `html` template result
+as `content` instead of a string:
+
+..  literalinclude:: _Modals/_html-content.js
+
+..  warning::
+    `lit` only auto-escapes values inside `${}` expressions of the `html`
+    template — the static markup written directly in the template is always
+    rendered as-is. Never use the `unsafeHTML()` directive (or otherwise
+    build the template from untrusted data) unless the content is fully
+    sanitized first, as doing so reintroduces the same HTML injection risk
+    the default escaping protects against.
+
+Translated labels can be included the same way, using the `lll()` helper
+from `@typo3/core/lit-helper.js`. The label itself must first be made
+available to JavaScript via :php:`PageRenderer->addInlineLanguageLabel()`:
+
+..  literalinclude:: _Modals/_HtmlContentLabel.php
+
+..  literalinclude:: _Modals/_html-content-translated.js

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_HtmlContentLabel.php
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_HtmlContentLabel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\Controller;
+
+use TYPO3\CMS\Core\Page\PageRenderer;
+
+final class SomeController
+{
+    public function __construct(
+        private readonly PageRenderer $pageRenderer,
+    ) {}
+
+    public function someAction(): void
+    {
+        $this->pageRenderer->loadJavaScriptModule('@my-vendor/my-extension/html-content-modal.js');
+        $this->pageRenderer->addInlineLanguageLabel(
+            'myExtension.modal.greeting',
+            'Hello, %s!',
+        );
+    }
+}

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_html-content-translated.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_html-content-translated.js
@@ -1,0 +1,13 @@
+import Modal from '@typo3/backend/modal.js';
+import { html } from 'lit';
+import { lll } from '@typo3/core/lit-helper.js';
+
+button.addEventListener('click', (event) => {
+  event.preventDefault();
+
+  Modal.advanced({
+    title: 'A header',
+    content: html`<p>${lll('myExtension.modal.greeting', 'World')}</p>`,
+    size: Modal.sizes.large,
+  });
+});

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_html-content.js
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/_Modals/_html-content.js
@@ -1,0 +1,12 @@
+import Modal from '@typo3/backend/modal.js';
+import { html } from 'lit';
+
+button.addEventListener('click', (event) => {
+  event.preventDefault();
+
+  Modal.advanced({
+    title: 'A header',
+    content: html`<p>This is <strong>bold</strong> HTML content.</p>`,
+    size: Modal.sizes.large,
+  });
+});


### PR DESCRIPTION
Modal content passed as a plain string is HTML-escaped by default. Add an example showing how to render actual HTML by passing a lit html template result instead, plus how to include translated labels via lll() and PageRenderer->addInlineLanguageLabel(). Also warns against using the unsafeHTML() directive with untrusted data, since that bypasses lit's default escaping.

Resolves: #5981
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3