### PR TITLE
[TASK] Remove FlexFormService deprecation note

### DIFF
--- a/Documentation/ApiOverview/FlexForms/Reading/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Reading/Index.rst
@@ -41,13 +41,6 @@ value is not defined in the plugin.
 `FlexFormTools`: read FlexForms values in PHP
 =============================================
 
-..  deprecated:: 14.0
-    Class :php-short:`\TYPO3\CMS\Core\Service\FlexFormService` has been merged
-    into :php-short:`\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools`.
-
-    :php-short:`\TYPO3\CMS\Core\Service\FlexFormService` can be used with
-    an alias up until TYPO3 v15.
-
 You can use the :php:`\TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools` to read
 the content of a FlexForm field.
 


### PR DESCRIPTION
FlexFormService was merged into FlexFormTools in 14.0 and its
compatibility alias is now removed in 15.0. Drop the migration note
from the FlexForms reading page; nothing of it remains in the API.

v15-only change, not backported.

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1740
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf
Releases: main

