### PR TITLE
[TASK] Move record header rendering from FormEngine to controllers

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Overview/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Overview/Index.rst
@@ -54,6 +54,10 @@ The controller does two distinct things here. First, it initializes a data array
 data providers from FormEngine that add all the information needed for the rendering stage. This data array
 is then passed onto FormEngine rendering to produce a result array containing all the HTML, CSS and JavaScript.
 
+..  deprecated:: 14.2
+    The `outerWrapContainer` has been deprecated in favour of the
+    `formWrapContainer`. See `Deprecation: #109192 - FormEngine OuterWrapContainer <https://docs.typo3.org/permalink/changelog:deprecation-109192-1741560000>`_
+
 In code, the basic workflow looks like this:
 
 ..  literalinclude:: _SomeClass.php

--- a/Documentation/ApiOverview/FormEngine/Overview/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Overview/Index.rst
@@ -55,8 +55,14 @@ data providers from FormEngine that add all the information needed for the rende
 is then passed onto FormEngine rendering to produce a result array containing all the HTML, CSS and JavaScript.
 
 ..  deprecated:: 14.2
-    The `outerWrapContainer` has been deprecated in favour of the
-    `formWrapContainer`. See `Deprecation: #109192 - FormEngine OuterWrapContainer <https://docs.typo3.org/permalink/changelog:deprecation-109192-1741560000>`_
+    The `outerWrapContainer` render type has been deprecated in favour of
+    `formWrapContainer`. 
+    The new container no longer renders the record
+    heading or the record identity footer (icon, table title, uid) — that
+    responsibility has moved to the controllers. If your controller relied on
+    :php:`OuterWrapContainer` rendering those elements, you need to render them
+    in your controller code after switching.
+    See `Deprecation: #109192 - FormEngine OuterWrapContainer <https://docs.typo3.org/permalink/changelog:deprecation-109192-1741560000>`_.
 
 In code, the basic workflow looks like this:
 

--- a/Documentation/ApiOverview/FormEngine/Overview/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Overview/Index.rst
@@ -56,12 +56,12 @@ is then passed onto FormEngine rendering to produce a result array containing al
 
 ..  deprecated:: 14.2
     The `outerWrapContainer` render type has been deprecated in favour of
-    `formWrapContainer`. 
-    The new container no longer renders the record
+    `formWrapContainer`. The new container no longer renders the record
     heading or the record identity footer (icon, table title, uid) — that
     responsibility has moved to the controllers. If your controller relied on
-    :php:`OuterWrapContainer` rendering those elements, you need to render them
-    in your controller code after switching.
+    :php-short:`\TYPO3\CMS\Backend\Form\Container\OuterWrapContainer` rendering
+    those elements, you need to render them in your controller code after
+    switching.
     See `Deprecation: #109192 - FormEngine OuterWrapContainer <https://docs.typo3.org/permalink/changelog:deprecation-109192-1741560000>`_.
 
 In code, the basic workflow looks like this:

--- a/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Rendering/Index.rst
@@ -208,7 +208,9 @@ FieldControl
 Currently, all elements usually implement all three of these, except in cases where it does not make sense. This API allows
 adding functionality to single nodes, without overriding the whole node. Containers and elements can come with default
 expansions (and usually do). TCA configuration can be used to add own stuff. On container side the implementation is still
-basic, only :php:`OuterWrapContainer` and :php:`InlineControlContainer` currently implement FieldInformation and FieldWizard.
+basic, only :php-short:`\TYPO3\CMS\Backend\Form\Container\FormWrapContainer` and
+:php-short:`\TYPO3\CMS\Backend\Form\Container\InlineControlContainer` currently
+implement FieldInformation and FieldWizard.
 
 See the :ref:`TCA reference ctrl section <t3tca:ctrl-reference-container>` for more information on how to configure these
 for containers in TCA.

--- a/Documentation/Images/Plantuml/FormEngine/FormEngineRenderTree.plantuml
+++ b/Documentation/Images/Plantuml/FormEngine/FormEngineRenderTree.plantuml
@@ -1,6 +1,5 @@
 @startuml
-Controller --|> OuterWrapContainer : Create headline and footer
-OuterWrapContainer --|> FullRecordContainer : Initialize tabbing
+Controller --|> FullRecordContainer : Create headline and footer
 FullRecordContainer --|> TabsContainer : Prepare data of each tab
 TabsContainer --|> "PaletteAndSingleContainer 1" : Prepare fields on first tab
 TabsContainer --|> "PaletteAndSingleContainer 2" : Prepare fields on second tab


### PR DESCRIPTION
Supersedes #6572, which GitHub refused to reopen after its branch was
recreated ("branch was force-pushed or recreated"). Same content, minus
an unrelated `.github/workflows/apply-precommit.yml` commit that had
gotten mixed into that branch, plus a small follow-up fixing `:php-short:`/FQN
usage and trailing whitespace in the deprecation note.

`OuterWrapContainer` was deprecated in 14.2 in favour of `FormWrapContainer`,
which no longer renders the record heading or identity footer itself — that
responsibility moved to the controllers. Update the render-tree diagram,
the FieldInformation/FieldWizard container reference, and add a deprecation
note explaining the migration impact.

Note: `OuterWrapContainer` is already fully removed on `main` (v15), not
merely deprecated, but this PR keeps the `deprecated::` framing as originally
written since it's accurate for the 14.3 backport. A follow-up PR will
reword the note on `main` once this is merged and backported.

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1644
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf
