### PR TITLE
[BUGFIX] Correct outdated note on per-type preview renderers

### DIFF
--- a/Documentation/ApiOverview/ContentElements/CustomBackendPreview.rst
+++ b/Documentation/ApiOverview/ContentElements/CustomBackendPreview.rst
@@ -145,6 +145,14 @@ approaches:
     This specifies the preview renderer only for records of type :php:`$type` as
     determined by the :ref:`type field <t3tca:types>` of your table.
 
+The content elements `text`, `textpic`, `textmedia` and
+`image` do not have their own `PreviewRenderer` — they use the
+standard :php-short:`\TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer`
+like any other content type. To customize their preview, use the
+:ref:`page TSconfig <ConfigureCE-Preview-PageTSconfig>` or
+:ref:`event listener <ConfigureCE-Preview-EventListener>` approach described
+above instead of registering a type-specific preview renderer.
+
 ..  note::
     The :ref:`recommended location <extension-configuration-tca>` is in the
     :php:`ctrl` array in your extension's :file:`Configuration/TCA/$table.php`
@@ -152,10 +160,3 @@ approaches:
     when your extension is the one that creates the table, the latter is used
     when you need to override TCA properties of tables added by the Core or
     other extensions.
-
-..  note::
-    The content elements :php:`text`, :php:`textpic`, :php:`textmedia` and
-    :php:`image` have their own :php:`PreviewRenderer`. Therefore it's not
-    sufficient to overwrite the :php:`StandardContentPreviewRenderer` but
-    you need to use the second approach from above for every single of
-    these content elements.

--- a/Documentation/ApiOverview/ContentElements/CustomBackendPreview.rst
+++ b/Documentation/ApiOverview/ContentElements/CustomBackendPreview.rst
@@ -145,13 +145,13 @@ approaches:
     This specifies the preview renderer only for records of type :php:`$type` as
     determined by the :ref:`type field <t3tca:types>` of your table.
 
-The content elements `text`, `textpic`, `textmedia` and
-`image` do not have their own `PreviewRenderer` — they use the
-standard :php-short:`\TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer`
-like any other content type. To customize their preview, use the
+Like all other content types, `text`, `textpic`, `textmedia` and
+`image` use the standard
+:php-short:`\TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer`. To customize
+previews for these elements, use the
 :ref:`page TSconfig <ConfigureCE-Preview-PageTSconfig>` or
 :ref:`event listener <ConfigureCE-Preview-EventListener>` approach described
-above instead of registering a type-specific preview renderer.
+above (instead of registering type-specific preview renderers as in the past).
 
 ..  note::
     The :ref:`recommended location <extension-configuration-tca>` is in the


### PR DESCRIPTION
The content elements text, textpic, textmedia and image no longer have their own PreviewRenderer classes (removed in TYPO3 v13.2, see https://review.typo3.org/c/Packages/TYPO3.CMS/+/83744 and https://review.typo3.org/c/Packages/TYPO3.CMS/+/85283). They use StandardContentPreviewRenderer like any other content type. The old note telling readers to register a type-specific previewRenderer for them was outdated and contradicted the page TSconfig / event listener approaches already documented above it.

Resolves: #6149
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3, 13.4