### PR TITLE
[BUGFIX] Add missing backend.form tag to custom link browser tutorial

### DIFF
--- a/Documentation/ApiOverview/LinkHandling/Tutorials/CustomLinkBrowser.rst
+++ b/Documentation/ApiOverview/LinkHandling/Tutorials/CustomLinkBrowser.rst
@@ -175,6 +175,11 @@ As our JavaScript class depends on classes provided by the backend system extens
 :php:`backend` has to be added as dependency. See also
 :ref:`backend-javascript-es6-loading`.
 
+The `backend.form` tag is required because the import map is only generated
+on the initial request. Without this tag, the module would not be resolvable
+when the link browser is opened later from within a form, for example from
+an inline record.
+
 
 .. _tutorial_backend_link_handler_canHandleLink:
 

--- a/Documentation/ApiOverview/LinkHandling/Tutorials/_CustomLinkBrowser/_JavaScriptModules.php
+++ b/Documentation/ApiOverview/LinkHandling/Tutorials/_CustomLinkBrowser/_JavaScriptModules.php
@@ -2,6 +2,7 @@
 
 return [
     'dependencies' => ['backend'],
+    'tags' => ['backend.form'],
     'imports' => [
         '@t3docs/examples/' => 'EXT:examples/Resources/Public/JavaScript/',
     ],


### PR DESCRIPTION
The Configuration/JavaScriptModules.php example was missing the backend.form tag, so the module's import map entry would not be available when the link browser is opened from a record that wasn't part of the initial page request, for example an inline child record. This causes "Unable to resolve specifier" errors in the browser console. Add the tag, per TYPO3 core's own Important-99490 changelog entry, and briefly explain why it's needed.

Resolves: #6019
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3, 13.4