### PR TITLE
[FEATURE] Document Redis key prefix option

### DIFF
--- a/Documentation/ApiOverview/Authentication/Sessions/SessionStorage.rst
+++ b/Documentation/ApiOverview/Authentication/Sessions/SessionStorage.rst
@@ -78,7 +78,8 @@ A sample configuration will look like this:
                     'hostname' => 'redis.myhost.example',
                     'password' => 'passw0rd',
                     'database' => 0,
-                    'port' => 6379
+                    'port' => 6379,
+                    'keyPrefix' => 'be_sessions_'
                 ]
             ],
             'FE' => [
@@ -87,7 +88,8 @@ A sample configuration will look like this:
                     'hostname' => 'redis.myhost.example',
                     'password' => 'passw0rd',
                     'database' => 0,
-                    'port' => 6379
+                    'port' => 6379,
+                    'keyPrefix' => 'fe_sessions_'
                 ]
             ],
         ],
@@ -107,6 +109,16 @@ The available options are:
 
 `password`
     The password to use when connecting to the specified database. Optional.
+
+`keyPrefix`
+    Prefix added to all Redis keys used by this session backend. Allows the
+    same Redis database to be shared by multiple applications or TYPO3
+    instances, as long as the prefix is unique. Optional, default: empty.
+
+    ..  versionadded:: 13.3
+
+        See `Feature: #104451 - Redis backends support for key prefixing
+        <https://docs.typo3.org/permalink/changelog:feature-104451-1721646565>`_.
 
 .. tip::
     If a Redis instance is running on the same machine as the webserver

--- a/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
@@ -362,6 +362,21 @@ Options for the redis caching backend
     is issued to one of them. Database numbers 0 and 1 are used and flushed by the Core unit tests
     and should not be used if possible.
 
+..  confval:: keyPrefix
+    :name: caching-backend-redis-keyPrefix
+    :type: string
+    :default: (empty)
+
+    ..  versionadded:: 13.3
+
+        See `Feature: #104451 - Redis backends support for key prefixing
+        <https://docs.typo3.org/permalink/changelog:feature-104451-1721646565>`_.
+
+    Prefix added to all keys this backend writes to Redis. Allows the same
+    Redis database to be shared by multiple caches or TYPO3 instances, as
+    long as the prefix is unique. If only one cache sharing the database has
+    no prefix set, flushing it flushes the whole database.
+
 ..  confval:: username
     :name: caching-backend-redis-username
     :type: string


### PR DESCRIPTION
RedisBackend and RedisSessionBackend both support a `keyPrefix` option
(added in 13.3) to share one Redis database across multiple caches,
sessions, or TYPO3 instances by namespacing keys, but neither the
cache backend options nor the session storage options documented it.

Verified against `.Build/vendor/typo3/cms-core`
`Classes/Cache/Backend/RedisBackend.php` and
`Classes/Session/Backend/RedisSessionBackend.php`.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1023
Releases: main, 14.3, 13.4
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf