### PR TITLE
[FEATURE] Document wizardSteps TCA option for the page creation wizard

### DIFF
--- a/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
+++ b/Documentation/ApiOverview/PageTypes/CreateNewPageType.rst
@@ -79,6 +79,25 @@ identifiers with specific suffixes:
 *   **Page is a root page:** `tx-examples-archive-page-root`
 *   **Page contains content from another page:** `tx-examples-archive-page-contentFromPid`
 
+..  _page-types-example-wizard-steps:
+
+Configure the page creation wizard steps
+========================================
+
+..  versionadded:: 14.2
+    See `Feature: #109271 - Add TCA configuration for dynamic page creation wizard steps <https://docs.typo3.org/permalink/changelog:feature-109271-1742217000>`_.
+
+The steps shown for a page type in the page creation wizard can be configured
+via the `wizardSteps` TCA option. Each step has a title and a list of fields
+to display, and steps can be positioned relative to each other using `before`
+or `after`. Fields required for the page type but not assigned to any step
+are automatically added to a fallback step at the end.
+
+..  literalinclude:: _pages_wizardSteps.php
+    :caption: EXT:my_extension/Configuration/TCA/Overrides/pages.php
+
+See :ref:`the wizardSteps TCA reference <t3tca:types-wizardSteps>` for details.
+
 ..  _page-types-example-page-wizard:
 ..  _page-types-example-dynamic-configuration:
 

--- a/Documentation/ApiOverview/PageTypes/_pages.php
+++ b/Documentation/ApiOverview/PageTypes/_pages.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'doktype',
         new SelectItem(
             'select',
-            label: 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:archive_page_type',
+            label: 'examples.messages:archive_page_type',
             value: $customPageDoktype,
             icon: $customIconClass,
             group: 'special',

--- a/Documentation/ApiOverview/PageTypes/_pages_wizardSteps.php
+++ b/Documentation/ApiOverview/PageTypes/_pages_wizardSteps.php
@@ -1,0 +1,15 @@
+<?php
+
+defined('TYPO3') or die();
+
+$GLOBALS['TCA']['pages']['types']['116']['wizardSteps'] = [
+    'setup' => [
+        'title' => 'examples.messages:wizard.step.setup',
+        'fields' => ['title', 'slug', 'nav_title', 'hidden', 'nav_hide'],
+    ],
+    'archive' => [
+        'title' => 'examples.messages:wizard.step.archive',
+        'fields' => ['tx_examples_archived_date'],
+        'after' => ['setup'],
+    ],
+];


### PR DESCRIPTION
Extend the "Create new page type" example with a section on the new
`wizardSteps` TCA option, which configures which fields appear in which
step of the page creation wizard for a given page type. This closes the
loop with the TCA reference manual's `wizardSteps` confval doc, which
already points here for a complete example.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1653
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf