### PR TITLE
[BUGFIX] Correct file upload validator options in Extbase docs

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Validation/BuiltIn.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Validation/BuiltIn.rst
@@ -358,6 +358,12 @@ No options beyond the optional `message` override.
 File upload validators
 ======================
 
+..  versionadded:: 13.3
+
+    See `Feature: #104526 - Provide validators for PSR-7 UploadedFile
+    objects in Extbase
+    <https://docs.typo3.org/permalink/changelog:feature-104526-1722603089>`_.
+
 The following validators are specifically designed for
 :php:`\TYPO3\CMS\Core\Http\UploadedFile` instances or
 :php-short:`\TYPO3\CMS\Extbase\Persistence\ObjectStorage` collections of uploaded
@@ -382,6 +388,13 @@ Class: :php:`\TYPO3\CMS\Extbase\Validation\Validator\FileExtensionValidator`
    * - `allowedExtensions`
      - Comma-separated list of allowed file extensions without the leading dot,
        for example `'jpg,jpeg,png'`.
+   * - `useStorageDefaults`
+     - If set to `true`, also allows the file extensions configured in
+       `$GLOBALS['TYPO3_CONF_VARS']['SYS']['textfile_ext']`,
+       `['mediafile_ext']` and `['miscfile_ext']`.
+
+At least one of ``allowedFileExtensions`` or ``useStorageDefaults`` must be
+set.
 
 
 ..  _extbase-validation-builtin-filesize:
@@ -425,6 +438,10 @@ Class: :php:`\TYPO3\CMS\Extbase\Validation\Validator\MimeTypeValidator`
    * - `allowedMimeTypes`
      - Array of allowed MIME type strings, for example
        `['image/jpeg', 'image/png']`.
+   * - `ignoreFileExtensionCheck`
+     - If set to `true`, disables the check that the file extension
+       matches the detected MIME type. Defaults to `false`. Be aware of
+       the security implications of setting this to `true`.
 
 
 ..  _extbase-validation-builtin-imagedimensions:
@@ -443,6 +460,10 @@ Class: :php:`\TYPO3\CMS\Extbase\Validation\Validator\ImageDimensionsValidator`
 
    * - Option
      - Description
+   * - `width`
+     - Exact required image width in pixels. Unset by default.
+   * - `height`
+     - Exact required image height in pixels. Unset by default.
    * - `minWidth`
      - Minimum image width in pixels.
    * - `maxWidth`
@@ -480,19 +501,23 @@ No configurable options.
 ----------
 
 Rejects uploaded files whose name matches dangerous executable extensions
-(such as `.php`, `.phar`, `.exe`). The default pattern is derived from
-TYPO3's `fileDenyPattern` configuration.
+(such as `.php`, `.phar`, `.exe`). It delegates to Core's
+:php:`\TYPO3\CMS\Core\Resource\Security\FileNameValidator`, which is
+driven by the global `fileDenyPattern` configuration and is not
+configurable per validator instance.
 
 Class: :php:`\TYPO3\CMS\Extbase\Validation\Validator\FileNameValidator`
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
+..  list-table::
+    :header-rows: 1
+    :widths: 25 75
 
-   * - Option
-     - Description
-   * - `regularExpression`
-     - A PCRE pattern the file name must match.
+    * - Option
+      - Description
+    * - `regularExpression`
+      - A PCRE pattern the file name must match.
+    * - `message`
+      - Error message to be shown if the validation fails.
 
 ..  important::
 


### PR DESCRIPTION
The File upload validators section documented an `allowedExtensions`
option for `FileExtensionValidator` that doesn't exist and omitted
`useStorageDefaults`; it was missing `ignoreFileExtensionCheck` for
`MimeTypeValidator` and the exact `width`/`height` options for
`ImageDimensionsValidator`; and it described `FileNameValidator` as
accepting a configurable `regularExpression` pattern, when it actually
delegates unconditionally to Core's `FileNameValidator` driven by the
global `fileDenyPattern`.

Verified against `.Build/vendor/typo3/cms-extbase`
`Classes/Validation/Validator/*` and added a `versionadded` note
linking Feature #104526, which introduced these validators in 13.3.

Not backported to 13.4: the Extbase Validation manual was rewritten for
14.3, so this fix doesn't apply to the pre-rewrite 13.4 content.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/984
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf