### PR TITLE
[TASK] Remove deprecated OuterWrapContainer migration note

### DIFF
--- a/Documentation/ApiOverview/FormEngine/Overview/Index.rst
+++ b/Documentation/ApiOverview/FormEngine/Overview/Index.rst
@@ -54,16 +54,6 @@ The controller does two distinct things here. First, it initializes a data array
 data providers from FormEngine that add all the information needed for the rendering stage. This data array
 is then passed onto FormEngine rendering to produce a result array containing all the HTML, CSS and JavaScript.
 
-..  deprecated:: 14.2
-    The `outerWrapContainer` render type has been deprecated in favour of
-    `formWrapContainer`. The new container no longer renders the record
-    heading or the record identity footer (icon, table title, uid) — that
-    responsibility has moved to the controllers. If your controller relied on
-    :php-short:`\TYPO3\CMS\Backend\Form\Container\OuterWrapContainer` rendering
-    those elements, you need to render them in your controller code after
-    switching.
-    See `Deprecation: #109192 - FormEngine OuterWrapContainer <https://docs.typo3.org/permalink/changelog:deprecation-109192-1741560000>`_.
-
 In code, the basic workflow looks like this:
 
 ..  literalinclude:: _SomeClass.php


### PR DESCRIPTION
`OuterWrapContainer` is now fully removed as of TYPO3 v15 (main), not
merely deprecated. Drop the `deprecated:: 14.2` note from the FormEngine
workflow overview; nothing of it remains in the current API, and the
underlying migration guidance is already covered by Core's own
Deprecation changelog entry.

v15-only change, not backported: the 14.3 branch's note stays as-is
since OuterWrapContainer is still present there, only deprecated.

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1644
Releases: main
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf