### PR TITLE
[BUGFIX] Fix links and references silently broken by missing role/underscore

### DIFF
--- a/Documentation/Administration/Installation/ClassicMode/ReleaseIntegrity.rst
+++ b/Documentation/Administration/Installation/ClassicMode/ReleaseIntegrity.rst
@@ -237,10 +237,10 @@ Public keys for release integrity checks
 
 ..  note::
     Starting in June 2017, TYPO3 releases have been cryptographically signed by the
-    `TYPO3 Release Team <typo3cms@typo3.org>` with a dedicated public key.
+    `TYPO3 Release Team <mailto:typo3cms@typo3.org>`_ with a dedicated public key.
     Since July 2017 releases are signed by individual members of the TYPO3
-    Release Team directly, namely `Benni Mack <benni@typo3.org>` and
-    `Oliver Hader <oliver@typo3.org>`.
+    Release Team directly, namely `Benni Mack <mailto:benni@typo3.org>`_ and
+    `Oliver Hader <mailto:oliver@typo3.org>`_.
 
 You can download the used public keys from `get.typo3.org.keys`_
 

--- a/Documentation/Administration/SystemSettings/ApplicationContext/Index.rst
+++ b/Documentation/Administration/SystemSettings/ApplicationContext/Index.rst
@@ -185,7 +185,7 @@ php.ini
 
 In `php.ini` there is the option of always loading a specific file first for
 each request. The property is
-`auto_prepend_file <https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file>`.
+`auto_prepend_file <https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file>`_.
 Enter the absolute path to a php file with the following content in your
 hosting package.
 

--- a/Documentation/Administration/Upgrade/ApplyingCorePatches/Index.rst
+++ b/Documentation/Administration/Upgrade/ApplyingCorePatches/Index.rst
@@ -260,7 +260,7 @@ First, install the package:
 
    composer req gilbertsoft/typo3-core-patches
 
-Then look up the change ID on `review.typo3.org <https://review.typo3.org/>`.
+Then look up the change ID on `review.typo3.org <https://review.typo3.org/>`_.
 You can find it in the URL or left of the title of the change. In the example
 it's `75368`.
 

--- a/Documentation/Administration/Upgrade/MigrateToComposer/Requirements.rst
+++ b/Documentation/Administration/Upgrade/MigrateToComposer/Requirements.rst
@@ -108,7 +108,7 @@ server about the changed web root folder if necessary. You do that by changing a
 `DocumentRoot` (Apache) or `root` (Nginx) configuration option. Most hosting
 providers offer a user interface to change the base directory of your project.
 
-For local development with `DDEV <https://ddev.com>`__ or `Docker <https://docker.com>`
+For local development with `DDEV <https://ddev.com>`__ or `Docker <https://docker.com>`_
 you will also need to adjust the corresponding configuration files.
 
 ..  _migratetocomposer-requirements-git-version-control:

--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
@@ -226,7 +226,7 @@ which allows four options:
     Require multi-factor authentication only for admin users
 
 To set this requirement only for a specific user or user group, a user TSconfig
-option `auth.mfa.required <t3tsref:user-auth-mfa-required>` is available.
+option `auth.mfa.required <https://docs.typo3.org/permalink/t3tsref:user-auth-mfa-required>`_ is available.
 The user TSconfig option overrules the global configuration.
 
 ..  code-block:: typoscript

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -442,7 +442,7 @@ The following configuration variables can be used to configure the TYPO3 backend
     :Default: false
 
     Don't use exec() function (except for ImageMagick which is disabled by
-    `[GFX][im]<typo3ConfVars_gfx_im>` =0). If set, all file operations are done
+    :ref:`[GFX][processor_enabled] <typo3ConfVars_gfx_processor_enabled>` = false). If set, all file operations are done
     by the default PHP functions. This is necessary under Windows! On Unix
     system commands using exec() can be used, unless this is disabled.
 

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -297,7 +297,7 @@ the TYPO3 frontend:
     :type: text
     :Default: ''
 
-    Same as `$TYPO3_CONF_VARS[SYS][cookieDomain]<_typo3ConfVars_sys_cookieDomain>`
+    Same as :ref:`$TYPO3_CONF_VARS[SYS][cookieDomain] <typo3ConfVars_sys_cookieDomain>`
     but only for FE cookies. If empty, :php:`$TYPO3_CONF_VARS[SYS][cookieDomain]`
     value will be used.
 
@@ -405,7 +405,7 @@ the TYPO3 frontend:
     only with plugins that dont use this parameter. However, using
     "&amp;no_cache=1" should be avoided anyway because there are better ways to
     disable caching for a certain part of the website
-    (see `COA_INT/USER_INT<t3tsref:cobj-coa-int>`).
+    (see `COA_INT/USER_INT <https://docs.typo3.org/permalink/t3tsref:cobj-coa-int>`_).
 
 ..  _typo3ConfVars_fe_additionalCanonicalizedUrlParameters:
 

--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -260,7 +260,7 @@ autoload
 (*required*)
 
 The autoload section defines the namespace/path mapping for
-`PSR-4 autoloading <https://www.php-fig.org/psr/psr-4/>`. In TYPO3 we follow
+`PSR-4 autoloading <https://www.php-fig.org/psr/psr-4/>`_. In TYPO3 we follow
 the convention that all classes (except test classes) are in the directory
 :file:`Classes/`.
 

--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Public/Index.rst
@@ -35,7 +35,7 @@ This can be achieved by applying proper access restrictions on the web server.
 See: :ref:`security-restrict-access-server-level`.
 
 By using the Composer package
-`helhum/typo3-secure-web <https://github.com/helhum/typo3-secure-web>` all
+:composer:`helhum/typo3-secure-web` all
 files except those that should be publicly available can be stored outside
 the servers web root.
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/Tutorials.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/Tutorials.rst
@@ -16,7 +16,7 @@ module is based on a regular TYPO3 installation. Extbase is not used.
 
 In this video dependency injection is achieved via `Constructor Promotion <https://www.php.net/manual/en/language.oop5.decon.php#language.oop5.decon.constructor.promotion>`__.
 
-Additionally `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>`
+Additionally `Named arguments <https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments>`_
 are used in the example.
 
 These features are available starting with PHP 8.0. With TYPO3 v11.5 it

--- a/Documentation/Testing/UnitTesting/Running.rst
+++ b/Documentation/Testing/UnitTesting/Running.rst
@@ -107,7 +107,7 @@ test class) you can use the filter option:
     php vendor/bin/phpunit -c Build/phpunit/UnitTests.xml --filter "MyTest"
 
 You can of course define a
-`Composer script <https://getcomposer.org/doc/articles/scripts.md>` as well, so that
+`Composer script <https://getcomposer.org/doc/articles/scripts.md>`_ as well, so that
 this command can be executed easily on the host, within a DDEV container and also in
 GitHub Actions or Gitlab CI.
 


### PR DESCRIPTION
Several inline hyperlinks and cross-references were written without the
role prefix (`:ref:`) or the trailing underscore RST requires to turn
`text <target>` into an actual link. Because this syntax is still
technically valid RST, phpDocumentor/guides renders it as plain
interpreted text instead of failing the build, so these silently
rendered as dead, unclickable text instead of a link.

Also update one reference to `[GFX][im]`, a setting renamed to
`processor_enabled` in TYPO3 8.0, and link `helhum/typo3-secure-web`
via the `:composer:` role instead of a raw GitHub URL.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf
Releases: main, 14.3, 13.4