### PR TITLE
[TASK] Bump PHP version examples to 8.5

### DIFF
--- a/Documentation/Administration/Docker/AutomateSetup/Index.rst
+++ b/Documentation/Administration/Docker/AutomateSetup/Index.rst
@@ -19,7 +19,7 @@ Docker environments.
     While this example uses a classic TYPO3 installation based on the
     `martinhelmich/typo3` image, the same approach can be adapted for
     Composer-based projects. To do so, use a different base image (e.g.
-    `php:8.4-apache`) and update the CLI path to match the Composer installation,
+    `php:8.5-apache`) and update the CLI path to match the Composer installation,
     typically `vendor/bin/typo3`.
 
 ..  contents:: Table of contents

--- a/Documentation/Administration/Installation/SystemRequirements/Index.rst
+++ b/Documentation/Administration/Installation/SystemRequirements/Index.rst
@@ -32,6 +32,10 @@ PHP requirements and configuration
 TYPO3 requires PHP with a supported version and specific configuration
 values and extensions.
 
+..  versionchanged:: 15.0
+    The minimum required PHP version was raised to PHP 8.5.
+    See `Breaking: #110211 - Raise minimum PHP version to 8.5 <https://docs.typo3.org/permalink/changelog:breaking-110211-1784210220>`_.
+
 ..  _system-requirements-php-configuration:
 
 Recommended PHP configuration settings
@@ -216,24 +220,24 @@ or NGINX using official base images.
 
 Recommended base images:
 
-* Apache: `php:8.4-apache`
-* NGINX: `nginx:stable` + `php:8.4-fpm`
+* Apache: `php:8.5-apache`
+* NGINX: `nginx:stable` + `php:8.5-fpm`
 
 Install required PHP extensions and set suitable PHP configuration.
 
 ..  tabs::
 
-    ..  tab:: Apache + PHP 8.4
+    ..  tab:: Apache + PHP 8.5
 
         ..  literalinclude:: _codesnippets/_Dockerfile-apache-php
             :language: dockerfile
-            :caption: Dockerfile for Apache with PHP 8.4
+            :caption: Dockerfile for Apache with PHP 8.5
 
-    ..  tab:: NGINX + PHP-FPM 8.4
+    ..  tab:: NGINX + PHP-FPM 8.5
 
         ..  literalinclude:: _codesnippets/_Dockerfile-fpm-php
             :language: dockerfile
-            :caption: Dockerfile for PHP 8.4 with FPM (for NGINX)
+            :caption: Dockerfile for PHP 8.5 with FPM (for NGINX)
 
         See :ref:`system-requirements-nginx` for NGINX configuration.
 
@@ -286,11 +290,11 @@ DDEV is a widely used and recommended solution for running TYPO3 projects
 locally. It provides a preconfigured Docker-based environment with TYPO3-
 compatible PHP, web server, and database services.
 
-To set up a TYPO3 project with PHP 8.4, run:
+To set up a TYPO3 project with PHP 8.5, run:
 
 ..  code-block:: bash
 
-    ddev config --php-version 8.4 --docroot public --project-type typo3
+    ddev config --php-version 8.5 --docroot public --project-type typo3
 
 This will generate the necessary configuration and allow you to start the
 project using:

--- a/Documentation/Administration/Installation/SystemRequirements/_codesnippets/_Dockerfile-apache-php
+++ b/Documentation/Administration/Installation/SystemRequirements/_codesnippets/_Dockerfile-apache-php
@@ -1,4 +1,4 @@
-FROM php:8.4-apache
+FROM php:8.5-apache
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite

--- a/Documentation/Administration/Installation/SystemRequirements/_codesnippets/_Dockerfile-fpm-php
+++ b/Documentation/Administration/Installation/SystemRequirements/_codesnippets/_Dockerfile-fpm-php
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm
+FROM php:8.5-fpm
 
 # Install required PHP extensions for TYPO3
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
TYPO3 v15 raises the minimum required PHP to 8.5. Update the Docker
and DDEV examples in the system requirements page accordingly, and
add a versionchanged note documenting the raised minimum.

v15-only change, not backported (14.3/13.4 target lower PHP).

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1801
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf
Releases: main