### PR TITLE
[TASK] Remove redundant :language: from literalinclude directives

### DIFF
--- a/Documentation/Administration/Deployment/EnvironmentStages/Configuration/Index.rst
+++ b/Documentation/Administration/Deployment/EnvironmentStages/Configuration/Index.rst
@@ -38,7 +38,6 @@ process. The best place for this is inside :file:`system/additional.php` (see
 :ref:`t3coreapi:configuration-files`). The PHP code for this could look like:
 
 ..  literalinclude:: _codesnippets/_additional.php
-    :language: php
     :caption: config/system/additional.php
 
 Each environment would have its own :file:`.env` file, which is only stored on
@@ -91,13 +90,11 @@ You can require these libraries through Packagist/Composer.
 Example for `symfony/dotenv`:
 
 ..  literalinclude:: _codesnippets/_dotenv-symfony.php
-    :language: php
     :caption: config/system/additional.php
 
 Example for `vlucas/phpdotenv`:
 
 ..  literalinclude:: _codesnippets/_dotenv-vlucas.php
-    :language: php
     :caption: config/system/additional.php
 
 Once this code has loaded the content from the :file:`.env` file into :php:`$_ENV`
@@ -137,14 +134,12 @@ will only be placed on your specific target server (and not be kept in your vers
 control system).
 
 ..  literalinclude:: _codesnippets/_environment.php
-    :language: php
     :caption: config/system/environment.php
 
 This file would also need to be loaded through the additional configuration
 workflow (which can be kept in your versioning control system):
 
 ..  literalinclude:: _codesnippets/_additional-native.php
-    :language: php
     :caption: config/system/additional.php
 
 Of course, you can move such a file to a special :file:`Shared/Data/` directory

--- a/Documentation/Administration/Docker/AutomateSetup/Index.rst
+++ b/Documentation/Administration/Docker/AutomateSetup/Index.rst
@@ -75,7 +75,6 @@ To automate setup, you must provide all required parameters via environment
 variables. Add these to the `web` service in your `docker-compose.yml`:
 
 ..  literalinclude:: _codesnippets/_docker-compose.yml
-    :language: yaml
     :caption: docker-compose.yml (excerpt)
 
 ..  warning::

--- a/Documentation/Administration/SystemSettings/ApplicationContext/Index.rst
+++ b/Documentation/Administration/SystemSettings/ApplicationContext/Index.rst
@@ -306,7 +306,6 @@ Here are a few examples of how to access the `ApplicationContext` with the
 :php:`Environment` class:
 
 ..  literalinclude:: _CodeSnippets/SunnyProducts.php
-    :language: php
     :caption: EXT:my_extension/Classes/ApplicationContext/SunnyProducts.php
 
 ..  _read-application-context-site-configuration:

--- a/Documentation/Administration/VersionControl/Index.rst
+++ b/Documentation/Administration/VersionControl/Index.rst
@@ -375,7 +375,6 @@ https://git-scm.com/docs/gitignore
 
         .. literalinclude:: _codesnippets/_GitIgnoreComposer.txt
             :caption: project_root/.gitignore
-            :language: plaintext
             :linenos:
 
         ..  seealso::
@@ -390,7 +389,6 @@ https://git-scm.com/docs/gitignore
 
         .. literalinclude:: _codesnippets/_GitIgnoreClassic.txt
             :caption: project_root/.gitignore
-            :language: plaintext
             :linenos:
 ..  note::
 

--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/Index.rst
@@ -292,7 +292,6 @@ third-party extension. The provider then has to be configured in the extension's
 tag.
 
 ..  literalinclude:: RegisterCustomProvider.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
@@ -311,13 +310,11 @@ If you do not want your provider to be selectable as a default provider, set the
 You can also completely deactivate existing providers with:
 
 ..  literalinclude:: DeactivateExistingProvider.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 You can also register multiple providers:
 
 ..  literalinclude:: RegisterMultipleProviders.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 The :php:`MfaProviderInterface` contains a lot of methods to be implemented by

--- a/Documentation/ApiOverview/Backend/Ajax.rst
+++ b/Documentation/ApiOverview/Backend/Ajax.rst
@@ -30,7 +30,6 @@ The controller needs not that much logic right now. We create a method called
 :php:`doSomethingAction()` which will be our Ajax endpoint.
 
 ..  literalinclude:: _Ajax/_ExampleController1.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
 In its current state, the method does nothing yet. We can add a very generic
@@ -38,7 +37,6 @@ handling that exponentiates an incoming number by 2. The incoming value will be
 passed as a query string argument named `input`.
 
 ..  literalinclude:: _Ajax/_ExampleController2.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
 ..  note::
@@ -50,7 +48,6 @@ We have computed our result by using the `exponentiation operator`_, but we
 do nothing with it yet. It is time to build a proper response:
 
 ..  literalinclude:: _Ajax/_ExampleController3.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/ExampleController.php
 
 
@@ -70,7 +67,6 @@ file will be exposed to JavaScript automatically. Let us register our endpoint
 now:
 
 ..  literalinclude:: _Ajax/_AjaxRoutes.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/AjaxRoutes.php
 
 The naming of the key `myextension_example_dosomething` and path
@@ -103,7 +99,6 @@ configure your endpoint to inherit access rights from this specific module by
 using the configuration option `inheritAccessFromModule`:
 
 ..  literalinclude:: _Ajax/_AjaxRoutesProtected.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/AjaxRoutes.php
 
 ..  _protect-ajax-endpoint-permission-checks-standalone:
@@ -133,7 +128,6 @@ example, we will ask the server to compute our input and write the result into
 the console.
 
 ..  literalinclude:: _Ajax/_Calculate.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/Calculate.js
 
 ..  seealso::

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/Index.rst
@@ -204,7 +204,6 @@ Module configuration options
         **Example**
 
         ..  literalinclude:: _ModuleConfiguration/_ModuleData.php
-            :language: php
             :caption: Excerpt of EXT:my_extension/Configuration/Backend/Modules.php
 
     ..  confval:: aliases
@@ -222,13 +221,11 @@ Module configuration options
         Example for a new module identifier:
 
         ..  literalinclude:: _ModuleConfiguration/_AliasModule.php
-            :language: php
             :caption: Excerpt of EXT:my_extension/Configuration/Backend/Modules.php
 
         Example for a route alias identifier:
 
         ..  literalinclude:: _ModuleConfiguration/_AliasIdentifier.php
-            :language: php
             :caption: Excerpt of EXT:my_extension/Configuration/Backend/Modules.php
 
     ..  confval:: routeOptions
@@ -264,7 +261,6 @@ Default module configuration options (without Extbase)
         controller/action pair and can restrict the allowed HTTP methods:
 
         ..  literalinclude:: _ModuleConfiguration/_Routes.php
-            :language: php
             :caption: Excerpt of EXT:my_extension/Configuration/Backend/Modules.php
 
         All subroutes are automatically registered in a
@@ -314,7 +310,6 @@ Extbase module configuration options
         can either be defined as array or comma-separated list:
 
         ..  literalinclude:: _ModuleConfiguration/_ControllerActions.php
-            :language: php
             :caption: Excerpt of EXT:my_extension/Configuration/Backend/Modules.php
 
         The modules define explicit routes for each controller/action combination,

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleTemplateFactory.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleTemplateFactory.rst
@@ -32,5 +32,4 @@ So it is useful to initialize the backend module template in a function commonly
 used by all actions:
 
 ..  literalinclude:: _BackendModuleController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/BackendModuleController.php

--- a/Documentation/ApiOverview/Backend/BackendRouting.rst
+++ b/Documentation/ApiOverview/Backend/BackendRouting.rst
@@ -21,7 +21,6 @@ Routes are defined inside extensions, in the files
 Here is an extract of :t3src:`backend/Configuration/Backend/Routes.php`:
 
 ..  literalinclude:: _BackendRouting/_RoutesBackend.php
-    :language: php
     :caption: EXT:backend/Configuration/Backend/Routes.php (excerpt)
 
 So, a route file essentially returns an array containing route mappings. A route
@@ -111,13 +110,11 @@ which are then resolved into a PSR-7 request attribute called
 These routes are defined within the route path as named placeholders:
 
 ..  literalinclude:: _BackendRouting/_RoutesMyRoute.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/Routes.php
 
 Within a controller (we use here a non-Extbase controller as example):
 
 ..  literalinclude:: _BackendRouting/_MyRouteController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyRouteController.php
 
 .. index:: Backend routing; Generating backend URLs
@@ -163,7 +160,6 @@ Via PHP
 Example within a controller (we use here a non-Extbase controller):
 
 ..  literalinclude:: _BackendRouting/_UriBuilderExample.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyRouteController.php
 
 ..  _backend-routing-sudo:

--- a/Documentation/ApiOverview/Backend/CustomPermissions.rst
+++ b/Documentation/ApiOverview/Backend/CustomPermissions.rst
@@ -26,7 +26,6 @@ Options are configured in the global variable
 the following example, which registers two custom permission options:
 
 ..  literalinclude:: _CustomPermissions/_ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 The result is that these options appear in the group access lists like

--- a/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/AjaxRequest/Index.rst
@@ -20,7 +20,6 @@ must be imported. To prepare a request, create a new instance of
 :js:`AjaxRequest` per request and pass the URL as the constructor argument:
 
 ..  literalinclude:: _MyRequest1.js
-    :language: js
     :caption: EXT:my_extension/Resources/Private/JavaScript/MyRequest.js
 
 The API offers a method :js:`withQueryArguments()` which allows to attach a query
@@ -31,7 +30,6 @@ possible to pass either strings, arrays or objects as an argument.
 Example:
 
 ..  literalinclude:: _MyRequest2.js
-    :language: js
     :caption: EXT:my_extension/Resources/Private/JavaScript/MyRequest.js
 
 The method detects whether the URL already contains a query string and appends
@@ -88,7 +86,6 @@ conversion will happen, but it is still recommended to set proper headers.
 Example:
 
 ..  literalinclude:: _MyRequestPromise1.js
-    :language: js
     :caption: EXT:my_extension/Resources/Private/JavaScript/MyRequest.js
 
 
@@ -103,7 +100,6 @@ In the examples above :js:`promise` is, as the name already spoils, a `Promise`_
 object. To fetch the actual response, we make use of :js:`then()`:
 
 ..  literalinclude:: _MyRequestPromise2.js
-    :language: js
     :caption: EXT:my_extension/Resources/Private/JavaScript/MyRequest.js
 
 :js:`response` is an object of type :js:`AjaxResponse` shipped by TYPO3
@@ -124,7 +120,6 @@ function may receive a :js:`AjaxResponse` object which contains the original
 response object.
 
 ..  literalinclude:: _MyRequestPromise3.js
-    :language: js
     :caption: EXT:my_extension/Resources/Private/JavaScript/MyRequest.js
 
 ..  hint::

--- a/Documentation/ApiOverview/Backend/JavaScript/ES6/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/ES6/Index.rst
@@ -34,14 +34,12 @@ A simple configuration example for an extension that maps
 the `Public/JavaScript` folder to an import prefix `@vendor/my-extensions`:
 
 ..  literalinclude:: _JavaScriptModulesSimple.php
-    :language: php
     :caption: EXT:my_extension/Configuration/JavaScriptModules.php
 
 Complex configuration example containing recursive-lookup exclusions,
 third-party library definitions and overwrites:
 
 ..  literalinclude:: _JavaScriptModulesExtended.php
-    :language: php
     :caption: EXT:my_extension/Configuration/JavaScriptModules.php
 
 .. _backend-javascript-es6-loading:
@@ -54,14 +52,12 @@ A module can be added to the current page response either via
 :php:`JavaScriptRenderer`:
 
 ..  literalinclude:: _PageRendererJavaScriptLoading.php
-    :language: php
     :caption: EXT:my_extension/Classes/SomeNamespace/SomeClass.php
 
 In a Fluid template the `includeJavaScriptModules` property of the
 :html:`<f:be.pageRenderer>` ViewHelper may be used:
 
 ..  literalinclude:: _BackendFluidTemplate.fluid.html
-    :language: html
     :caption: EXT:my_extension/Resources/Private/Backend/Templates/SomeTemplate.fluid.html
 
 ..  _backend-javascript-es6-tips-es6:
@@ -119,5 +115,4 @@ CKEditor is not part of the main record but needs to be loaded for
 the child record.
 
 ..  literalinclude:: _JavaScriptModulesBackendForm.php
-    :language: php
     :caption: EXT:my_extension/Configuration/JavaScriptModules.php

--- a/Documentation/ApiOverview/Backend/JavaScript/EventApi/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/EventApi/Index.rst
@@ -37,7 +37,6 @@ by using the method :js:`bindTo()`, which accepts any element, :js:`document` an
 Example:
 
 ..  literalinclude:: _DirectBinding.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 
@@ -52,7 +51,6 @@ inside its bound element.
 Example:
 
 ..  literalinclude:: _EventDelegation.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 The event listener is now called every time the element matching the selector
@@ -70,7 +68,6 @@ detach the event listener.
 Example:
 
 ..  literalinclude:: _ReleaseEvent.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 
@@ -97,7 +94,6 @@ Arguments:
 Example:
 
 ..  literalinclude:: _RegularEvent.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 
@@ -118,7 +114,6 @@ Arguments:
 Example:
 
 ..  literalinclude:: _DebounceEvent.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 
@@ -143,7 +138,6 @@ the event listener gets called up to 20 times in total (2000 / 100).
 Example:
 
 ..  literalinclude:: _ThrottleEvent.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js
 
 
@@ -164,5 +158,4 @@ Arguments:
 Example:
 
 ..  literalinclude:: _RequestAnimationFrameEvent.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/MyScript.js

--- a/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/HotkeyApi/Index.rst
@@ -84,5 +84,4 @@ Example
 =======
 
 ..  literalinclude:: _example.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/hotkey.js

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/Modals.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/Modals.rst
@@ -189,14 +189,12 @@ into the button.
 A modal with static backdrop:
 
 ..  literalinclude:: _Modals/_static_backdrop.js
-    :language: js
 
 Templates, using the HTML class :html:`.t3js-modal-trigger` to initialize
 a modal dialog are also able to use the new option by adding the
 :html:`data-static-backdrop` attribute to the corresponding element.
 
 ..  literalinclude:: _Modals/_StaticBackdrop.fluid.html
-    :language: html
 
 ..  _modules-modals-html-content:
 

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/MultiStepWizard.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/MultiStepWizard.rst
@@ -127,7 +127,6 @@ sheet. As it used :javascript:`SeverityEnum.warning` the title and buttons
 will be colored in yellow.
 
 ..  literalinclude:: _MultiStepWizard/_multi-step-wizard.js
-    :language: javascript
     :caption: EXT:my_extension/Resources/Public/JavaScript/HelloWorldModule.js
 
 To call the JavaScript from above you have to use the

