### PR TITLE
[TASK] Remove stale "deployment guide in progress" banner

### DIFF
--- a/Documentation/Administration/Deployment/Index.rst
+++ b/Documentation/Administration/Deployment/Index.rst
@@ -21,14 +21,6 @@ However, for larger or more professional projects,
 `automated deployment <https://docs.typo3.org/permalink/t3coreapi:automated-deployment>`_
 using tools is highly recommended.
 
-..  attention::
-    We currently work on improving this section. We are very happy about any
-    Contribution. There is a project on GitHub:
-    `Project: TYPO3 Deployment Guide <https://github.com/orgs/TYPO3-Documentation/projects/26>`_
-    dedicated to improving the deployment information.
-
-    Please `Contribute to the TYPO3 documentation <https://docs.typo3.org/permalink/h2document:docs-official-workflow-methods>`_
-
 ..  _deployment-what-why:
 
 What is deployment and why do I need it?


### PR DESCRIPTION
The tracked GitHub project for improving the deployment section (https://github.com/orgs/TYPO3-Documentation/projects/26) is long since finished. The section now has a full guide (initial/incremental deployment, environment stages, tools, automated deployment), so the banner asking for contributions to an active effort is outdated.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3, 13.4