### PR TITLE
[BUGFIX] Correct description of the date() example in base variants

### DIFF
--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -149,7 +149,7 @@ are available:
 ..  option:: date
 
     :type: string
-    :Example: checking the current month: `date("j") == 7`
+    :Example: checking the day of the month: `date("j") == 7`
 
     Get the current date in given format.
 


### PR DESCRIPTION
The `date` function example in [BaseVariants.rst](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/blob/main/Documentation/ApiOverview/SiteHandling/BaseVariants.rst) describes `date("j") == 7` as "checking the current month", but the PHP date format character `j` returns the day of the month. The description now matches the example. The month would be `n`; the example itself is kept as-is.

Spotted while reviewing #6651; the same text exists on `13.4` and `14.3`, so both backport labels apply.