--- a/Documentation/ApiOverview/Backend/JavaScript/Modules/SessionStorageWrapper.rst
+++ b/Documentation/ApiOverview/Backend/JavaScript/Modules/SessionStorageWrapper.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _SessionStorageWrapper/_storage.js
-    :language: js
 
 ..  _modules-sessionstorage-api-methods:
 

--- a/Documentation/ApiOverview/BitSets/Index.rst
+++ b/Documentation/ApiOverview/BitSets/Index.rst
@@ -20,16 +20,13 @@ recommend creating specific bitset classes that extend the TYPO3
 The functionality is best described by an example:
 
 ..  literalinclude:: _BitSet/_PlainExample.php
-    :language: php
 
 The example above uses global constants. Implementing that via an
 extended bitset class makes it clearer and easier to use:
 
 ..  literalinclude:: _BitSet/_Permissions.php
-    :language: php
     :caption: EXT:my_extension/Classes/Bitmask/Permissions.php
 
 Then use your custom bitset class:
 
 ..  literalinclude:: _BitSet/_PlainExample2.php
-    :language: php

--- a/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
@@ -322,7 +322,6 @@ caches.
 
 
 ..  literalinclude:: _redis.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
 

--- a/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Configuration/Index.rst
@@ -33,7 +33,6 @@ populate a new cache to the system. Without further configuration, the cache
 system falls back to the default backend and default frontend settings:
 
 ..  literalinclude:: _default.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Extensions, like :ref:`Extbase <extbase-extension-framework>`, define default caches this way,
