### PR TITLE
Update _csp_reporting_false.yaml

### DIFF
--- a/Documentation/ApiOverview/ContentSecurityPolicy/_csp_reporting_false.yaml
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/_csp_reporting_false.yaml
@@ -1,4 +1,4 @@
-enforce:
+report:
   inheritDefault: true
   mutations: {}
   reportingUrl: false


### PR DESCRIPTION
The documentation mentions `enforce` and `report`, so just disabling the reporting should happen under the `report` key, otherwise the whole CSP of the site is diabled