### PR TITLE
[BUGFIX] Point out that nonces require the nonce-proxy source keyword

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -687,6 +687,15 @@ as listed below, or use TypoScript only for passing DOM attributes
 and using external scripts to actually evaluate these attributes to control
 functionality.
 
+..  note::
+    Using a nonce in your HTML is not enough on its own — the relevant
+    policy directive (for example `script-src` or `style-src`) must also
+    allow the source keyword `nonce-proxy`, otherwise the nonce is never
+    added to the compiled `Content-Security-Policy` header and the browser
+    still blocks the content. See the `nonce-proxy` source in the
+    :ref:`extension-specific <content-security-policy-extension>` and
+    :ref:`site-specific <content-security-policy-site>` examples above.
+
 TYPO3 provides APIs to get the nonce for the current request:
 
 ..  _content-security-policy-nonce-retrieve-php:


### PR DESCRIPTION
The Nonce section thoroughly explains how to output a nonce attribute in HTML/PHP/Fluid, but never mentioned that the relevant directive (script-src, style-src, ...) must also allow the nonce-proxy source keyword, or the nonce is stripped when the policy is compiled and the browser still blocks the content. The keyword itself was already demonstrated in the extension-specific and site-specific examples, just without being called out in the surrounding prose.

Resolves: #6348
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
Releases: main, 14.3, 13.4