@@ -46,7 +45,6 @@ is an example configuration to switch **pages** to the **Redis** backend using
 database 3:
 
 ..  literalinclude:: _redis.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
 Some backends have mandatory as well as optional parameters (which are
@@ -71,5 +69,4 @@ Example configuration to switch the *extbase_reflection* cache to use the
 **null** backend:
 
 ..  literalinclude:: _null.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php

--- a/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Developer/Index.rst
@@ -28,7 +28,6 @@ manager will choose the default
 :ref:`database backend <caching-backend-db>` by default.
 
 ..  literalinclude:: _init.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  tip::
@@ -55,7 +54,6 @@ in this case.
     them for whatever reason.
 
 ..  literalinclude:: _transient.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  _caching-developer-example:
@@ -69,7 +67,6 @@ in the :ref:`container service configuration
 <configure-dependency-injection-in-extensions>`:
 
 ..  literalinclude:: _Services.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions
@@ -83,7 +80,6 @@ sure they are unique and clearly hint at the purpose of your cache.
 Here is some example code which retrieves the cache via dependency injection:
 
 ..  literalinclude:: _MyClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 ..  tip::
@@ -98,7 +94,6 @@ service configuration <configure-dependency-injection-in-extensions>` needs to
 be extended:
 
 ..  literalinclude:: _Services_autowiring.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions

--- a/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/QuickStart/Index.rst
@@ -33,7 +33,6 @@ Example for a configuration of a
 instead of the default database backend with compression for the pages cache:
 
 ..  literalinclude:: _settings.php
-    :language: php
     :caption: config/system/settings.php | typo3conf/system/settings.php
 
 

--- a/Documentation/ApiOverview/CodeEditor/Index.rst
+++ b/Documentation/ApiOverview/CodeEditor/Index.rst
@@ -104,7 +104,6 @@ Register an addon
 To register an addon, the following code may be used:
 
 ..  literalinclude:: _register_addon.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/T3editor/Addons.php
 
 The following configuration options are available:
@@ -151,7 +150,6 @@ Register a mode
 To register a mode, the following code may be used:
 
 ..  literalinclude:: _register_mode.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/T3editor/Modes.php
 
 The following configuration options are available:

--- a/Documentation/ApiOverview/CommandControllers/Tutorial.rst
+++ b/Documentation/ApiOverview/CommandControllers/Tutorial.rst
@@ -28,7 +28,6 @@ Create a class called :php:`DoSomethingCommand` which extends
 :php:`\Symfony\Component\Console\Command\Command`.
 
 ..  literalinclude:: _Tutorial/_DoSomethingCommandViaAttribute.php
-    :language: php
     :caption: EXT:my_extension/Classes/Command/MyCommand.php
 
 The following two methods should be overridden by your class:

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -169,7 +169,6 @@ extension. Therefore we need to add the path to the
 :ref:`t3tsref:cobj-fluidtemplate-properties-templaterootpaths`:
 
 ..  literalinclude:: _AddingYourOwnContentElements/_setup.typoscript
-    :language: typoscript
     :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
 
 You can use any index (`200` in this example), just make sure it is unique.
@@ -178,7 +177,6 @@ If needed you can also add paths for partials and layouts.
 Now you can register the rendering of your custom content element:
 
 ..  literalinclude:: _AddingYourOwnContentElements/_setup_2.typoscript
-    :language: typoscript
     :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
 
 The :typoscript:`lib.contentElement` path is defined in file
@@ -310,7 +308,6 @@ The new field *tx_examples_separator* is added to the TCA definition of the tabl
 :file:`Configuration/TCA/Overrides/tt_content.php`:
 
 ..  literalinclude:: _AddingYourOwnContentElements/_tt_content_temporary_column.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/tt_content.php
 
 You can read more about defining fields via TCA in the :ref:`t3tca:start`.
@@ -325,7 +322,6 @@ called :sql:`tx_myextension_mytable`:
 
 
 ..  literalinclude:: _AddingYourOwnContentElements/_tt_content_reference.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/tt_content.php
 
 ..  _configure-ce-extend-tt-content-defining-field-tce:
@@ -340,7 +336,6 @@ id of the general storage folder. Then the examples extension will only use
 the content records from the given page id.
 
 ..  literalinclude:: _AddingYourOwnContentElements/_page-page-id.tsconfig
-    :language: typoscript
     :caption: EXT:my_extension/Configuration/page.tsconfig
 
 If more than one page id is allowed, this configuration must be used instead
@@ -348,7 +343,6 @@ If more than one page id is allowed, this configuration must be used instead
 instead of `###PAGE_TSCONFIG_ID###`):
 
 ..  literalinclude:: _AddingYourOwnContentElements/_page-page-id-list.tsconfig
-    :language: typoscript
     :caption: EXT:my_extension/Configuration/page.tsconfig
 
 ..  note::
@@ -379,7 +373,6 @@ Each processor has to be added with a fully qualified class name and optional
 parameters to be used in the data processor:
 
 ..  literalinclude:: _AddingYourOwnContentElements/_setup_myextension_newcontentcsv.typoscript
-    :language: typoscript
     :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
 
 You can now iterate over the variable `myTable` in the Fluid template, in this

--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -70,7 +70,6 @@ needs to be enabled, **or** the site-specific :file:`csp.yaml` configuration
 file needs to set the `enforce` or `report` disposition like this:
 
 ..  literalinclude:: _csp_enforce.yaml
-    :language: yaml
     :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
 
 Within the TYPO3 backend, a specific backend module is available to inspect policy
@@ -251,15 +250,12 @@ Resulting configuration example:
 And this is how you would do that with a CSP YAML configuration file, one per site:
 
 ..  literalinclude:: _csp_example_com.yaml
-    :language: yaml
     :caption: config/sites/example-com/csp.yaml | typo3conf/sites/example-com/csp.yaml
 
 ..  literalinclude:: _csp_example_org.yaml
-    :language: yaml
     :caption: config/sites/example-org/csp.yaml | typo3conf/sites/example-org/csp.yaml
 
 ..  literalinclude:: _ContentSecurityPolicies_example.php
-    :language: yaml
     :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
 
 This is really just a simple demo, that has room for improvements. For example,
@@ -378,7 +374,6 @@ In frontend, a dedicated :file:`sites/<my_site>/csp.yaml` can be
 used to declare policies for a specific site, for example:
 
 ..  literalinclude:: _csp.yaml
-    :language: yaml
     :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
 
 
@@ -391,7 +386,6 @@ The Content Security Policy for a particular site can be disabled with the
 :yaml:`active` key set to :yaml:`false`:
 
 ..  literalinclude:: _csp_active.yaml
-    :language: yaml
     :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
 
 
@@ -465,12 +459,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_append.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 12-15
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_append.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 27-31
 
@@ -492,12 +484,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_extend.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 7-10
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_extend.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 22-26
 
@@ -518,12 +508,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_inherit_again.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 8-9,21-22
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_inherit_again.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 23-26,37-40
 
@@ -547,12 +535,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_inherit_once.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 8-9,21-22
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_inherit_once.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 23-26,37-40
 
@@ -576,12 +562,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_reduce.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 9-12
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_reduce.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 24-28
 
@@ -601,12 +585,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_remove.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 12-13
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_remove.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 27-30
 
@@ -626,12 +608,10 @@ via the following modes:
         Example:
 
         ..  literalinclude:: _csp_mode_set.yaml
-            :language: yaml
             :caption: config/sites/<my_site>/csp.yaml | typo3conf/sites/<my_site>/csp.yaml
             :emphasize-lines: 2-5
 
         ..  literalinclude:: _ContentSecurityPolicies_mode_set.php
-            :language: php
             :caption: EXT:my_extension/Configuration/ContentSecurityPolicies.php
             :emphasize-lines: 16-20
 

--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -18,7 +18,6 @@ The :php:`\TYPO3\CMS\Core\Context\Context` object can be retrieved via
 :ref:`dependency injection <DependencyInjection>`:
 
 ..  literalinclude:: _MyController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 This information is separated in so-called
@@ -82,7 +81,6 @@ Example
 ~~~~~~~
 
 ..  literalinclude:: _MyControllerUsingDateAspect.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 
@@ -189,7 +187,6 @@ Example
 ~~~~~~~
 
 ..  literalinclude:: _MyControllerUsingLanguageAspect.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 
@@ -273,7 +270,6 @@ Example
 ~~~~~~~
 
 ..  literalinclude:: _MyControllerUsingUserAspect.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 
@@ -316,7 +312,6 @@ Example
 ~~~~~~~
 
 ..  literalinclude:: _MyControllerUsingVisibilityAspect.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 
@@ -358,5 +353,4 @@ Example
 ~~~~~~~
 
 ..  literalinclude:: _MyControllerUsingWorkspaceAspect.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php

--- a/Documentation/ApiOverview/Country/Index.rst
+++ b/Documentation/ApiOverview/Country/Index.rst
@@ -32,7 +32,6 @@ Using the PHP API
 :php:`\TYPO3\CMS\Core\Country\CountryProvider` class:
 
 ..  literalinclude:: _MyClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
@@ -106,7 +105,6 @@ A country object can be used to fetch all information about it, also with
 translatable labels:
 
 ..  literalinclude:: _MyClassWithTranslation.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClassWithTranslation.php
 
 

--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -48,7 +48,6 @@ Basic usage
 ===========
 
 ..  literalinclude:: _BasicUsage.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php
 
 After this initialization you usually want to perform the actual operations by
@@ -625,7 +624,6 @@ from within your :ref:`Extbase <extbase-extension-framework>` plugin (for exampl
 custom ViewHelper):
 
 ..  literalinclude:: _SomeController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/SomeController.php
 
 ..  _tce-clear-cache-hook-cache-post:
@@ -638,7 +636,6 @@ function. Configuration of the hook can be done from
 :file:`ext_localconf.php`. An example might look like:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 

--- a/Documentation/ApiOverview/DataHandler/UsingDataHandler/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/UsingDataHandler/Index.rst
@@ -81,7 +81,6 @@ Submitting data
 This is the most basic example of how to submit data into the database.
 
 ..  literalinclude:: _SubmitData.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php
 
 
@@ -93,7 +92,6 @@ Executing commands
 The most basic way of executing commands:
 
 ..  literalinclude:: _ExecuteCommands.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php
 
 
@@ -111,7 +109,6 @@ calling the :php:`start()` method (which will initialize internal state).
     "admin" or have :ref:`specific permissions <t3tsref:useroptions>` to do so.
 
 ..  literalinclude:: _ClearCache.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 Caches are organized in groups. Clearing "all" caches will actually clear caches
@@ -156,7 +153,6 @@ be updated at the earliest occasion possible. Finally, the cache for
 all pages is cleared.
 
 ..  literalinclude:: _SubmitComplexData.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php
 
 
@@ -177,7 +173,6 @@ should not set this argument since you want DataHandler to use the global
 :php:`$GLOBALS['BE_USER']`.
 
 ..  literalinclude:: _UseAlternativeUser.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php
 
 
@@ -192,5 +187,4 @@ In this property, the data handler collects all errors.
 You can use these, for example, for logging or other error handling.
 
 ..  literalinclude:: _ErrorHandling.php
-    :language: php
     :caption: EXT:my_extension/Classes/DataHandling/MyClass.php

--- a/Documentation/ApiOverview/Database/DoctrineDbal/Connection/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/Connection/Index.rst
@@ -73,7 +73,6 @@ Another way is to inject the :php:`Connection` object directly via
     the factory option in the service configuration:
 
     ..  literalinclude:: _Services.yaml
-        :language: yaml
         :caption: EXT:my_extension/Configuration/Services.yaml
         :emphasize-lines: 10-18
 
@@ -83,7 +82,6 @@ Another way is to inject the :php:`Connection` object directly via
     the constructor:
 
     ..  literalinclude:: _MyTableRepositoryWithConnection.php
-        :language: php
         :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 
@@ -140,7 +138,6 @@ The :php:`insert()` method creates and executes an :sql:`INSERT INTO` statement.
 Example:
 
 ..  literalinclude:: _MyTableRepository_insert.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -163,7 +160,6 @@ Arguments of the :php:`insert()` method:
     a string:
 
     ..  literalinclude:: _MyTableRepository_insert_types.php
-        :language: php
         :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
     Read :ref:`how to instantiate <database-connection-instantiation>` a
@@ -187,7 +183,6 @@ thrown.
 This method insert multiple rows at once:
 
 ..  literalinclude:: _MyTableRepository_bulkinsert.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -226,7 +221,6 @@ Create an :sql:`UPDATE` statement and execute it. The example from FAL's
 :php:`ResourceStorage` sets a storage to offline:
 
 ..  literalinclude:: _MyTableRepository_update.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 This method supports the native database field declaration :sql:`json`,
@@ -266,7 +260,6 @@ Execute a :sql:`DELETE` query using `equal` conditions in :sql:`WHERE`, example
 from :php:`BackendUtility`, to mark rows as no longer locked by a user:
 
 ..  literalinclude:: _MyTableRepository_delete.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -305,7 +298,6 @@ a :ref:`delete() <database-connection-delete>` of all rows. This typically
 resets "auto increment primary keys" to zero. Use with care:
 
 ..  literalinclude:: _MyCacheRepository_truncate.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -327,7 +319,6 @@ table :sql:`tx_myextension_mytable` whose
 field :sql:`some_value` field set to :php:`$something`:
 
 ..  literalinclude:: _MyTableRepository_count.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -375,7 +366,6 @@ conditions. Its usage is limited, the :ref:`restriction builder
 quoted:
 
 ..  literalinclude:: _MyTableRepository_select.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -423,7 +413,6 @@ This method returns the :sql:`uid` of the last :ref:`insert()
 directly afterwards:
 
 ..  literalinclude:: _MyTableRepository_lastinsertId.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -451,7 +440,6 @@ good example could be found in the Core.
 The method can also be useful in loops to save some precious code characters:
 
 ..  literalinclude:: _MyTableRepository_queryBuilder.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to instantiate <database-connection-instantiation>` a connection
@@ -483,7 +471,6 @@ Example:
     :caption: EXT:my_extension/ext_tables.sql
 
 ..  literalinclude:: _MyTableRepository_insert.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  note::

--- a/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/ExpressionBuilder/Index.rst
@@ -51,7 +51,6 @@ one argument.
 Example: finding :sql:`tt_content` records:
 
 ..  literalinclude:: _RepositoryWithJunctions.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
@@ -162,7 +161,6 @@ with field name), the second argument is an optional alias.
 Examples:
 
 ..  literalinclude:: _RepositoryAgregate.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
@@ -208,7 +206,6 @@ for SQLite and :sql:`CONCAT(field1, field2, field3, ...)` for other database ven
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryConcat.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-castInt:
@@ -227,7 +224,6 @@ except PostgreSQL. For PostgreSQL :sql:`"value"::INTEGER` cast notation
 is used.
 
 ..  literalinclude:: _RepositoryCastInt.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-castText:
@@ -247,7 +243,6 @@ or similar methods based on the database engine.
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryCastText.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-castVarchar:
@@ -268,7 +263,6 @@ where :sql:`"value"::INTEGER` cast notation is used.
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryCastVarChar.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 
@@ -354,7 +348,6 @@ more complex compatible replacement expression construct is created.
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryLeftPad.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 
@@ -369,7 +362,6 @@ The :php:`length()` string function can be used to return the length of a
 string in bytes.
 
 ..  literalinclude:: _RepositoryLength.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`
@@ -395,7 +387,6 @@ vendors except SQLite which uses
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryRepeat.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-right:
@@ -413,7 +404,6 @@ database vendors except SQLite, which uses :sql:`substring("value", start_of_str
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryRight.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 
@@ -433,7 +423,6 @@ more complex compatible replacement expression construct is created.
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositoryRightPad.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-space:
@@ -452,7 +441,6 @@ and SQLite.
 ..  include:: _EscapeWarning.rst.txt
 
 ..  literalinclude:: _RepositorySpace.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 ..  _database-expression-builder-trim:
@@ -466,7 +454,6 @@ Using the :php:`->trim()` expression ensures that fields are trimmed at the
 database level. The following examples give a better idea of what is possible:
 
 ..  literalinclude:: _RepositoryWithTrim.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyTableRepository.php
 
 Read :ref:`how to correctly instantiate <database-query-builder-instantiation>`

--- a/Documentation/ApiOverview/Database/DoctrineDbal/Middleware/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/Middleware/Index.rst
@@ -46,7 +46,6 @@ Global driver middlewares are applied to all
 Example:
 
 ..  literalinclude:: _ext_localconf_global.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 
@@ -58,7 +57,6 @@ Disable a global middleware for a specific connection
 Example:
 
 ..  literalinclude:: _ext_localconf_global_disable.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 
@@ -71,7 +69,6 @@ In this example, the custom driver middleware :php:`MyDriverMiddleware` is added
 to the `Default` connection:
 
 ..  literalinclude:: _ext_localconf_specific.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 
@@ -83,13 +80,11 @@ Migration
 For example:
 
 ..  literalinclude:: _ext_localconf_specific_deprecated.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 needs to be converted to:
 
 ..  literalinclude:: _ext_localconf_specific.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 ..  _database-middleware-specific-registration-v12-v13:
@@ -102,7 +97,6 @@ the :php:`Typo3Version` class to provide the configuration suitable for the Core
 version and avoiding the deprecation notice:
 
 ..  literalinclude:: _ext_localconf_specific_dual_versions.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 
@@ -165,7 +159,6 @@ structure for a middleware configuration is:
 Example:
 
 ..  literalinclude:: _ext_localconf_sorting.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php
 
 ..  tip::
@@ -217,18 +210,15 @@ Example
 The custom driver:
 
 ..  literalinclude:: _CustomDriver.php
-    :language: php
     :caption: EXT:my_extension/Classes/DoctrineDBAL/CustomDriver.php
 
 The custom driver middleware which implements the
 :php:`\TYPO3\CMS\Core\Database\Middleware\UsableForConnectionInterface`:
 
 ..  literalinclude:: _CustomMiddleware.php
-    :language: php
     :caption: EXT:my_extension/Classes/DoctrineDBAL/CustomMiddleware.php
 
 Register the custom driver middleware:
 
 ..  literalinclude:: _ext_localconf_CustomMiddleware.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php | config/system/additional.php

--- a/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/QueryBuilder/Index.rst
@@ -64,7 +64,6 @@ argument. The :ref:`ConnectionPool <database-connection-pool>` object can be
 injected via :ref:`dependency injection <DependencyInjection>`.
 
 ..  literalinclude:: _MyRepository.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyRepository.php
 
 ..  attention::

--- a/Documentation/ApiOverview/Database/DoctrineDbal/RestrictionBuilder/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/RestrictionBuilder/Index.rst
@@ -342,7 +342,6 @@ enforced, or even not applied at all, by returning an empty expression in certai
 To add a custom restriction class, use the following snippet:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  note::
@@ -359,7 +358,6 @@ Removing third party restrictions is possible, by setting the option
 or :file:`ext_localconf.php` of an extension:
 
 ..  literalinclude:: _ext_localconf_remove.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  _database-restriction-builder-examples:

--- a/Documentation/ApiOverview/DependencyInjection/Index.rst
+++ b/Documentation/ApiOverview/DependencyInjection/Index.rst
@@ -293,7 +293,6 @@ direct dependency of the controller service. A typical constructor dependency in
 to resolve the dependency by the framework looks like this:
 
 ..  literalinclude:: _ConstructorInjection.php
-    :language: php
     :caption: EXT:my_extension/Controller/UserController.php
 
 The symfony container setup process will now see :php:`UserRepository` as a dependency
@@ -313,7 +312,6 @@ Method injection
 A second way to get services injected is by using :php:`inject*()` methods:
 
 ..  literalinclude:: _MethodInjection.php
-    :language: php
     :caption: EXT:my_extension/Controller/UserController.php
 
 This ends up with basically the same result as above: The controller instance retrieves
@@ -328,7 +326,6 @@ since the instance is not set during :php:`__construct()`. But that's just an
 implementation detail. More important is an abstraction scenario. Consider this case:
 
 ..  literalinclude:: _MethodInjectionWithAbstract.php
-    :language: php
     :caption: EXT:my_extension/Controller/UserController.php
 
 We have an abstract controller service with a dependency plus a controller service that extends
@@ -367,7 +364,6 @@ Interface injection
 -------------------
 
 ..  literalinclude:: _InterfaceInjection.php
-    :language: php
     :caption: EXT:my_extension/Controller/UserController.php
 
 Notice the difference? The code requests the injection of an interface and not a class!
@@ -391,31 +387,24 @@ A :file:`Services.yaml` file configures different service implementation for
 some service consumers:
 
 ..  literalinclude:: _MyFirstController.php
-    :language: php
     :caption: EXT:my_extension/Controller/MyFirstController.php
 
 ..  literalinclude:: _MySecondController.php
-    :language: php
     :caption: EXT:my_extension/Controller/MySecondController.php
 
 ..  literalinclude:: _MyThirdController.php
-    :language: php
     :caption: EXT:my_extension/Controller/MyThirdController.php
 
 ..  literalinclude:: _MyServiceInterface.php
-    :language: php
     :caption: EXT:my_extension/Service/MyServiceInterface.php
 
 ..  literalinclude:: _MyDefaultServiceImplementation.php
-    :language: php
     :caption: EXT:my_extension/Service/MyDefaultServiceImplementation.php
 
 ..  literalinclude:: _MyOtherServiceImplementation.php
-    :language: php
     :caption: EXT:my_extension/Service/MyOtherServiceImplementation.php
 
 ..  literalinclude:: _ServicesYamlUsingInterfaceInjection.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 
@@ -441,7 +430,6 @@ A basic :file:`Services.yaml` file of an extension looks like the following.
     cache must be flushed, see :ref:`above <dependency-injection-caches>` for details.
 
 ..  literalinclude:: _ServicesYamlDefaults.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 
@@ -488,7 +476,6 @@ to be different than above declared defaults. This can be done using PHP attribu
 The most common use case is :php:`public: true`:
 
 ..  literalinclude:: _MyServiceUsingAutoconfigurePublicTrue.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceUsingAutoconfigurePublicTrue.php
 
 The above usage of the :php:`Autoconfigure` attribute declares this service as
@@ -498,7 +485,6 @@ The above usage of the :php:`Autoconfigure` attribute declares this service as
 Similar with :php:`shared: false`:
 
 ..  literalinclude:: _MyServiceUsingAutoconfigureSharedFalse.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceUsingAutoconfigureSharedFalse.php
 
 It is possible to set both using :php:`#[Autoconfigure(public: true, shared: false)]`.
@@ -519,7 +505,6 @@ via constructor or method injection, rather than
 the "foreign" service as "public" in :file:`Services.yaml`:
 
 ..  literalinclude:: _ServicesYamlDeclaringForeignServicePublicTrue.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 
@@ -541,13 +526,11 @@ naive approach is to inject the core :php:`CacheManager` and retrieve the
 runtime cache instance:
 
 ..  literalinclude:: _MyServiceUsingCacheManager.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceUsingCacheManager.php
 
 This can be simplified, resulting in more streamlined code:
 
 ..  literalinclude:: _MyServiceGettingRuntimeCacheInjected.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceGettingRuntimeCacheInjected.php
 
 The "cache.runtime" service alias, configured by the TYPO3 core extension,
@@ -559,7 +542,6 @@ of the results, which is useful for "compile-time" state that remains constant
 during requests. For example, to inject a feature toggle status:
 
 ..  literalinclude:: _MyServiceGettingFeatureToggleResultInjected.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceGettingFeatureToggleResultInjected.php
 
 Another example, including alias definition, is new in TYPO3 v13. It enables
@@ -567,11 +549,9 @@ injecting values from :file:`ext_conf_templates.txt` files using the
 :php:`ExtensionConfiguration` API.
 
 ..  literalinclude:: _CoreExtensionConfiguration.php
-    :language: php
     :caption: EXT:core/Configuration/ExtensionConfiguration.php
 
 ..  literalinclude:: _MyServiceGettingExtensionConfigurationValueInjected.php
-    :language: php
     :caption: EXT:my_extension/Services/MyServiceGettingExtensionConfigurationValueInjected.php
 
 This example demonstrates the combination of a service class with an alias and
@@ -613,14 +593,12 @@ files from extensions. The global files can provide defaults but can not overrid
 service definitions from service configuration files loaded afterwards.
 
 ..  literalinclude:: _ServicesYamlInstallationWide.yaml
-    :language: yaml
     :caption: config/system/services.yaml
 
 The concrete clock implementation is now injected when a type hint to the
 interface is given:
 
 ..  literalinclude:: _MyServiceUsingClockInterface.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyServiceUsingClockInterface.php
 
 

--- a/Documentation/ApiOverview/Deprecation/Index.rst
+++ b/Documentation/ApiOverview/Deprecation/Index.rst
@@ -75,7 +75,6 @@ Instead of using the :abbr:`GUI (Graphical User Interface)` you can also enable
 or disable the deprecation log with the :php:`disabled` option:
 
 ..  literalinclude:: _settings.php
-    :language: php
     :caption: Excerpt of config/system/settings.php | typo3conf/system/settings.php
 
 Deprecation logging can also be enabled in the :file:`additional.php`
@@ -83,7 +82,6 @@ configuration file, here with safeguarding to only enable it in
 development context:
 
 ..  literalinclude:: _additional.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
 For more information on how to configure the writing of deprecation logs see

--- a/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
+++ b/Documentation/ApiOverview/Events/EventDispatcher/Index.rst
@@ -54,7 +54,6 @@ If you just want to listen on an existing event, see section
     for all properties:
 
     ..  literalinclude:: _DoingThisAndThatEvent.php
-        :language: php
         :caption: EXT:my_extension/Classes/Event/DoingThisAndThatEvent.php
 
     Read more about :ref:`implementing event classes <EventDispatcherEvents>`.
@@ -67,7 +66,6 @@ If you just want to listen on an existing event, see section
     If the event dispatcher is not yet available, you need to inject it:
 
     ..  literalinclude:: _SomeClass.php
-        :language: php
         :caption: EXT:my_extension/Classes/SomeClass.php
 
 #.  Dispatch the event
@@ -76,7 +74,6 @@ If you just want to listen on an existing event, see section
     Use the data of mutable properties as it suits your business logic:
 
     ..  literalinclude:: _SomeClass2.php
-        :language: php
         :caption: EXT:my_extension/Classes/SomeClass.php
 
 ..  index:: ! PSR-14
@@ -217,7 +214,6 @@ An example listener, which hooks into the :ref:`Mailer API <mail>` to modify
 mailer settings to not send any emails, could look like this:
 
 ..  literalinclude:: _MailerEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MailerEventListener.php
 
 An extension can define multiple listeners. The attribute can be used on class
@@ -262,14 +258,12 @@ The PHP attribute is repeatable, which allows to register the same class
 to listen for different events, for example:
 
 ..  literalinclude:: _MailerEventListenerRepeatable.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MailerEventListener.php
 
 The PHP attribute can also be used on a method level. The above example can also
 be written as:
 
 ..  literalinclude:: _MailerEventListenerRepeatable2.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MailerEventListener.php
 
 
@@ -287,7 +281,6 @@ entry with the tag :yaml:`event.listener` can be added to the
 :file:`Configuration/Services.yaml` file of that extension.
 
 ..  literalinclude:: _ServicesWithMethod.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
@@ -311,7 +304,6 @@ If no attribute :yaml:`method` is given, the class is treated as invokable, thus
 its :php:`__invoke()` method will be called:
 
 ..  literalinclude:: _ServicesWithoutMethod.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
@@ -330,14 +322,12 @@ For example, a third-party extension listens on the event
 :php:`\TYPO3\CMS\Frontend\Event\ModifyHrefLangTagsEvent` via the PHP attribute:
 
 ..  literalinclude:: _ServicesOverrideBase.php
-    :language: php
     :caption: EXT:some_extension/Classes/EventListener/SeoEvent.php
     :emphasize-lines: 12
 
 or via :file:`Services.yaml` declaration:
 
 ..  literalinclude:: _ServicesOverrideBase.yaml
-    :language: yaml
     :caption: EXT:some_extension/Configuration/Services.yaml
     :emphasize-lines: 5
 
@@ -345,14 +335,12 @@ If you want to replace this event listener with your custom implementation, your
 achieve this by specifying the overridden identifier via the PHP attribute:
 
 ..  literalinclude:: _ServicesOverrideCustom.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Classes/EventListener/MySeoEvent.php
     :emphasize-lines: 12
 
 or via :file:`Services.yaml` declaration:
 
 ..  literalinclude:: _ServicesOverrideCustom.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
     :emphasize-lines: 6
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AddUserSettingsJavaScriptModulesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AddUserSettingsJavaScriptModulesEvent.rst
@@ -16,7 +16,6 @@ Example
 =======
 
 ..  literalinclude:: _AddUserSettingsJavaScriptModulesEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/UserSettings/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterBackendPageRenderEvent.rst
@@ -16,7 +16,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterBackendPageRenderEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-backend-page-render-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterFileStorageTreeItemsPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterFileStorageTreeItemsPreparedEvent.rst
@@ -55,7 +55,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterFileStorageTreeItemsPreparedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/ModifyFileStorageTreeItems.php
 
 ..  _AfterFileStorageTreeItemsPreparedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageContentPreviewRenderedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageContentPreviewRenderedEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterPageContentPreviewRenderedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _AfterPageContentPreviewRenderedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPagePreviewUriGeneratedEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterPagePreviewUriGeneratedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-page-preview-uri-generated-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
@@ -51,7 +51,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterPageTreeItemsPreparedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _AfterPageTreeItemsPreparedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterRawPageRowPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterRawPageRowPreparedEvent.rst
@@ -20,7 +20,6 @@ Example: sort pages by title in the page tree
 =============================================
 
 ..  literalinclude:: _AfterRawPageRowPreparedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _AfterRawPageRowPreparedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterRecordSummaryForLocalizationEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterRecordSummaryForLocalizationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-record-summary-for-localization-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendGroupFilterListIsAssembledEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendGroupFilterListIsAssembledEvent.rst
@@ -24,7 +24,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterBackendGroupFilterListIsAssembledEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-backend-group-filter-list-is-assembled-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendGroupListConstraintsAssembledFromDemandEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendGroupListConstraintsAssembledFromDemandEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterBackendGroupListConstraintsAssembledFromDemandEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-backend-group-list-constraints-assembled-from-demand-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendUserListConstraintsAssembledFromDemandEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterBackendUserListConstraintsAssembledFromDemandEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterBackendUserListConstraintsAssembledFromDemandEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-backend-user-list-constraints-assembled-from-demand-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterFilemountsListIsAssembledEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BackendUser/AfterFilemountsListIsAssembledEvent.rst
@@ -24,7 +24,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterFilemountsListIsAssembledEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _after-filemounts-list-is-assembled-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeBackendPageRenderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeBackendPageRenderEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeBackendPageRenderEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _BeforeBackendPageRenderEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeLiveSearchFormIsBuiltEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeLiveSearchFormIsBuiltEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeLiveSearchFormIsBuiltEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _BeforeLiveSearchFormIsBuiltEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeModuleCreationEvent.rst
@@ -17,7 +17,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeModuleCreationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _before-module-creation-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforePagePreviewUriGeneratedEvent.rst
@@ -26,7 +26,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforePagePreviewUriGeneratedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _before-page-preview-uri-generated-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/BeforeSearchInDatabaseRecordProviderEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeSearchInDatabaseRecordProviderEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/CustomFileSelectorsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/CustomFileSelectorsEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _CustomFileSelectorsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _custom-file-selectors-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsContentUsedOnPageLayoutEvent.rst
@@ -23,7 +23,6 @@ Example: display "Unused elements detected on this page" for elements with missi
 =========================================================================================
 
 ..  literalinclude:: _IsContentUsedOnPageLayoutEvent/_ContentUsedOnPage.php
-    :language: php
     :caption: EXT:my_extension/Classes/Listener/ContentUsedOnPage.php
 
 ..  _IsContentUsedOnPageLayoutEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/IsFileSelectableEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _IsFileSelectableEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _is-file-selectable-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyAllowedItemsEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyAllowedItemsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-allowed-items-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyButtonBarEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyButtonBarEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyButtonBarEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-button-bar-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyClearCacheActionsEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyClearCacheActionsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 The response returned by the AJAX endpoint should look like this:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyConstraintsForLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyConstraintsForLiveSearchEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyConstraintsForLiveSearchEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _ModifyConstraintsForLiveSearchEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForContentEvent.rst
@@ -16,7 +16,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyDatabaseQueryForContentEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-database-query-for-content-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyDatabaseQueryForRecordListingEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyDatabaseQueryForRecordListingEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-database-query-for-record-listing-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyEditFormUserAccessEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyEditFormUserAccessEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyGenericBackendMessagesEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyGenericBackendMessagesEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-generic-backend-messages-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyImageManipulationPreviewUrlEvent.rst
@@ -28,7 +28,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyImageManipulationPreviewUrlEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-image-manipulation-preview-url-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyInlineElementControlsEvent.rst
@@ -17,7 +17,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyInlineElementControlsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-inline-element-controls-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkExplanationEvent.rst
@@ -38,7 +38,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyLinkExplanationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-link-explanation-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyLinkHandlersEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyLinkHandlersEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyNewContentElementWizardItemsEvent.rst
@@ -22,7 +22,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyNewContentElementWizardItemsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-new-content-element-wizard-items-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyPageLayoutContentEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyPageLayoutContentEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-page-layout-content-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyQueryForLiveSearchEvent.rst
@@ -24,7 +24,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyQueryForLiveSearchEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyRecordListTableActionsEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyRecordListTableActionsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-record-list-table-actions-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/ModifyResultItemInLiveSearchEvent.rst
@@ -16,7 +16,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyResultItemInLiveSearchEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _modify-result-item-in-live-search-event-api:

--- a/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/PageContentPreviewRenderingEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _PageContentPreviewRenderingEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/EventListener/MyEventListener.php
 
 ..  _PageContentPreviewRenderingEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedInEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/AfterUserLoggedInEvent.rst
@@ -22,7 +22,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterUserLoggedInEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Authentication/EventListener/MyEventListener.php
 
 ..  _after-user-logged-in-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeRequestTokenProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/BeforeRequestTokenProcessedEvent.rst
@@ -22,7 +22,6 @@ the case when you are not using a login callback and have not the possibility
 to submit a request token:
 
 ..  literalinclude:: _BeforeRequestTokenProcessedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Authentication/EventListener/MyEventListener.php
 
 ..  _before-request-token-processed-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Authentication/LoginAttemptFailedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Authentication/LoginAttemptFailedEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _LoginAttemptFailedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Authentication/EventListener/MyEventListener.php
 
 ..  _login-attempt-failed-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterFlexFormDataStructureIdentifierInitializedEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterFlexFormDataStructureIdentifierInitializedEvent/_FlexFormParsingModifyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Configuration/EventListener/FlexFormParsingModifyEventListener.php
 
 ..  _after-flex-form-data-structure-identifier-initialized-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterRichtextConfigurationPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/AfterRichtextConfigurationPreparedEvent.rst
@@ -21,7 +21,6 @@ Example: enable debugging in the rich text editor
 The following event listener enables debugging in the rich text editor:
 
 ..  literalinclude:: _AfterRichtextConfigurationPreparedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Configuration/EventListener/EnableDebugRichTextEditorEventListener.php
 
 ..  _AfterRichtextConfigurationPreparedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeTcaOverridesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/BeforeTcaOverridesEvent.rst
@@ -32,7 +32,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeTcaOverridesEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Configuration/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/ModifyLoadedPageTsConfigEvent.rst
@@ -15,7 +15,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyLoadedPageTsConfigEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Configuration/EventListener/MyEventListener.php
 
 ..  _modify-loaded-page-ts-config-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Configuration/SiteConfigurationLoadedEvent.rst
@@ -27,7 +27,6 @@ is no need to :ref:`add an import manually <routing-examples-imports>` to the
 site configuration.
 
 ..  literalinclude:: _SiteConfigurationLoadedEvent/_ImportRoutesIntoSiteConfiguration.php
-    :language: php
     :caption: EXT:my_extension/Classes/Configuration/EventListener/ImportRoutesIntoSiteConfiguration.php
 
 For more sophisticated examples, see also

--- a/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Core/BootCompletedEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _BootCompletedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Bootstrap/EventListener/MyEventListener.php
 
 ..  _boot-completed-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/BeforePageIsRetrievedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/BeforePageIsRetrievedEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforePageIsRetrievedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Access/MyEventListener.php
 
 ..  _before-page-is-retrieved-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/BeforeRecordLanguageOverlayEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/BeforeRecordLanguageOverlayEvent.rst
@@ -24,7 +24,6 @@ be necessary if your site is configured with free mode, but you have a record
 type that has languages connected.
 
 ..  literalinclude:: _BeforeRecordLanguageOverlayEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Language/MyEventListener.php
 
 ..  _BeforeRecordLanguageOverlayEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Domain/RecordAccessGrantedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Domain/RecordAccessGrantedEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _RecordAccessGrantedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Access/MyEventListener.php
 
 ..  _record-access-granted-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Imaging/ModifyRecordOverlayIconIdentifierEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Imaging/ModifyRecordOverlayIconIdentifierEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyRecordOverlayIconIdentifierEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Core/EventListener/ModifyRecordOverlayIconIdentifierEventListener.php
 
 ..  _modify-record-overlay-icon-identifier-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/AfterLinkResolvedByStringRepresentationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/AfterLinkResolvedByStringRepresentationEvent.rst
@@ -29,7 +29,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterLinkResolvedByStringRepresentationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/LinkHandling/EventListener/MyEventListener.php
 
 ..  _after-link-resolved-by-string-representation-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/AfterTypoLinkDecodedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/AfterTypoLinkDecodedEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterTypoLinkDecodedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/LinkHandling/EventListener/MyEventListener.php
 
 ..  _after-typo-link-decoded-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/LinkHandling/BeforeTypoLinkEncodedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/LinkHandling/BeforeTypoLinkEncodedEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeTypoLinkEncodedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/LinkHandling/EventListener/MyEventListener.php
 
 ..  _before-typo-link-encoded-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerSentMessageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/AfterMailerSentMessageEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterMailerSentMessageEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Mail/EventListener/MyEventListener.php
 
 ..  _after-mailer-sent-message-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Mail/BeforeMailerSentMessageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Mail/BeforeMailerSentMessageEvent.rst
@@ -25,7 +25,6 @@ Example
 This event adds an additional BCC receiver right before the mail is sent:
 
 ..  literalinclude:: _BeforeMailerSentMessageEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Mail/EventListener/AddMailMessageBcc.php
 
 ..  _BeforeMailerSentMessageEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/AfterPackageActivationEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterPackageActivationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Package/EventListener/MyEventListener.php
 
 ..  _after-package-activation-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Package/PackageInitializationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Package/PackageInitializationEvent.rst
@@ -32,7 +32,6 @@ Example
 =======
 
 ..  literalinclude:: _PackageInitializationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Package/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/EnrichPasswordValidationContextDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/PasswordPolicy/EnrichPasswordValidationContextDataEvent.rst
@@ -33,7 +33,6 @@ Example
 =======
 
 ..  literalinclude:: _EnrichPasswordValidationContextDataEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _enrich-password-validation-context-data-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterDefaultUploadFolderWasResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterDefaultUploadFolderWasResolvedEvent.rst
@@ -17,7 +17,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterDefaultUploadFolderWasResolvedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/EventListener/MyEventListener.php
 
 ..  _after-default-upload-folder-was-resolved-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterFileCommandProcessedEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterFileCommandProcessedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/EventListener/MyEventListener.php
 
 ..  _after-file-command-processed-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/AfterVideoPreviewFetchedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/AfterVideoPreviewFetchedEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterVideoPreviewFetchedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/EventListener/MyEventListener.php
 
 ..  _after-video-preview-fetched-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/BeforeFileAddedEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeFileAddedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/EventListener/MyEventListener.php
 
 ..  _before-file-added-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Resource/ModifyFileDumpEvent.rst
@@ -24,7 +24,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyFileDumpEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/EventListener/MyEventListener.php
 
 ..  _modify-file-dump-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Security/BeforePersistingReportEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/BeforePersistingReportEvent.rst
@@ -22,7 +22,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforePersistingReportEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/ContentSecurityPolicy/EventListener/MyEventListener.php
 
 ..  _BeforePersistingReportEvent-example-api:

--- a/Documentation/ApiOverview/Events/Events/Core/Security/PolicyMutatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/Security/PolicyMutatedEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _PolicyMutatedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/ContentSecurityPolicy/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/AfterTemplatesHaveBeenDeterminedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/AfterTemplatesHaveBeenDeterminedEvent.rst
@@ -26,7 +26,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterTemplatesHaveBeenDeterminedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/TypoScript/EventListener/MyEventListener.php
 
 ..  _after-templates-have-been-determined-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/BeforeLoadedPageTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/BeforeLoadedPageTsConfigEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeLoadedPageTsConfigEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/TypoScript/EventListener/MyEventListener.php
 
 ..  _before-loaded-page-ts-config-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/BeforeLoadedUserTsConfigEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/BeforeLoadedUserTsConfigEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeLoadedUserTsConfigEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/TypoScript/EventListener/MyEventListener.php
 
 ..  _before-loaded-user-ts-config-event-api:

--- a/Documentation/ApiOverview/Events/Events/Core/TypoScript/EvaluateModifierFunctionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Core/TypoScript/EvaluateModifierFunctionEvent.rst
@@ -27,7 +27,6 @@ A simple TypoScript example looks like this:
 The corresponding event listener class could look like this:
 
 ..  literalinclude:: _EvaluateModifierFunctionEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/TypoScript/EventListener/MyEventListener.php
 
 ..  _evaluate-modifier-function-event-api:

--- a/Documentation/ApiOverview/Events/Events/Extbase/Configuration/BeforeFlexFormConfigurationOverrideEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Configuration/BeforeFlexFormConfigurationOverrideEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeFlexFormConfigurationOverrideEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Extbase/EventListener/MyEventListener.php
 
 ..  _before-flex-form-configuration-override-event-api:

--- a/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyQueryBeforeFetchingObjectDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Extbase/Persistence/ModifyQueryBeforeFetchingObjectDataEvent.rst
@@ -21,7 +21,6 @@ repository and model classes. By using an event listener, this setting is
 centralized and does not to be repeated in each repository class.
 
 ..  literalinclude:: _ModifyQueryBeforeFetchingObjectDataEvent/_DisableRespectStoragePage.php
-    :language: php
     :caption: EXT:my_extension/Classes/Extbase/EventListener/DisableRespectStoragePage.php
 
 ..  _modify-query-before-fetching-object-data-event-api:

--- a/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ModifyEditFileFormDataEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyEditFileFormDataEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/FileList/EventListener/MyEventListener.php
 
 ..  _modify-edit-file-form-data-event-api:

--- a/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Filelist/ProcessFileListActionsEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _ProcessFileListActionsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/FileList/EventListener/MyEventListener.php
 
 ..  _process-file-list-actions-event-api:

--- a/Documentation/ApiOverview/Events/Events/Fluid/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Fluid/ModifyInfoModuleContentEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyComponentDefinitionEvent/_ModifyComponentDefinitionListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/ModifyComponentDefinitionListener.php
 
 ..  _modify-component-definition-event-api:

--- a/Documentation/ApiOverview/Events/Events/Fluid/ProvideStaticVariablesToComponentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Fluid/ProvideStaticVariablesToComponentEvent.rst
@@ -30,7 +30,6 @@ Example
 =======
 
 ..  literalinclude:: _ProvideStaticVariablesToComponentEvent/_ProvideStaticVariablesToComponentListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/ProvideStaticVariablesToComponentListener.php
 
 ..  _provide-static-variables-to-component-event-api:

--- a/Documentation/ApiOverview/Events/Events/Fluid/RenderComponentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Fluid/RenderComponentEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _RenderComponentEvent/_RenderComponentListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/RenderComponentListener.php
 
 ..  _render-component-event-api:

--- a/Documentation/ApiOverview/Events/Events/Form/AfterCurrentPageIsResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Form/AfterCurrentPageIsResolvedEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterCurrentPageIsResolvedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
 
 ..  _AfterCurrentPageIsResolvedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Form/AfterLinkResolvedByStringRepresentationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Form/AfterLinkResolvedByStringRepresentationEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterFormDefinitionLoadedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/LinkHandling/EventListener/MyEventListener.php
 
 ..  _after-form-definition-loaded-event-api:

--- a/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsCreatedEvent.rst
@@ -28,7 +28,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeFormIsCreatedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
 
 ..  _BeforeFormIsCreatedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsDeletedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsDeletedEvent.rst
@@ -29,7 +29,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeFormIsDeletedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
 
 ..  _BeforeFormIsDeletedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsDuplicatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Form/BeforeFormIsDuplicatedEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeFormIsDuplicatedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListener/MyEventListener.php
 
 ..  _BeforeFormIsDuplicatedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCacheableContentIsGeneratedEvent.rst
@@ -31,7 +31,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterCacheableContentIsGeneratedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _AfterCacheableContentIsGeneratedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterCachedPageIsPersistedEvent.rst
@@ -16,7 +16,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterCachedPageIsPersistedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _AfterCachedPageIsPersistedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterContentHasBeenFetchedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterContentHasBeenFetchedEvent.rst
@@ -23,7 +23,6 @@ registration, removes some of the fetched page content elements based on
 specific field values.
 
 ..  literalinclude:: _AfterContentHasBeenFetchedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _AfterContentHasBeenFetchedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterContentObjectRendererInitializedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterContentObjectRendererInitializedEvent.rst
@@ -17,7 +17,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterContentObjectRendererInitializedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _after-content-object-renderer-initialized-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterGetDataResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterGetDataResolvedEvent.rst
@@ -17,7 +17,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterGetDataResolvedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _after-get-data-resolved-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterImageResourceResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterImageResourceResolvedEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterImageResourceResolvedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _after-image-resource-resolved-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/AfterLinkIsGeneratedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/AfterLinkIsGeneratedEvent.rst
@@ -34,7 +34,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterLinkIsGeneratedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _after-link-is-generated-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/BeforeDatabaseRecordLinkResolvedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/BeforeDatabaseRecordLinkResolvedEvent.rst
@@ -39,7 +39,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeDatabaseRecordLinkResolvedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _BeforeDatabaseRecordLinkResolvedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/BeforeStdWrapContentStoredInCacheEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/BeforeStdWrapContentStoredInCacheEvent.rst
@@ -22,7 +22,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeStdWrapContentStoredInCacheEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/EnhanceStdWrapEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/EnhanceStdWrapEvent.rst
@@ -29,7 +29,6 @@ Example
 =======
 
 ..  literalinclude:: _EnhanceStdWrapEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyCacheLifetimeForPageEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyCacheLifetimeForPageEvent.rst
@@ -18,7 +18,6 @@ The following listener limits the cache lifetime to 30 seconds in development
 context:
 
 ..  literalinclude:: _ModifyCacheLifetimeForPageEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _modify-cache-lifetime-for-page-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyHrefLangTagsEvent.rst
@@ -24,7 +24,6 @@ With :yaml:`after` and :yaml:`before`, you can make sure your own listener is
 executed after or before the given identifiers.
 
 ..  literalinclude:: _ModifyHrefLangTagsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyImageSourceCollectionEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyImageSourceCollectionEvent.rst
@@ -18,7 +18,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyImageSourceCollectionEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _modify-image-source-collection-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyPageLinkConfigurationEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyPageLinkConfigurationEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _modify-page-link-configuration-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/ModifyRecordsAfterFetchingContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ModifyRecordsAfterFetchingContentEvent.rst
@@ -19,7 +19,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyRecordsAfterFetchingContentEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _modify-records-after-fetching-content-event-api:

--- a/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Frontend/ShouldUseCachedPageDataIfAvailableEvent.rst
@@ -21,7 +21,6 @@ Example
 =======
 
 ..  literalinclude:: _ShouldUseCachedPageDataIfAvailableEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Frontend/EventListener/MyEventListener.php
 
 ..  _should-use-cached-page-data-if-available-event-api:

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/LogoutConfirmedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/LogoutConfirmedEvent.rst
@@ -28,7 +28,6 @@ event. We therefore need different logic to determine the user who just logged
 out. This logic is not part of the example below.
 
 ..  literalinclude:: _LogoutConfirmedEvent/_DeletePrivateKeyOnLogout.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListeners/DeletePrivateKeyOnLogout.php
 
 ..  _logout-confirmed-event-api:

--- a/Documentation/ApiOverview/Events/Events/FrontendLogin/ModifyRedirectUrlValidationResultEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/FrontendLogin/ModifyRedirectUrlValidationResultEvent.rst
@@ -25,7 +25,6 @@ Example: validate that the redirect after frontend login goes to a trusted domai
 =================================================================================
 
 ..  literalinclude:: _ModifyRedirectUrlValidationResultEvent/_ValidateRedirectUrl.php
-    :language: php
     :caption: EXT:my_extension/Classes/EventListeners/ValidateRedirectUrl.php
 
 ..  _modify-redirect-url-validation-result-event-api:

--- a/Documentation/ApiOverview/Events/Events/IndexedSearch/BeforeFinalSearchQueryIsExecutedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/IndexedSearch/BeforeFinalSearchQueryIsExecutedEvent.rst
@@ -28,7 +28,6 @@ Example
 Changing the host of the current request and setting it as canonical:
 
 ..  literalinclude:: _BeforeFinalSearchQueryIsExecutedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/IndexedSearch/EventListener/MyEventListener.php
 
 ..  _BeforeFinalSearchQueryIsExecutedEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Info/ModifyInfoModuleContentEvent.rst
@@ -38,7 +38,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyInfoModuleContentEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Info/EventListener/MyEventListener.php
 
 ..  _modify-info-module-content-event-api:

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/BeforeRecordIsAnalyzedEvent.rst
@@ -37,7 +37,6 @@ the method is called :php:`__invoke`:
 The listener must then be registered in the extensions :php:`Services.yaml`:
 
 ..  literalinclude:: _BeforeRecordIsAnalyzedEvent/_Services.yaml
-    :language: yaml
     :caption: EXT:examples/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.

--- a/Documentation/ApiOverview/Events/Events/Linkvalidator/ModifyValidatorTaskEmailEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Linkvalidator/ModifyValidatorTaskEmailEvent.rst
@@ -34,7 +34,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyValidatorTaskEmailEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Linkvalidator/EventListener/MyEventListener.php
 
 The :php:`\TYPO3\CMS\Linkvalidator\Result\LinkAnalyzerResult` contains the

--- a/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Lowlevel/ModifyBlindedConfigurationOptionsEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyBlindedConfigurationOptionsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Lowlevel/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Redirects/AfterAutoCreateRedirectHasBeenPersistedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/AfterAutoCreateRedirectHasBeenPersistedEvent.rst
@@ -25,7 +25,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterAutoCreateRedirectHasBeenPersistedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _after-auto-create-redirect-has-been-persisted-event-api:

--- a/Documentation/ApiOverview/Events/Events/Redirects/BeforeRedirectMatchDomainEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/BeforeRedirectMatchDomainEvent.rst
@@ -33,7 +33,6 @@ Example
 =======
 
 ..  literalinclude:: _BeforeRedirectMatchDomainEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _before-redirect-match-domain-event-api:

--- a/Documentation/ApiOverview/Events/Events/Redirects/ModifyAutoCreateRedirectRecordBeforePersistingEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/ModifyAutoCreateRedirectRecordBeforePersistingEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyAutoCreateRedirectRecordBeforePersistingEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _modify-auto-create-redirect-record-before-persisting-event-api:

--- a/Documentation/ApiOverview/Events/Events/Redirects/ModifyRedirectManagementControllerViewDataEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/ModifyRedirectManagementControllerViewDataEvent.rst
@@ -27,7 +27,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyRedirectManagementControllerViewDataEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _modify-redirect-management-controller-view-data-event-api:

--- a/Documentation/ApiOverview/Events/Events/Redirects/RedirectWasHitEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/RedirectWasHitEvent.rst
@@ -28,7 +28,6 @@ can either implement your own listener with the same identifier
 before and dynamically set the records :php:`disable_hitcount` flag.
 
 ..  literalinclude:: _RedirectWasHitEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _redirect-was-hit-event-api:

--- a/Documentation/ApiOverview/Events/Events/Redirects/SlugRedirectChangeItemCreatedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Redirects/SlugRedirectChangeItemCreatedEvent.rst
@@ -46,7 +46,6 @@ custom source type for the same task, and instead providing a custom event
 listener to build sources for non-zero page types.
 
 ..  literalinclude:: _SlugRedirectChangeItemCreatedEvent/_PageTypeSource/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 ..  _slug-redirect-change-item-created-event-examples-custom-source:
@@ -55,13 +54,11 @@ With a custom source implementation
 -----------------------------------
 
 ..  literalinclude:: _SlugRedirectChangeItemCreatedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/EventListener/MyEventListener.php
 
 Example of a :php:`CustomSource` implementation:
 
 ..  literalinclude:: _SlugRedirectChangeItemCreatedEvent/_CustomSource.php
-    :language: php
     :caption: EXT:my_extension/Classes/Redirects/CustomSource.php
 
 ..  _slug-redirect-change-item-created-event-default-event-listeners:
@@ -101,7 +98,6 @@ Remove plain slug source, if page type 0 differs
 ------------------------------------------------
 
 ..  literalinclude:: _SlugRedirectChangeItemCreatedEvent/_AddPageTypeZeroSource/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/MyEventListener.php
 
 ..  _slug-redirect-change-item-created-event-api:

--- a/Documentation/ApiOverview/Events/Events/SEO/ModifyUrlForCanonicalTagEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/SEO/ModifyUrlForCanonicalTagEvent.rst
@@ -35,7 +35,6 @@ Example
 Changing the host of the current request and setting it as canonical:
 
 ..  literalinclude:: _ModifyUrlForCanonicalTagEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Seo/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Events/Scheduler/ModifyNewSchedulerTaskWizardItemsEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Scheduler/ModifyNewSchedulerTaskWizardItemsEvent.rst
@@ -21,7 +21,6 @@ The following example adds an additional item to the scheduler task wizard,
 removes an existing item and modifies one.
 
 ..  literalinclude:: _ModifyNewSchedulerTaskWizardItemsEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Seo/EventListener/MyEventListener.php
 
 ..  _ModifyNewSchedulerTaskWizardItemsEvent-api:

--- a/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/AfterRecordPublishedEvent.rst
@@ -23,7 +23,6 @@ Example
 =======
 
 ..  literalinclude:: _AfterRecordPublishedEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Workspaces/EventListener/MyEventListener.php
 
 ..  _after-record-published-event-api:

--- a/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Workspaces/ModifyVersionDifferencesEvent.rst
@@ -20,7 +20,6 @@ Example
 =======
 
 ..  literalinclude:: _ModifyVersionDifferencesEvent/_MyEventListener.php
-    :language: php
     :caption: EXT:my_extension/Classes/Workspaces/EventListener/MyEventListener.php
 
 

--- a/Documentation/ApiOverview/Events/Hooks/Index.rst
+++ b/Documentation/ApiOverview/Events/Hooks/Index.rst
@@ -29,7 +29,6 @@ clear-cache post-processing. The objective of this could be to perform
 additional actions whenever the cache is cleared for a specific page:
 
 ..  literalinclude:: _ext_localconf_addhook.php
-    :language: php
     :caption: EXT:site_package/ext_localconf.php
 
 This hook registers the class/method name to a hook inside of
@@ -46,7 +45,6 @@ If we take a look inside of :code:`\TYPO3\CMS\Core\DataHandling\DataHandler` we
 find the hook to be activated like this:
 
 ..  literalinclude:: _DataHandler.php
-    :language: php
     :caption: :code:`\TYPO3\CMS\Core\DataHandling\DataHandler` (excerpt)
 
 This is how hooks are typically constructed. The main action happens in line 5
@@ -109,7 +107,6 @@ Using `\TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance()`
 Data submission to extensions:
 
 ..  literalinclude:: _SomeClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/SomeClass.php
 
 ..  _hooks-creation-function:
@@ -120,7 +117,6 @@ Using with `\TYPO3\CMS\Core\Utility\GeneralUtility::callUserFunction()`
 Constructor post-processing:
 
 ..  literalinclude:: _SomeClassPostProc.php
-    :language: php
     :caption: EXT:my_extension/Classes/SomeClass.php
 
 ..  index:: Hooks; Configuration
@@ -151,7 +147,6 @@ available to you will depend on a search in the documentation for that
 particular extension.
 
 ..  literalinclude:: _ext_localconf_schema.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 `<extension_key>`
@@ -190,7 +185,6 @@ which do not have a natural identifier like extensions have their
 extension keys.
 
 ..  literalinclude:: _ext_localconf_schema_core.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 `<main_key>`

--- a/Documentation/ApiOverview/Fal/Collections/Index.rst
+++ b/Documentation/ApiOverview/Fal/Collections/Index.rst
@@ -75,7 +75,6 @@ The following example demonstrates the usage of collections. Here is what
 happens in the controller:
 
 ..  literalinclude:: _MyController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/MyController.php
 
 All collections are fetched and passed
@@ -87,7 +86,6 @@ In the view we can then either use collection member variables as usual
 record selection:
 
 ..  literalinclude:: _List.fluid.html
-    :language: html
     :caption: EXT:my_extension/Resources/Private/Templates/List.fluid.html
 
 Here is what the result may look like (the exact result will obviously

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesCollection.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesCollection.rst
@@ -11,7 +11,6 @@ provides a convenience method to retrieve a
 :ref:`File Collection <fal-architecture-components-collections>`.
 
 ..  literalinclude:: _ExamplesCollection/_CollectionExample.php
-    :language: php
     :caption: EXT:my_extension/Classes/CollectionExample.php
 
 In this example, we retrieve and load the content from the
@@ -22,4 +21,3 @@ if the above code passed the :php:`$collection` variable to
 a :ref:`Fluid <fluid>` view, you could do the following:
 
 ..  literalinclude:: _ExamplesCollection/_Iteration.fluid.html
-    :language: html

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileFolder.rst
@@ -27,7 +27,6 @@ By uid
 A file can be retrieved using its uid:
 
 ..  literalinclude:: _ExamplesFileFolder/_GetFileByUid.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
@@ -37,7 +36,6 @@ By its combined identifier
 --------------------------
 
 ..  literalinclude:: _ExamplesFileFolder/_GetFileByCombinedIdentifier.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 The syntax of argument 1 for :php:`getFileObjectFromCombinedIdentifier()` is
@@ -69,7 +67,6 @@ By filename from its folder
 ---------------------------
 
 ..  literalinclude:: _ExamplesFileFolder/_GetFileByFilenameFromItsFolder.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
@@ -79,7 +76,6 @@ By its filename from the folder object
 --------------------------------------
 
 ..  literalinclude:: _ExamplesFileFolder/_GetFileByItsFilenameFromTheFolderObject.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
@@ -89,7 +85,6 @@ Copying a file
 ==============
 
 ..  literalinclude:: _ExamplesFileFolder/_CopyingFile.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 
@@ -100,7 +95,6 @@ Deleting a file
 ===============
 
 ..  literalinclude:: _ExamplesFileFolder/_DeletingFile.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 ..  _fal-using-fal-examples-file-folder-add-file:
@@ -112,7 +106,6 @@ This example adds a new file in the root folder of the default
 storage:
 
 ..  literalinclude:: _ExamplesFileFolder/_AddingFile.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 The default storage uses :file:`fileadmin/` unless this was configured
@@ -124,7 +117,6 @@ So, for this example, the resulting file path would typically be
 To store the file in a sub-folder use :php:`$storage->getFolder()`:
 
 ..  literalinclude:: _ExamplesFileFolder/_AddingFileToSubFolder.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 In this example, the file path would likely be
@@ -199,7 +191,6 @@ entry and the relation to the other item (in this case a :sql:`tt_content`
 record):
 
 ..  literalinclude:: _ExamplesFileFolder/_CreatingFileReference.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 The above example comes from the "examples" extension
@@ -248,7 +239,6 @@ to some other element, in this case the :sql:`media` field of the :sql:`pages`
 table:
 
 ..  literalinclude:: _ExamplesFileFolder/_GetReferencedFile.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 where :php:`$uid` is the ID of some page. The return value is an array
@@ -271,7 +261,6 @@ a folder object for some path in that storage (path relative to storage root),
 finally retrieve the files:
 
 ..  literalinclude:: _ExamplesFileFolder/_GetFilesInFolder.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 ..  _fal-using-fal-examples-file-folder-eid:

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileSearch.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesFileSearch.rst
@@ -21,7 +21,6 @@ Searching for files in a folder
 ===============================
 
 ..  literalinclude:: _ExamplesFileSearch/_SearchInFolder.php
-    :language: php
     :caption: EXT:my_extension/Classes/SearchInFolderExample.php
 
 
@@ -31,7 +30,6 @@ Searching for files in a storage
 ================================
 
 ..  literalinclude:: _ExamplesFileSearch/_SearchInStorage.php
-    :language: php
     :caption: EXT:my_extension/Classes/SearchInStorageExample.php
 
 ..  seealso::
@@ -49,7 +47,6 @@ restrictions to the :php:`FileSearchDemand`. Please note, that
 methods for ease of use:
 
 ..  literalinclude:: _ExamplesFileSearch/_SearchInStorageWithRestrictions.php
-    :language: php
     :caption: EXT:my_extension/Classes/SearchInStorageWithRestrictionsExample.php
 
 

--- a/Documentation/ApiOverview/Fal/UsingFal/ExamplesStorageRepository.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/ExamplesStorageRepository.rst
@@ -26,7 +26,6 @@ no storage has been explicitly chosen or defined (for example,
 when not using a :ref:`combined identifier <fal-architecture-components-files-folders>`).
 
 ..  literalinclude:: _ExamplesStorageRepository/_GetDefaultStorageExample.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/GetDefaultStorageExample.php
 
 
@@ -38,5 +37,4 @@ Getting any storage
 The :php:`StorageRepository` class should be used for retrieving any storage.
 
 ..  literalinclude:: _ExamplesStorageRepository/_GetStorageObjectExample.php
-    :language: php
     :caption: EXT:my_extension/Classes/Resource/GetStorageObjectExample.php

--- a/Documentation/ApiOverview/Fal/UsingFal/Tca.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/Tca.rst
@@ -13,7 +13,6 @@ The TCA field type :ref:`t3tca:columns-file` can be used to provide a field
 in which files can be referenced and/or uploaded:
 
 ..  literalinclude:: _Tca/_my_table.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/my_table.php
 
 The property :ref:`appearance <t3tca:columns-file-properties-appearance>` can be
@@ -23,7 +22,6 @@ should be displayed.
 Example:
 
 ..  literalinclude:: _Tca/_overrides_my_table.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/my_table.php
 
 This will suppress two buttons for upload and external URL and only leave

--- a/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
+++ b/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
@@ -189,7 +189,6 @@ Because the Gravatar ViewHelper creates an :html:`<img>` tag the use of the
 `$this->tag` is advised:
 
 ..  literalinclude:: _CustomViewHelper/_GravatarTagBasedViewHelper.php
-    :language: php
     :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php (Example 2, tag-based)
     :linenos:
 
@@ -311,7 +310,6 @@ available in the :php-short:`\TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelpe
 This returns the evaluated object between the opening and closing tag.
 
 ..  literalinclude:: _CustomViewHelper/_GravatarTagBasedViewHelper_getContentArgumentName.php
-    :language: php
     :caption: EXT:my_extension/Classes/ViewHelpers/GravatarViewHelper.php  (Example 3, with content arguments)
     :linenos:
 

--- a/Documentation/ApiOverview/FormEngine/DataCompiling/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/DataCompiling/Index.rst
@@ -173,7 +173,6 @@ from the extension "news" hooks in between these two to add some own preparation
 code in :file:`ext_localconf.php`:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:news/ext_localconf.php
 
 This is pretty powerful since it allows extensions to hook in additional stuff at any point of the processing chain, and
@@ -226,7 +225,6 @@ As an example, if editing a full database record, the default `TcaCheckboxItems`
 :php:`disabled` in the :php:`tcaDatabaseRecord` group in an extension's :file:`ext_localconf.php` file:
 
 ..  literalinclude:: _ext_localconf_disable.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Extension authors can then add an own data provider, which :php:`depends`

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -31,7 +31,6 @@ or JavaScript created by a sub-class is returned by the sub-class "up" again in 
 format.
 
 ..  literalinclude:: _SomeContainer.php
-    :language: php
     :caption: EXT:my_extension/Classes/Containers/SomeContainer.php
 
 Above example lets :php:`NodeFactory` find and compile some data from "subContainer", and merges the child result
@@ -80,7 +79,6 @@ to add for instance an own multi-language rendering of flex fields. It does that
 flex container with own implementation:
 
 ..  literalinclude:: _ext_localconf_flex.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 This re-routes the :php:`renderType` "flex" to an own class. If multiple registrations for a single renderType exist,
@@ -99,14 +97,12 @@ the one with highest priority wins.
 Adding a new renderType in :file:`ext_localconf.php`
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 And use it in TCA for a specific field, keeping the full database functionality in DataHandler together with the
 data preparation of FormDataCompiler, but just routing the rendering of that field to the new element:
 
 ..  literalinclude:: _tx_cooltagcloud.php
-    :language: php
     :caption: EXT:cool_tag_cloud/Configuration/TCA/overrides/tx_cooltagcloud.php
 
 The above examples are a static list of nodes that can be changed by settings in :file:`ext_localconf.php`. If that
@@ -120,7 +116,6 @@ editing in his user settings, then the resolvers return their own :php:`RichText
 field:
 
 ..  literalinclude:: _ext_localconf_rte.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 The trick here is that CKEditor registers his resolver with a higher priority (50) than "rtehtmlarea" (40), so the
@@ -181,13 +176,11 @@ function :php:`JavaScriptModuleInstruction::create()`.
 You can for example use it in a container:
 
 ..  literalinclude:: _SomeContainerJavaScript.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/SomeContainer.php
 
 Or a controller:
 
 ..  literalinclude:: _SomeController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/Controller/SomeController.php
 
 .. _FormEngine-Rendering-NodeExpansion:
@@ -224,7 +217,6 @@ Example. The :php:`InputTextElement` (standard input element) defines a couple o
 main result HTML:
 
 ..  literalinclude:: _InputTextElement.php
-    :language: php
     :caption: EXT:my_extension/Classes/Backend/Form/InputTextElement.php
 
 This element defines three wizards to be called by default. The :php:`renderType` concept is re-used, the
@@ -252,14 +244,12 @@ table to trigger a data import via Ajax.
 Add a new renderType in :file:`ext_localconf.php`:
 
 ..  literalinclude:: _ext_localconf_fieldcontrol.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Register the control in :file:`Configuration/TCA/Overrides/pages.php`:
 
 
 ..  literalinclude:: _pages.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
 
 ..  note::
@@ -269,7 +259,6 @@ Add the PHP class for rendering the control in
 :file:`Classes/FormEngine/FieldControl/ImportDataControl.php`:
 
 ..  literalinclude:: _ImportDataControl.php
-    :language: php
     :caption: EXT:my_extension/Classes/FormEngine/FieldControl/ImportDataControl.php
 
 ..  todo: switch from RequireJS to ES6
@@ -283,19 +272,16 @@ Add the JavaScript for defining the behavior of the control in
 :file:`Resources/Public/JavaScript/ImportData.js`:
 
 ..  literalinclude:: _ImportData.js
-    :language: js
     :caption: EXT:my_extension/Resources/Public/JavaScript/ImportData.js
 
 Add an Ajax route for the request in
 :file:`Configuration/Backend/AjaxRoutes.php`:
 
 ..  literalinclude:: _AjaxRoutes.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/AjaxRoutes.php
 
 Add the Ajax controller class in
 :file:`Classes/Controller/Ajax/ImportDataController.php`:
 
 ..  literalinclude:: _ImportDataController.php
-    :language: php
     :caption: EXT:my_extension/Classes/Controller/Ajax/ImportDataController.php

--- a/Documentation/ApiOverview/Icon/Index.rst
+++ b/Documentation/ApiOverview/Icon/Index.rst
@@ -34,7 +34,6 @@ To register icons for your own extension, create a file called
 The file needs to return a PHP configuration array with the following keys:
 
 ..  literalinclude:: _Icons.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Icons.php
 
 ..  _icon-registration-minimal-svg-sprite:

--- a/Documentation/ApiOverview/LinkHandling/LinkBuilder.rst
+++ b/Documentation/ApiOverview/LinkHandling/LinkBuilder.rst
@@ -25,7 +25,6 @@ Register a custom link builder in your extension's
 :ref:`ext-localconf-php`:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 The link builders provided by the Core can be found in namespace

--- a/Documentation/ApiOverview/Localization/ManagingTranslations.rst
+++ b/Documentation/ApiOverview/Localization/ManagingTranslations.rst
@@ -114,7 +114,6 @@ allows overriding XLIFF files. This applies to both translations and default
 (language = English) files.
 
 ..  literalinclude:: _snippets/_ext_localconf.php
-    :language: php
     :caption: EXT:examples/ext_localconf.php
 
 The German language file could look like this:

--- a/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/MassApproval.rst
+++ b/Documentation/ApiOverview/Localization/TranslationServer/Crowdin/MassApproval.rst
@@ -71,7 +71,6 @@ The following script demonstrates mass approval using the Crowdin API v2:
 
 ..  literalinclude:: _codesnippets/crowdin_mass_approve.php
     :caption: crowdin_mass_approve.php
-    :language: php
 
 ..  _crowdin-mass-approval-implementation-usage:
 

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -21,7 +21,6 @@ Instantiation
 automatically instantiate the logger:
 
 ..  literalinclude:: _MyClassLoggerInjection.php
-    :language: php
     :caption: EXT:my_extension/Classes/Service/MyClass.php
 
 ..  tip::
@@ -215,14 +214,12 @@ dependency injection services as a class attribute.
 Registration via class attribute for :php:`\Psr\Log\LoggerInterface` injection:
 
 ..  literalinclude:: _MyClassChannel.php
-    :language: php
     :caption: EXT:my_extension/Classes/Service/MyClass.php
 
 Registration via parameter attribute for :php:`\Psr\Log\LoggerInterface`
 injection, overwrites possible class attributes:
 
 ..  literalinclude:: _MyClassChannel2.php
-    :language: php
     :caption: EXT:my_extension/Classes/Service/MyClass.php
 
 The instantiated logger will now have the channel "security",

--- a/Documentation/ApiOverview/Logging/Quickstart/Index.rst
+++ b/Documentation/ApiOverview/Logging/Quickstart/Index.rst
@@ -20,7 +20,6 @@ Instantiate a logger for the current class
 automatically instantiate the logger:
 
 ..  literalinclude:: _MyClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 

--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -92,7 +92,6 @@ The corresponding configuration might look like this for the example class
 :php:`\T3docs\Examples\Controller`:
 
 ..  literalinclude:: _ext_localconf_FileWriter.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 
@@ -162,13 +161,11 @@ accepts all options of :php:`FileWriter` in addition of the following:
 The following example introduces log rotation for the "main" log file:
 
 ..  literalinclude:: _additionalRotationFileWriter.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
 Another example introduces log rotation for the "deprecation" log file:
 
 ..  literalinclude:: _additionalRotationFileWriterForDeprecations.php
-    :language: php
     :caption: config/system/additional.php | typo3conf/system/additional.php
 
 
@@ -241,7 +238,6 @@ One or more log writers for this class are configured in the file
 :file:`ext_localconf.php`:
 
 ..  literalinclude:: _ext_localconf_FileWriter_config.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  _logging-writers-examples:

--- a/Documentation/ApiOverview/MessageBus/Index.rst
+++ b/Documentation/ApiOverview/MessageBus/Index.rst
@@ -76,7 +76,6 @@ A :file:`Services.yaml` entry is needed to use :yaml:`before`/:yaml:`after`
 for registration if you need to define an order:
 
 ..  literalinclude:: _demo-handler.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 ..  _message-bus-routing:
@@ -212,7 +211,6 @@ name used in the settings is resolved to a service that has been tagged with
     ];
 
 ..  literalinclude:: _custom-transport.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml | config/system/services.yaml
 
 The TYPO3 Core has been tested with three transports:
@@ -244,7 +242,6 @@ Use the following configuration to limit the process of messages to
 max. 100 each 60 seconds:
 
 ..  literalinclude:: _add-rate-limiter.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml | config/system/services.yaml
 
 ..  hint::
@@ -260,7 +257,6 @@ The :php:`InMemoryTransport` is a transport that should only be used while
 testing.
 
 ..  literalinclude:: _in-memory-transport.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml | config/system/services.yaml
 
 
@@ -279,7 +275,6 @@ To add your own middleware, tag it as :yaml:`messenger.middleware` and set the
 order using TYPO3's :yaml:`before` and :yaml:`after` ordering mechanism:
 
 ..  literalinclude:: _custom-middleware.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml | config/system/services.yaml
 
 

--- a/Documentation/ApiOverview/Namespaces/Index.rst
+++ b/Documentation/ApiOverview/Namespaces/Index.rst
@@ -117,13 +117,11 @@ extension key is used.
 For a backend module:
 
 ..  literalinclude:: _Modules.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Backend/Modules.php
 
 For a frontend module:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 .. index:: pair: Namespaces; Tests

--- a/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
+++ b/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
@@ -59,7 +59,6 @@ identifier in the `typeicon_classes` array. This identifier must be registered
 later in the Icon API.
 
 ..  literalinclude:: _pages.php
-    :language: php
     :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
 
 ..  _page-types-example-register-icon:
@@ -71,7 +70,6 @@ The identifier used in the TCA (`tx-examples-archive-page`) must be
 registered in :file:`Configuration/Icons.php` to link it to an SVG file.
 
 ..  literalinclude:: _Icons.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Icons.php
 
 You can also provide icons for special states by registering additional

--- a/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.rst
+++ b/Documentation/ApiOverview/RequestLifeCycle/RequestAttributes/FrontendCacheInstruction.rst
@@ -21,7 +21,6 @@ the attribute may or may not exist already. A safe way to interact with it is
 like this:
 
 ..  literalinclude:: _FrontendCacheInstruction/_MyEarlyMiddleware.php
-    :language: php
     :caption: EXT:my_extension/Classes/Middleware/MyEarlyMiddleware.php
 
 Extension with middlewares or other code after
@@ -29,7 +28,6 @@ Extension with middlewares or other code after
 be set already. Usage example:
 
 ..  literalinclude:: _FrontendCacheInstruction/_MyLaterMiddleware.php
-    :language: php
     :caption: EXT:my_extension/Classes/Middleware/MyLaterMiddleware.php
 
 

--- a/Documentation/ApiOverview/Routing/Extending/Index.rst
+++ b/Documentation/ApiOverview/Routing/Extending/Index.rst
@@ -47,7 +47,6 @@ After implementing the matching interface, your aspect needs to be
 registered in :file:`ext_localconf.php`:
 
 ..  literalinclude:: _codesnippets/_ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 It can now be used in the routing configuration as `type`. The example above
@@ -78,7 +77,6 @@ The interfaces contain methods you need to implement as well as a description of
 To register the enhancer, add the following to your `ext_localconf.php`:
 
 ..  literalinclude:: _codesnippets/_ext_localconf_custom_enhancer.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Now you can use your new enhancer in the routing configuration as `type`. The

--- a/Documentation/ApiOverview/Rte/InTheBackend/PlugRte.rst
+++ b/Documentation/ApiOverview/Rte/InTheBackend/PlugRte.rst
@@ -29,7 +29,6 @@ based on the implementation of ext:rte_ckeditor.
    than the Core's implementation:
 
     ..  literalinclude:: _ext_localconf.php
-        :language: php
         :caption: EXT:my_extension/ext_localconf.php
 
 -  Now create the class :php:`\MyVendor\MyExtension\Form\Resolver\RichTextNodeResolver`.
@@ -38,7 +37,6 @@ based on the implementation of ext:rte_ckeditor.
    are met, the RichTextElement class name is returned:
 
     ..  literalinclude:: _RichTextNodeResolver.php
-        :language: php
         :caption: :php:`\MyVendor\MyExtension\Form\Resolver\RichTextNodeResolver`
 
 -  Next step is to implement the RichtTextElement class. You can look up the

--- a/Documentation/ApiOverview/Seo/MetaTagApi.rst
+++ b/Documentation/ApiOverview/Seo/MetaTagApi.rst
@@ -64,7 +64,6 @@ This :php:`MetaTagManager` must implement :php:`\TYPO3\CMS\Core\MetaTag\MetaTagM
 To use the manager, you must register it in :php:`ext_localconf.php`:
 
 ..  literalinclude:: _MetaTagApi/_ext_localconf_register_manager.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Registering a :php:`MetaTagManager` works with the :php:`DependencyOrderingService`. So you can also specify the
@@ -73,7 +72,6 @@ want to implement your own :php:`OpenGraphMetaTagManager`, you can use the follo
 
 
 ..  literalinclude:: _MetaTagApi/_ext_localconf_register_manager_open_graph.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 This will result in :php:`MyOpenGraphMetaTagManager` having a higher priority and it will first check if your own

--- a/Documentation/ApiOverview/Seo/PageTitleApi.rst
+++ b/Documentation/ApiOverview/Seo/PageTitleApi.rst
@@ -117,7 +117,6 @@ Usage example in an :ref:`Extbase <extbase-extension-framework>` controller:
 Configure the new page title provider in your TypoScript setup:
 
 ..  literalinclude:: _PageTitleProvider/_ExampleSetInController/_setup.typoscript
-    :language: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
 ..  _page-title-provider-custom-site-config:
@@ -141,7 +140,6 @@ and PHP Cache`.
 Configure the new page title provider to be used in your TypoScript setup:
 
 ..  literalinclude:: _PageTitleProvider/_website.typoscript
-    :language: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
 The registered page title providers are called after each other in the

--- a/Documentation/ApiOverview/Services/Configuration/RegistrationChanges.rst
+++ b/Documentation/ApiOverview/Services/Configuration/RegistrationChanges.rst
@@ -13,7 +13,6 @@ overridden in any extension's :file:`ext_localconf.php` file. Example:
 
 
 ..  literalinclude:: _RegistrationChanges/_ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 The general syntax is:

--- a/Documentation/ApiOverview/Services/Developer/Implementing.rst
+++ b/Documentation/ApiOverview/Services/Developer/Implementing.rst
@@ -28,7 +28,6 @@ Registering a service is done inside the :file:`ext_localconf.php`
 file. Let's look at what is inside.
 
 ..  literalinclude:: _Implementing/_ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 A service is registered with TYPO3 CMS by calling

--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -38,7 +38,6 @@ behaviors for each language.
 Example of a language configuration (excerpt):
 
 ..  literalinclude:: _language-example.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 ..  index:: pair: Site handling; Languages properties

--- a/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
+++ b/Documentation/ApiOverview/SiteHandling/BaseVariants.rst
@@ -59,7 +59,6 @@ Example
 =======
 
 ..  literalinclude:: _base-variants.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
@@ -59,5 +59,4 @@ Example
 Show the content of a Fluid template in case of an error with HTTP status 404:
 
 ..  literalinclude:: _fluid-error-handler.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/PageErrorHandler.rst
@@ -61,7 +61,6 @@ Internal error page
 Show the internal page with uid `145` on all errors with HTML status code `404`.
 
 ..  literalinclude:: _page-error-handler-internal.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 ..  _sitehandling-error-handling-page-examples-external-error:
@@ -73,5 +72,4 @@ Shows an external page on all errors with a HTTP status code not defined
 otherwise.
 
 ..  literalinclude:: _page-error-handler-external.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/WriteCustomErrorHandler.rst
@@ -74,7 +74,6 @@ Example for a simple 404 error handler
 The configuration:
 
 ..  literalinclude:: _custom-error-handler.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 The error handler class:

--- a/Documentation/ApiOverview/SiteHandling/ExtendingSiteConfig.rst
+++ b/Documentation/ApiOverview/SiteHandling/ExtendingSiteConfig.rst
@@ -35,7 +35,6 @@ form are left alone and will not get overwritten when saved.
 Example:
 
 ..  literalinclude:: _extending-site-config.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 Access it via the API:

--- a/Documentation/ApiOverview/SiteHandling/SiteSets.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSets.rst
@@ -400,7 +400,6 @@ After the example site package is installed, you can include the site set
 in your site configuration:
 
 ..  literalinclude:: _Sets/_site-package/_site_config.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 ..  _site-sets-example-typoscript:

--- a/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
+++ b/Documentation/ApiOverview/SiteHandling/SiteSettings.rst
@@ -57,7 +57,6 @@ Adding site settings
 Add settings to the :file:`settings.yaml <set-settings-yaml>`:
 
 ..  literalinclude:: _site-settings.yaml
-    :language: yaml
     :caption: config/sites/<my_site>/settings.yaml | typo3conf/sites/<my_site>/settings.yaml
 
 ..  note::

--- a/Documentation/ApiOverview/SiteHandling/StaticRoutes.rst
+++ b/Documentation/ApiOverview/SiteHandling/StaticRoutes.rst
@@ -44,7 +44,6 @@ suitable for files like :file:`robots.txt` or :file:`humans.txt`.
 A configuration example:
 
 ..  literalinclude:: _static-routes-static-text.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 
@@ -66,7 +65,6 @@ resources which are typically located in the directory
 A configuration example:
 
 ..  literalinclude:: _static-routes-assets.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml
 
 This enables you to reach the files at :samp:`https://example.org/example.svg`
@@ -88,5 +86,4 @@ content delivered.
 A configuration example:
 
 ..  literalinclude:: _static-routes-uri.yaml
-    :language: yaml
     :caption: config/sites/<some_site>/config.yaml | typo3conf/sites/<some_site>/config.yaml

--- a/Documentation/ApiOverview/SiteHandling/UseSiteInConditions.rst
+++ b/Documentation/ApiOverview/SiteHandling/UseSiteInConditions.rst
@@ -72,4 +72,3 @@ Example for EXT:form
 Translate options via :yaml:`siteLanguage` condition:
 
 ..  literalinclude:: _form-condition.yaml
-    :language: yaml

--- a/Documentation/ApiOverview/SoftReferences/Index.rst
+++ b/Documentation/ApiOverview/SoftReferences/Index.rst
@@ -86,7 +86,6 @@ url
 The default setup is found in :t3src:`core/Configuration/Services.yaml`:
 
 ..  literalinclude:: _Services.yaml
-    :language: yaml
     :caption: Excerpt from EXT:core/Configuration/Services.yaml
 
 ..  _soft-references-examples:
@@ -98,7 +97,6 @@ For the :sql:`tt_content.bodytext` field of type text from the example
 above, the configuration looks like this:
 
 ..  literalinclude:: _tt_content_bodytext.php
-    :language: php
     :caption: Excerpt from EXT:frontend/Configuration/TCA/tt_content.php
 
 This means, the parsers for the soft reference types `typolink_tag`, `email` and
@@ -209,7 +207,6 @@ registering them in your :file:`Services.yaml` file. This will load them
 via :ref:`dependency injection <Dependency-Injection>`:
 
 ..  literalinclude:: _YourSoftReferenceParser.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 Read :ref:`how to configure dependency injection in extensions <dependency-injection-in-extensions>`.
@@ -256,5 +253,4 @@ They can be retrieved with the :php:`getSoftReferenceParser()` method. You
 have to provide the desired key as the first and only argument.
 
 ..  literalinclude:: _MyController.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyController.php

--- a/Documentation/ApiOverview/SystemRegistry/Index.rst
+++ b/Documentation/ApiOverview/SystemRegistry/Index.rst
@@ -47,7 +47,6 @@ the :php:`Registry` class via :ref:`dependency injection <DependencyInjection>`.
 The instance returned will always be the same, as the registry is a singleton:
 
 ..  literalinclude:: _Injection.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 You can access registry values through its :php:`get()` method. The :php:`get()`
@@ -70,13 +69,11 @@ The registry can be used, for example, to write run information of a
 :ref:`console command <symfony-console-commands>` into the registry:
 
 ..  literalinclude:: _MyCommand.php
-    :language: php
     :caption: EXT:my_extension/Classes/Command/MyCommand.php
 
 This information can be retrieved later using:
 
 ..  literalinclude:: _MyClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 

--- a/Documentation/ApiOverview/Xclasses/Index.rst
+++ b/Documentation/ApiOverview/Xclasses/Index.rst
@@ -83,7 +83,6 @@ The syntax is as follows and is commonly located in an extension's
 :file:`ext_localconf.php` file:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 In this example, we declare that the :code:`\TYPO3\CMS\Backend\Controller\NewRecordController` class

--- a/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/ConfigurationFiles.rst
@@ -122,7 +122,6 @@ file with all configuration of other extensions.
 The following example contains the complete code:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Additionally, it is possible to extend TYPO3 in a lot of different ways (adding

--- a/Documentation/ExtensionArchitecture/BestPractises/ExtensionLoadingOrder.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/ExtensionLoadingOrder.rst
@@ -33,7 +33,6 @@ the :composer:`typo3/cms-felogin` system extension, the dependency should be def
 as follows:
 
 ..  literalinclude:: _snippets/_require-composer.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
 
 This ensures that TYPO3 loads the extension **after** the

--- a/Documentation/ExtensionArchitecture/BestPractises/SoftwareDesignPrinciples.rst
+++ b/Documentation/ExtensionArchitecture/BestPractises/SoftwareDesignPrinciples.rst
@@ -53,7 +53,6 @@ entity: The DTO getters retrieve the data, and the Extbase domain model entity's
 receive that data:
 
 ..  literalinclude:: _dto.php
-    :language: php
     :caption: Example of DTO and AbstractEntity used in an Extbase controller
 
 DTOs are helpful because:

--- a/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ComposerJson.rst
@@ -89,7 +89,6 @@ Subsequently:
 *   The Composer package name will be `my-vendor/my-extension`
 
 ..  literalinclude:: _ComposerJson/_MinimalComposer.json
-    :language: json
     :caption: EXT:my_extension/composer.json
 
 * see `composer.json schema <https://getcomposer.org/doc/04-schema.md>`__ for
@@ -121,7 +120,6 @@ Extended composer.json
     further changes to :file:`composer.json <extension-composer-json>` for testing extensions.
 
 ..  literalinclude:: _ComposerJson/_ExtendedComposer.json
-    :language: json
     :caption: EXT:my_extension/composer.json
 
 
@@ -152,13 +150,11 @@ the extension loading order.
 Here the Classic mode compatible extension has a dependency on Composer package `symfony/dotenv`:
 
 ..  literalinclude:: _ComposerJson/_ClassicModeComposerWithPackages.json
-    :language: json
     :caption: EXT:my_extension/composer.json
 
 Here the Classic mode compatible extension does not depend on any Composer packages:
 
 ..  literalinclude:: _ComposerJson/_ClassicModeComposerWithoutPackages.json
-    :language: json
     :caption: EXT:my_extension/composer.json
 
 ..  important::
@@ -283,7 +279,6 @@ properly.
 Example for extension key `my_extension`:
 
 ..  literalinclude:: _ComposerJson/_ExtensionKey.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
     :emphasize-lines: 4
 
@@ -303,7 +298,6 @@ is *required* for Classic mode installations)
     of a dedicated field.
 
 ..  literalinclude:: _ComposerJson/_ExtensionKey.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
     :emphasize-lines: 5
 
@@ -350,7 +344,6 @@ as an empty object to ensure future compatibility with TYPO3 Classic mode
 and to avoid deprecation messages in TYPO3 v14:
 
 ..  literalinclude:: _ComposerJson/_ExtensionKey.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
     :emphasize-lines: 6,7,8
 
@@ -365,7 +358,6 @@ their autoloader in a standardized way.
 Here is an example of an extension that ships a local Composer vendor directory:
 
 ..  literalinclude:: _ComposerJson/_providesPackagesComposer.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
 
 In this example, the package `symfony/dotenv` is provided by the extension itself
@@ -408,7 +400,6 @@ replace with ``typo3-ter`` vendor name
 --------------------------------------
 
 ..  literalinclude:: _ComposerJson/_ReplaceTypo3Ter.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
 
 This was used previously as long as the TER Composer Repository was
@@ -421,7 +412,6 @@ replace with ``"ext_key": "self.version"``
 ------------------------------------------
 
 ..  literalinclude:: _ComposerJson/_ReplaceExtKey.json
-    :language: json
     :caption: Excerpt of EXT:my_extension/composer.json
 
 This was used previously, but is not compatible with latest Composer

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Icons.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Icons.rst
@@ -20,5 +20,4 @@
     See the :ref:`Icon API <icon>` for details.
 
 ..  literalinclude:: /ApiOverview/Icon/_Icons.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Icons.php

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/ServicesYaml.rst
@@ -32,7 +32,6 @@ This file can configure services. TYPO3 uses it for:
 *  :ref:`Registering a widget with the dashboard <ext_dashboard:register-new-widget>`
 
 ..  literalinclude:: _snippets/_example_services.yaml
-    :language: yaml
     :caption: EXT:my_extension/Configuration/Services.yaml
 
 ..  seealso::

--- a/Documentation/ExtensionArchitecture/FileStructure/Configuration/Sets/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Configuration/Sets/Index.rst
@@ -42,7 +42,6 @@ Example:
     example, :ref:`settings defined in the "Fluid Styled Content" site set <typo3/cms-fluid-styled-content:site-set-fluid-styled-content-settings>`:
 
     ..  literalinclude:: /ApiOverview/SiteHandling/_Sets/_site-package/_settings-map.yaml
-        :language: yaml
         :caption: config/sites/<my_site>/settings.yaml | typo3conf/sites/<my_site>/settings.yaml
 
 .. _extension-configuration-sets-settings-definitions-yaml:

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtConfTemplate.rst
@@ -106,7 +106,6 @@ To retrieve the configuration use the API provided by the
 :ref:`constructor injection <Constructor-injection>`:
 
 ..  literalinclude:: _ExtConfTemplate/_MyClass.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 This will return the whole configuration as an array.
@@ -114,7 +113,6 @@ This will return the whole configuration as an array.
 To directly fetch specific values like :typoscript:`myVariable` from the example above:
 
 ..  literalinclude:: _ExtConfTemplate/_MyClass2.php
-    :language: php
     :caption: EXT:my_extension/Classes/MyClass.php
 
 

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtLocalconf.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtLocalconf.rst
@@ -97,7 +97,6 @@ automatically as soon as the extension is installed.
 The skeleton of the :file:`ext_localconf.php` looks like this:
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 Read :ref:`why the check for the TYPO3 constant is necessary <globals-constants-typo3>`.

--- a/Documentation/ExtensionArchitecture/HowTo/Events/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Events/Index.rst
@@ -33,7 +33,6 @@ It is best practice to use a descriptive class name and to put it in the
 namespace :php:`MyVendor\MyExtension\EventListener`.
 
 .. literalinclude:: _Joh316PasswordInformer.php
-   :language: php
 
 ..  _extension-development-events-dispatch-event:
 

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendExtbaseModel/Index.rst
@@ -148,7 +148,6 @@ configuration array) as described in :ref:`Extending TCA <extending-tca>`. Exten
 original model in your extension using a class:
 
 ..  literalinclude:: _MyExtendedModel.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Model/MyExtendedModel.php
 
 Add all the additional fields that you require. By convention the database
