### PR TITLE
[TASK] Document main only/changelog label conventions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,11 @@ Makefile                    # local install/build/test commands
     LTS branches, skips this entirely), this repo has `main`, `14.3`,
     `13.4` (verify this is still current) — default to `main, 14.3`; add
     `13.4` only for a bugfix/security fix worth backporting that far, not
-    for plain content/style changes.
+    for plain content/style changes. If a PR gets no `backport <version>`
+    label, label it `main only` instead (mutually exclusive with
+    `backport <version>` — not both). Separately, label every PR that
+    addresses a `TYPO3-Documentation/Changelog-To-Doc` issue with
+    `changelog`, regardless of its backport status.
 
 ## References
 


### PR DESCRIPTION
Note when to label a PR main only vs. backport <version>, and that
changelog applies to any PR addressing a Changelog-To-Doc issue
regardless of backport status.

Releases: main
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf