### PR TITLE
Correct MFA options count in documentation

### DIFF
--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
@@ -211,19 +211,13 @@ Enforcing MFA for users
 It seems reasonable to require MFA for specific users or user groups. This can
 be achieved with
 :ref:`$GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa'] <typo3ConfVars_be_requireMfa>`
-which allows four options:
+which allows five options:
 
-`0`
-    Do not require multi-factor authentication (default)
-
-`1`
-    Require multi-factor authentication for all users
-
-`2`
-    Require multi-factor authentication only for non-admin users
-
-`3`
-    Require multi-factor authentication only for admin users
+* `0`: Do not require multi-factor authentication (default)
+* `1`: Require multi-factor authentication for all users
+* `2`: Require multi-factor authentication only for non-admin users
+* `3`: Require multi-factor authentication only for admin users
+* `4`: Require multi-factor authentication only for system maintainers
 
 To set this requirement only for a specific user or user group, a user TSconfig
 option `auth.mfa.required <https://docs.typo3.org/permalink/t3tsref:user-auth-mfa-required>`_ is available.

--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
@@ -211,13 +211,22 @@ Enforcing MFA for users
 It seems reasonable to require MFA for specific users or user groups. This can
 be achieved with
 :ref:`$GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa'] <typo3ConfVars_be_requireMfa>`
-which allows the following options:
+which allows five options:
 
-* `0`: Do not require multi-factor authentication (default)
-* `1`: Require multi-factor authentication for all users
-* `2`: Require multi-factor authentication only for non-admin users
-* `3`: Require multi-factor authentication only for admin users
-* `4`: Require multi-factor authentication only for system maintainers
+`0`
+    Do not require multi-factor authentication (default)
+
+`1`
+    Require multi-factor authentication for all users
+
+`2`
+    Require multi-factor authentication only for non-admin users
+
+`3`
+    Require multi-factor authentication only for admin users
+
+`4`
+    Require multi-factor authentication only for system maintainers
 
 To set this requirement only for a specific user or user group, a user TSconfig
 option `auth.mfa.required <https://docs.typo3.org/permalink/t3tsref:user-auth-mfa-required>`_ is available.

--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
@@ -211,7 +211,7 @@ Enforcing MFA for users
 It seems reasonable to require MFA for specific users or user groups. This can
 be achieved with
 :ref:`$GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa'] <typo3ConfVars_be_requireMfa>`
-which allows five options:
+which allows the following options:
 
 * `0`: Do not require multi-factor authentication (default)
 * `1`: Require multi-factor authentication for all users


### PR DESCRIPTION
Updated the options for requiring multi-factor authentication (MFA) to include five options instead of four like on https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.1/Feature-93526-MultiFactorAuthentication.html