@@ -163,11 +162,9 @@ The extended model needs to be registered for :ref:`Extbase persistence <extbase
 :file:`Configuration/Extbase/Persistence/Classes.php` and :file:`ext_localconf.php`.
 
 ..  literalinclude:: _Classes.php
-    :language: php
     :caption: EXT:my_extension/Configuration/Extbase/Persistence/Classes.php
 
 ..  literalinclude:: _ext_localconf.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  _extending-extbase-model_extend_original_repository:
@@ -178,7 +175,6 @@ Extend the original repository (optional)
 Similarly, extend the original repository:
 
 ..  literalinclude:: _MyExtendedModelRepository.php
-    :language: php
     :caption: EXT:my_extension/Classes/Domain/Repository/MyExtendedModelRepository.php
 
 The rule that a repository must follow the naming schema of the model also
@@ -200,7 +196,6 @@ Extbase to use your repository instead of the original one whenever the original
 repository is requested via Dependency Injection in a controller or service.
 
 ..  literalinclude:: _ext_localconf_repository.php
-    :language: php
     :caption: EXT:my_extension/ext_localconf.php
 
 ..  _extending-extbase-model_alternative_strategies:

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/Index.rst
@@ -99,7 +99,6 @@ calling :php:`ExtensionManagementUtility::addToAllTCAtypes()`. The parameters ar
 Example code:
 
 ..  literalinclude:: _fe_users.php
-    :language: php
     :caption: EXT:some_extension/Configuration/TCA/Overrides/fe_users.php
 
 If the fourth parameter is omitted or the field is not found,

--- a/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Creation.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Creation.rst
@@ -111,7 +111,6 @@ Method :php:`getPrerequisites()`
     :yaml:`install.upgradewizard`:
 
     ..  literalinclude:: _tagUpgradeWizard.yaml
-        :language: yaml
         :caption: EXT:my_extension/Configuration/Services.yaml
 
 After creating the new upgrade wizard, delete all caches in

--- a/Documentation/Testing/AcceptanceTesting/Index.rst
+++ b/Documentation/Testing/AcceptanceTesting/Index.rst
@@ -64,14 +64,12 @@ The suite file (for instance :file:`Backend.suite.yml`) should contain a line
 to load and configure the backend login module:
 
 ..  literalinclude:: _AcceptanceTests/_Backend.suite.yml
-    :language: yaml
     :caption: EXT:some_extension/Tests/Acceptance/Backend.suite.yml
 
 This allows an editor and an admin user to easily log into the TYPO3 backend
 without further fuzz. An acceptance test can use it like this:
 
 ..  literalinclude:: _AcceptanceTests/_ModuleCest.php
-    :language: php
     :caption: EXT:styleguide/Tests/Acceptance/Backend/ModuleCest.php
 
 The call :php:`$I->useExistingSession('admin')` logs in an admin user into the TYPO3
@@ -89,7 +87,6 @@ methods takes care the according frames are fully loaded before proceeding with
 further tests:
 
 ..  literalinclude:: _AcceptanceTests/_SomeCest.php
-    :language: php
     :caption: EXT:styleguide/Tests/Acceptance/Backend/SomeCest.php
 
 ..  _testing-writing-acceptance-pagetree:
@@ -101,7 +98,6 @@ An abstract class of `typo3/testing-framework` can be extended and used to open 
 select specific pages in the page tree. A typical class looks like this:
 
 ..  literalinclude:: _AcceptanceTests/_PageTree.php
-    :language: php
     :caption: typo3/sysext/core/Tests/Acceptance/Support/Helper/PageTree.php
 
 This example is taken from the Core extension, other extensions should use their own
@@ -109,7 +105,6 @@ instance in an own extension based namespace. If this is done, the PageTree supp
 class can be injected into a test:
 
 ..  literalinclude:: _AcceptanceTests/_ElementsBasicInputDateCest.php
-    :language: php
     :caption: EXT:some_extension/Tests/Acceptance/Backend/SomeCest.php
 
 The example above (adapt to your namespaces!) instructs the PageTree helper to find

--- a/Documentation/Testing/FunctionalTesting/Index.rst
+++ b/Documentation/Testing/FunctionalTesting/Index.rst
@@ -28,7 +28,6 @@ hesitate looking around, there is plenty to discover.
 As a starter, let's have a look at a basic scenario from the styleguide example again:
 
 ..  literalinclude:: _FunctionalTests/_GeneratorTest.php
-    :language: php
     :caption: EXT:styleguide/Tests/Functional/TcaDataGenerator/GeneratorTest.php
 
 That's the basic setup needed for a functional test: Extend :php:`FunctionalTestCase`,
@@ -44,7 +43,6 @@ call :php:`parent::setUp()` before doing own stuff. An example can be found in
 :php:`TYPO3\CMS\Backend\Tests\Functional\Domain\Repository\Localization\LocalizationRepositoryTest`:
 
 ..  literalinclude:: _FunctionalTests/_LocalizationRepositoryTest.php
-    :language: php
     :caption: typo3/sysext/backend/Tests/Functional/Domain/Repository/Localization/LocalizationRepositoryTest.php
 
 The above example overrides :php:`setUp()` to first call :php:`parent::setUp()`. This is
@@ -68,14 +66,12 @@ that wants to test if it works well together with workspaces, would for example 
 the workspaces extension as additional to-load extension:
 
 ..  literalinclude:: _FunctionalTests/_SomeTest.php
-    :language: php
     :caption: EXT:my_extension/Tests/Functional/SomeTest.php
 
 Furthermore, third party extensions and fixture extensions can be loaded for
 any given test case:
 
 ..  literalinclude:: _FunctionalTests/_SomeTestExtensions.php
-    :language: php
     :caption: EXT:my_extension/Tests/Functional/SomeTestExtensions.php
 
 In this case the fictional extension `some_extension` comes with an own fixture extension that should
@@ -116,7 +112,6 @@ In general, the methods need the absolute path to the fixture file to load them.
 keywords are allowed:
 
 ..  literalinclude:: _FunctionalTests/_SomeTestImportDataSet.php
-    :language: php
     :caption: EXT:some_extension/Tests/Functional/SomeTestImportDataSet.php
 
 ..  _testing-writing-functional-assert-database:
@@ -142,7 +137,6 @@ example, one may want to check if an image has been properly sized down. The ima
 on can be linked into the test instance:
 
 ..  literalinclude:: _FunctionalTests/_SomeTestFiles.php
-    :language: php
     :caption: EXT:my_extension/Tests/Functional/SomeTestFiles.php
 
 It is also possible to *copy* the files to the test instance instead of only linking it
@@ -160,7 +154,6 @@ If extensions need additional settings in :file:`config/system/settings.php`, th
 :php:`$configurationToUseInTestInstance` can be used to specify these:
 
 ..  literalinclude:: _FunctionalTests/_SomeTestConfiguration.php
-    :language: php
     :caption: EXT:my_extension/Tests/Functional/SomeTestConfiguration.php
 
 ..  _testing-writing-functional-frontend:
@@ -172,7 +165,6 @@ To prepare a frontend test, the system can be instructed to load a set of
 :file:`.typoscript` files for a working frontend:
 
 ..  literalinclude:: _FunctionalTests/_SomeTestFrontend.php
-    :language: php
     :caption: EXT:my_extension/Tests/Functional/SomeTestFrontend.php
 
 This instructs the system to load the :file:`Basic.typoscript` as TypoScript

--- a/Documentation/Testing/UnitTesting/Index.rst
+++ b/Documentation/Testing/UnitTesting/Index.rst
@@ -41,13 +41,11 @@ be annotated with :php:`@test`.
 Example for a system under test located at :file:`typo3/sysext/core/Utility/ArrayUtility.php` (stripped):
 
 ..  literalinclude:: _UnitTests/_ArrayUtility.php
-    :language: php
     :caption: typo3/sysext/core/Utility/ArrayUtility.php (stripped)
 
 The test file is located at :file:`typo3/sysext/core/Tests/Unit/Utility/ArrayUtilityTest.php` (stripped):
 
 ..  literalinclude:: _UnitTests/_ArrayUtilityTest.php
-    :language: php
     :caption: typo3/sysext/core/Tests/Unit/Utility/ArrayUtilityTest.php  (stripped)
 
 This way it is easy to find unit tests for any given file. Note PhpStorm understands this structure and
@@ -122,7 +120,6 @@ Data providers are used quite often for this and we encourage developers to do s
 from :php:`ArrayUtilityTest`:
 
 ..  literalinclude:: _UnitTests/_ArrayUtilityTestDataProvider.php
-    :language: php
     :caption: typo3/sysext/core/Tests/Unit/Utility/ArrayUtilityTest.php (excerpts)
 
 
@@ -144,7 +141,6 @@ like additional objects, they should be usually "mocked away". A simple example 
 :php:`TYPO3\CMS\Backend\Tests\Unit\Controller\FormInlineAjaxControllerTest`:
 
 ..  literalinclude:: _UnitTests/_FormInlineAjaxControllerTest.php
-    :language: php
     :caption: typo3/sysext/backend/Tests/Unit/Controller/FormInlineAjaxControllerTest.php
 
 The above case is pretty straight since the mocked dependency is hand over as argument to
@@ -153,7 +149,6 @@ dependency on its own - typically using :php:`GeneralUtility::makeInstance()`, t
 can be manually registered for makeInstance:
 
 ..  literalinclude:: _UnitTests/_SomeTest.php
-    :language: php
     :caption: EXT:my_extension/Tests/Unit/SomeTest.php
 
 This works well for prototypes. :php:`addInstance()` adds objects to a LiFo, multiple instances
@@ -162,7 +157,6 @@ empty to avoid side effects on other tests. Singleton instances can be registere
 similar way:
 
 ..  literalinclude:: _UnitTests/_TcaFlexPrepareTest.php
-    :language: php
     :caption: typo3/sysext/backend/Tests/Unit/Form/FormDataProvider/TcaFlexPrepareTest.php
 
 ..  todo: EnvironmentService has been removed with version 12.0, find another Example here
@@ -206,5 +200,4 @@ a simple example, this is from :php:`TYPO3\CMS\Core\Tests\Unit\Cache\CacheManage
 and tests both the exception class and the exception code:
 
 ..  literalinclude:: _UnitTests/_OnTheFlyTest.php
-    :language: php
     :caption: typo3/sysext/backend/Tests/Unit/Form/FormDataGroup/OnTheFlyTest.php


### PR DESCRIPTION
The language can be auto-detected from the included file's extension
in these cases, so the explicit option is unnecessary.

Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf