### PR TITLE
[TASK] Use the short translation domain syntax in example labels

### DIFF
--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/RegisterCustomProvider.yaml
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/RegisterCustomProvider.yaml
@@ -5,7 +5,7 @@ services:
     tags:
       - name: mfa.provider
         identifier: 'my-provider'
-        title: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider.title'
-        description: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider.description'
-        setupInstructions: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider.setupInstructions'
+        title: 'my_extension.messages:myProvider.title'
+        description: 'my_extension.messages:myProvider.description'
+        setupInstructions: 'my_extension.messages:myProvider.setupInstructions'
         icon: 'tx-myextension-provider-icon'

--- a/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/RegisterMultipleProviders.yaml
+++ b/Documentation/ApiOverview/Authentication/MultiFactorAuthentication/RegisterMultipleProviders.yaml
@@ -5,9 +5,9 @@ services:
     tags:
       - name: mfa.provider
         identifier: 'my-provider-1'
-        title: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider1.title'
-        description: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider1.description'
-        setupInstructions: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider1.setupInstructions'
+        title: 'my_extension.messages:myProvider1.title'
+        description: 'my_extension.messages:myProvider1.description'
+        setupInstructions: 'my_extension.messages:myProvider1.setupInstructions'
         icon: 'tx-myextension-provider1-icon'
 
   MyVendor\MyExtension\Authentication\Mfa\MySecondProvider:
@@ -15,9 +15,9 @@ services:
     tags:
       - name: mfa.provider
         identifier: 'my-provider-2'
-        title: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider2.title'
-        description: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider2.description'
-        setupInstructions: 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myProvider2.setupInstructions'
+        title: 'my_extension.messages:myProvider2.title'
+        description: 'my_extension.messages:myProvider2.description'
+        setupInstructions: 'my_extension.messages:myProvider2.setupInstructions'
         icon: 'tx-myextension-provider2-icon'
         # Important so that this provider acts as a fallback
         defaultProviderAllowed: true

--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -104,7 +104,7 @@ The following page TSconfig example creates a simple backend layout consisting o
                    columns {
                      1 {
                        identifier = border
-                       name = LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:colPos.I.3
+                       name = frontend.ttc:colPos.I.3
                        allowedContentTypes = html, text, ...
                        colPos = 3
                        colspan = 1

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ThirdlevelModules.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ThirdlevelModules.rst
@@ -38,7 +38,7 @@ file of an extension:
        'path' => '/module/content/typoscript/custom-info',
        'iconIdentifier' => 'module-custom-info',
        'labels' => [
-           'title' => 'LLL:EXT:extkey/Resources/Private/Language/locallang.xlf:mod_title',
+           'title' => 'extkey.messages:mod_title',
        ],
        'routes' => [
            '_default' => [

--- a/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ToplevelModules.rst
+++ b/Documentation/ApiOverview/Backend/BackendModules/ModuleConfiguration/ToplevelModules.rst
@@ -66,7 +66,7 @@ Register a new toplevel module in your extension:
 
    return [
        'myextension' => [
-           'labels' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_mod_web.xlf',
+           'labels' => 'my_extension.mod_web',
            'iconIdentifier' => 'modulegroup-myextension',
            'navigationComponent' => '@typo3/backend/page-tree/page-tree-element',
        ]

--- a/Documentation/ApiOverview/Backend/LoginProvider.rst
+++ b/Documentation/ApiOverview/Backend/LoginProvider.rst
@@ -25,7 +25,7 @@ or :file:`config/system/additional.php`  like this:
         'provider' => \MyVendor\MyExtension\LoginProvider\CustomLoginProvider::class,
         'sorting' => 50,
         'iconIdentifier' => 'actions-key',
-        'label' => 'LLL:EXT:backend/Resources/Private/Language/locallang.xlf:login.link'
+        'label' => 'backend.messages:login.link'
     ];
 
 The settings are defined as:

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_page.tsconfig
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_page.tsconfig
@@ -4,8 +4,8 @@ mod.wizards.newContentElement.wizardItems {
     elements {
       myextension_newcontentelement {
         iconIdentifier = content-text
-        title = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_title
-        description = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_newcontentelement_description
+        title = my_extension.messages:myextension_newcontentelement_title
+        description = my_extension.messages:myextension_newcontentelement_description
         tt_content_defValues {
           CType = myextension_newcontentelement
         }

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_page_change_group_header.tsconfig
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_page_change_group_header.tsconfig
@@ -1,3 +1,3 @@
 mod.wizards.newContentElement.wizardItems {
-  mygroup.header = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:mygroup.header
+  mygroup.header = my_extension.messages:mygroup.header
 }

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_content_element_group.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_content_element_group.php
@@ -8,10 +8,10 @@ defined('TYPO3') or die();
 
 ExtensionManagementUtility::addPlugin(
     [
-        'label' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_title',
+        'label' => 'my_extension.messages:myextension_myplugin_title',
         'value' => 'myextension_myplugin',
         'icon' => 'content-text',
         'group' => 'plugin',
-        'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_description',
+        'description' => 'my_extension.messages:myextension_myplugin_description',
     ],
 );

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_description.diff
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_description.diff
@@ -5,7 +5,7 @@
          'label' => 'Example - basic content',
          'value' => $key,
 +        'icon' => 'examples-icon-basic',
-+        'description' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:basic_content.description',
++        'description' => 'examples.db:basic_content.description',
          'group' => 'default',
      ],
      'textmedia',

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_plugin.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_plugin.php
@@ -8,10 +8,10 @@ defined('TYPO3') or die();
 
 ExtensionManagementUtility::addPlugin(
     [
-        'label' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_title',
+        'label' => 'my_extension.messages:myextension_myplugin_title',
         'value' => 'myextension_myplugin',
         'icon' => 'content-text',
         'group' => 'plugin',
-        'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_description',
+        'description' => 'my_extension.messages:myextension_myplugin_description',
     ],
 );

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_reference.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_reference.php
@@ -6,7 +6,7 @@ defined('TYPO3') or die();
 $temporaryColumn = [
     'myextension_reference' => [
         'exclude' => 0,
-        'label' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_db.xlf:' .
+        'label' => 'my_extension.db:' .
             'tt_content.myextension_reference',
         'config' => [
             'type' => 'select',

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_register_group.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_register_group.php
@@ -11,14 +11,14 @@ ExtensionManagementUtility::addTcaSelectItemGroup(
     'tt_content',
     'CType',
     'myextension_myplugingroup',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin.group',
+    'my_extension.messages:myextension_myplugin.group',
 );
 
 ExtensionUtility::registerPlugin(
     'my_extension',
     'MyPlugin',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_title',
+    'my_extension.messages:myextension_myplugin_title',
     'myextension_myplugin',
     'myextension_myplugingroup',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_description',
+    'my_extension.messages:myextension_myplugin_description',
 );

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_register_plugin.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_register_plugin.php
@@ -9,8 +9,8 @@ defined('TYPO3') or die();
 ExtensionUtility::registerPlugin(
     'my_extension',
     'MyPlugin',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_title',
+    'my_extension.messages:myextension_myplugin_title',
     'myextension_myplugin',
     'plugins',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:myextension_myplugin_description',
+    'my_extension.messages:myextension_myplugin_description',
 );

--- a/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_temporary_column.php
+++ b/Documentation/ApiOverview/ContentElements/_AddingYourOwnContentElements/_tt_content_temporary_column.php
@@ -6,7 +6,7 @@ defined('TYPO3') or die();
 $temporaryColumn = [
     'myextension_separator' => [
         'exclude' => 0,
-        'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tt_content.myextension_separator',
+        'label' => 'examples.db:tt_content.myextension_separator',
         'config' => [
             'type' => 'select',
             'renderType' => 'selectSingle',

--- a/Documentation/ApiOverview/ContentElements/_Plugins/_tt_content_extbase_plugin.php
+++ b/Documentation/ApiOverview/ContentElements/_Plugins/_tt_content_extbase_plugin.php
@@ -9,8 +9,8 @@ defined('TYPO3') or die();
 ExtensionUtility::registerPlugin(
     'MyExtension',
     'MyPlugin',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:my_plugin.title',
+    'my_extension.messages:my_plugin.title',
     'myextension_pluginicon',
     'plugins',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:my_plugin.description',
+    'my_extension.messages:my_plugin.description',
 );

--- a/Documentation/ApiOverview/ContentElements/_Plugins/_tt_content_plugin.php
+++ b/Documentation/ApiOverview/ContentElements/_Plugins/_tt_content_plugin.php
@@ -8,11 +8,11 @@ defined('TYPO3') or die();
 
 ExtensionManagementUtility::addPlugin(
     [
-        'label' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_db.xlf:my_plugin.title',
+        'label' => 'my_extension.db:my_plugin.title',
         'value' => 'myextension_myplugin',
         'group' => 'plugins',
         'icon' => 'myextension_mypluginicon',
-        'description' => 'LLL:EXT:my_extension/Resources/Private/Language/locallang_db.xlf:my_plugin.description',
+        'description' => 'my_extension.db:my_plugin.description',
     ],
     'CType',
     'my_extension',

--- a/Documentation/ApiOverview/CropVariants/ContentElement/Index.rst
+++ b/Documentation/ApiOverview/CropVariants/ContentElement/Index.rst
@@ -19,7 +19,7 @@ your `image` field configuration of tt_content records:
                     'config' => [
                         'cropVariants' => [
                             'mobile' => [
-                                'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                                'title' => 'ext_key.messages:imageManipulation.mobile',
                                 'cropArea' => [
                                     'x' => 0.1,
                                     'y' => 0.1,
@@ -48,7 +48,7 @@ It is also possible to set the cropping configuration only for a **specific tt_c
                'disabled' => true,
            ],
            'mobile' => [
-               'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+               'title' => 'ext_key.messages:imageManipulation.mobile',
                'cropArea' => [
                    'x' => 0.1,
                    'y' => 0.1,
@@ -57,11 +57,11 @@ It is also possible to set the cropping configuration only for a **specific tt_c
                ],
                'allowedAspectRatios' => [
                    '4:3' => [
-                       'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                       'title' => 'core.wizards:imwizard.ratio.4_3',
                        'value' => 4 / 3
                    ],
                    'NaN' => [
-                       'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                       'title' => 'core.wizards:imwizard.ratio.free',
                        'value' => 0.0
                    ],
                ],

--- a/Documentation/ApiOverview/CropVariants/General/Index.rst
+++ b/Documentation/ApiOverview/CropVariants/General/Index.rst
@@ -34,27 +34,27 @@ Each crop variant has at least one *ratio configuration* defined under `allowedA
          'type' => 'imageManipulation',
          'cropVariants' => [
              'mobile' => [
-                 'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                 'title' => 'ext_key.messages:imageManipulation.mobile',
                  'allowedAspectRatios' => [
                      '4:3' => [
-                         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                         'title' => 'core.wizards:imwizard.ratio.4_3',
                          'value' => 4 / 3
                      ],
                      'NaN' => [
-                         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                         'title' => 'core.wizards:imwizard.ratio.free',
                          'value' => 0.0
                      ],
                  ],
              ],
              'desktop' => [
-                 'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.desktop',
+                 'title' => 'ext_key.messages:imageManipulation.desktop',
                  'allowedAspectRatios' => [
                      '4:3' => [
-                         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.4_3',
+                         'title' => 'core.wizards:imwizard.ratio.4_3',
                          'value' => 4 / 3
                      ],
                      'NaN' => [
-                         'title' => 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                         'title' => 'core.wizards:imwizard.ratio.free',
                          'value' => 0.0
                      ],
                  ],
@@ -78,7 +78,7 @@ The example below has an initial crop area in the same size that the previous im
         'type' => 'imageManipulation',
         'cropVariants' => [
             'mobile' => [
-                'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                'title' => 'ext_key.messages:imageManipulation.mobile',
                 'cropArea' => [
                     'x' => 0.1,
                     'y' => 0.1,
@@ -111,7 +111,7 @@ and centered.
         'type' => 'imageManipulation',
         'cropVariants' => [
             'mobile' => [
-                'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                'title' => 'ext_key.messages:imageManipulation.mobile',
                 'focusArea' => [
                     'x' => 1 / 3,
                     'y' => 1 / 3,
@@ -140,7 +140,7 @@ the crop area. The focus area cannot intersect with any cover areas.
         'type' => 'imageManipulation',
         'cropVariants' => [
             'mobile' => [
-                'title' => 'LLL:EXT:ext_key/Resources/Private/Language/locallang.xlf:imageManipulation.mobile',
+                'title' => 'ext_key.messages:imageManipulation.mobile',
                 'coverAreas' => [
                     [
                         'x' => 0.05,

--- a/Documentation/ApiOverview/Events/Events/Backend/_BeforeLiveSearchFormIsBuiltEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_BeforeLiveSearchFormIsBuiltEvent/_MyEventListener.php
@@ -13,7 +13,7 @@ final class BeforeLiveSearchFormIsBuiltEventListener
     public function __invoke(BeforeLiveSearchFormIsBuiltEvent $event): void
     {
         $event->addHints(...[
-            'LLL:EXT:my-package/Resources/Private/Language/locallang.xlf:identifier',
+            'my_package.messages:identifier',
         ]);
         $event->setAdditionalViewData(['myVariable' => 'some data']);
     }

--- a/Documentation/ApiOverview/FlexForms/Definition/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/Definition/Index.rst
@@ -31,7 +31,7 @@ Select field
 
     <settings.orderBy>
         <label>
-            LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy
+            example.backend:settings.registration.orderBy
         </label>
         <config>
             <type>select</type>
@@ -39,13 +39,13 @@ Select field
             <items>
                 <numIndex index="0">
                     <label>
-                        LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.crdate
+                        example.backend:settings.registration.orderBy.crdate
                     </label>
                     <value>crdate</value>
                 </numIndex>
                 <numIndex index="1">
                     <label>
-                        LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy.title
+                        example.backend:settings.registration.orderBy.title
                     </label>
                     <value>title</value>
                 </numIndex>
@@ -66,7 +66,7 @@ Populate a `select` field using a PHP function (`itemsProcFunc`)
 
     <settings.orderBy>
         <label>
-            LLL:EXT:example/Resources/Private/Language/Backend.xlf:settings.registration.orderBy
+            example.backend:settings.registration.orderBy
         </label>
         <config>
             <type>select</type>

--- a/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
+++ b/Documentation/ApiOverview/FormEngine/Rendering/_pages.php
@@ -3,7 +3,7 @@
 defined('TYPO3') or die();
 
 (static function (): void {
-    $langFile = 'LLL:EXT:my_extension/Ressources/Private/Language/locallang.xlf';
+    $langFile = 'my_extension.messages';
 
     $GLOBALS['TCA']['pages']['columns']['somefield'] = [
         'label' => $langFile . ':pages.somefield',

--- a/Documentation/ApiOverview/LinkHandling/LinkBrowserApi/Index.rst
+++ b/Documentation/ApiOverview/LinkHandling/LinkBrowserApi/Index.rst
@@ -44,7 +44,7 @@ LinkBrowser tabs are registered in page TSconfig like this:
 
    TCEMAIN.linkHandler.<tabIdentifier> {
        handler = TYPO3\CMS\Backend\LinkHandler\FileLinkHandler
-       label = LLL:EXT:backend/Resources/Private/Language/locallang_browse_links.xlf:file
+       label = backend.browse_links:file
        displayAfter = page
        scanAfter = page
        configuration {

--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/Index.rst
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/Index.rst
@@ -68,7 +68,7 @@ The minimal page TSconfig configuration is:
 
    TCEMAIN.linkHandler.anIdentifier {
        handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
-       label = LLL:EXT:extension/Resources/Private/Language/locallang.xlf:link.customTab
+       label = extension.messages:link.customTab
        configuration {
            table = tx_example_domain_model_item
        }

--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/PageLinkHandler.rst
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/PageLinkHandler.rst
@@ -20,7 +20,7 @@ The PageLinkHandler is preconfigured in the page TSconfig as:
    TCEMAIN.linkHandler {
       page {
          handler = TYPO3\CMS\Backend\LinkHandler\PageLinkHandler
-         label = LLL:EXT:backend/Resources/Private/Language/locallang_browse_links.xlf:page
+         label = backend.browse_links:page
       }
    }
 

--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/RecordLinkHandler.rst
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/RecordLinkHandler.rst
@@ -29,7 +29,7 @@ In order to use the :php:`RecordLinkHandler` it can be configured as following:
 
       TCEMAIN.linkHandler.anIdentifier {
           handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
-          label = LLL:EXT:extension/Resources/Private/Language/locallang.xlf:link.customTab
+          label = extension.messages:link.customTab
           configuration {
               table = tx_example_domain_model_item
           }
@@ -77,7 +77,7 @@ The minimal page TSconfig configuration is:
 
    TCEMAIN.linkHandler.anIdentifier {
        handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
-       label = LLL:EXT:extension/Resources/Private/Language/locallang.xlf:link.customTab
+       label = extension.messages:link.customTab
        configuration {
            table = tx_example_domain_model_item
        }

--- a/Documentation/ApiOverview/LinkHandling/Linkhandler/_CustomLinkHandlers/_page.tsconfig
+++ b/Documentation/ApiOverview/LinkHandling/Linkhandler/_CustomLinkHandlers/_page.tsconfig
@@ -1,7 +1,7 @@
 TCEMAIN.linkHandler {
   github {
     handler = T3docs\\Examples\\LinkHandler\\GitHubLinkHandler
-    label = LLL:EXT:examples/Resources/Private/Language/locallang_browse_links.xlf:github
+    label = examples.browse_links:github
     displayAfter = url
     scanBefore = url
     configuration {

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -408,7 +408,7 @@ In Fluid, you can now use the defined language key ("language"):
 
 ..  code-block:: html
 
-    <f:translate languageKey="{language}" id="LLL:EXT:my_extension/Resources/Private/Language/emails.xml:subject" />
+    <f:translate languageKey="{language}" id="my_extension.emails:subject" />
 
 ..  _mail-fluid-email-set-request:
 

--- a/Documentation/ApiOverview/PageTypes/_pages.php
+++ b/Documentation/ApiOverview/PageTypes/_pages.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
         'doktype',
         new SelectItem(
             'select',
-            label: 'LLL:EXT:examples/Resources/Private/Language/locallang.xlf:archive_page_type',
+            label: 'examples.messages:archive_page_type',
             value: $customPageDoktype,
             icon: $customIconClass,
             group: 'special',

--- a/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaColumnTitle.php
+++ b/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaColumnTitle.php
@@ -3,7 +3,7 @@
 [
     'columns' => [
         'title' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.title',
+            'label' => 'tea.db:tx_tea_domain_model_tea.title',
             'config' => [
                 'type' => 'input',
                 'size' => 40,

--- a/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaCtrl.php
+++ b/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaCtrl.php
@@ -2,7 +2,7 @@
 
 [
     'ctrl' => [
-        'title' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea',
+        'title' => 'tea.db:tx_tea_domain_model_tea',
         'label' => 'title',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',

--- a/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaTypes.php
+++ b/Documentation/CodeSnippets/Tutorials/Tea/Configuration/TCA/TeaTypes.php
@@ -3,9 +3,9 @@
 [
     'types' => [
         1 => [
-            'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+            'showitem' => '--div--;core.form.tabs:general,
                     title, description, image, owner,
-                 --div--;LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.tabs.access,
+                 --div--;tea.db:tx_tea_domain_model_tea.tabs.access,
                     --palette--;;hidden,
                     --palette--;;access,',
         ],

--- a/Documentation/ExtensionArchitecture/Extbase/Domain/_snippets/_EnumExample.php
+++ b/Documentation/ExtensionArchitecture/Extbase/Domain/_snippets/_EnumExample.php
@@ -10,7 +10,7 @@ enum Status: string
     case IN_REVIEW = 'in-review';
     case PUBLISHED = 'published';
 
-    public const LLL_PREFIX = 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:status-';
+    public const LLL_PREFIX = 'my_extension.messages:status-';
 
     public function getLabel(): string
     {

--- a/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_tt_content.php
+++ b/Documentation/ExtensionArchitecture/Extbase/QuickStart/_snippets/_tt_content.php
@@ -9,6 +9,6 @@ defined('TYPO3') or die();
 ExtensionUtility::registerPlugin(
     'MyExtension',
     'ConferenceList',
-    'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:plugin.conferencelist.title',
+    'my_extension.messages:plugin.conferencelist.title',
     'content-plugin',
 );

--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTables.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTables.rst
@@ -47,7 +47,7 @@ Before:
 
     $GLOBALS['TYPO3_USER_SETTINGS']['columns']['myCustomSetting'] = [
         'type' => 'check',
-        'label' => 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:myCustomSetting',
+        'label' => 'my_ext.messages:myCustomSetting',
     ];
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToUserSettings(
         'myCustomSetting',
@@ -62,7 +62,7 @@ After:
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserSetting(
         'myCustomSetting',
         [
-            'label' => 'LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:myCustomSetting',
+            'label' => 'my_ext.messages:myCustomSetting',
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',

--- a/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_scheduler.php
+++ b/Documentation/ExtensionArchitecture/FileStructure/_ext_tables_scheduler.php
@@ -7,7 +7,7 @@ use TYPO3\CMS\Scheduler\Task\CachingFrameworkGarbageCollectionTask;
 
 defined('TYPO3') or die();
 
-$lll = 'LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:';
+$lll = 'my_extension.messages:';
 
 // Add caching framework garbage collection task
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Modules.php
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/_ModuleConfiguration/_Modules.php
@@ -110,7 +110,7 @@ return [
         'access' => 'admin',
         'workspaces' => 'live',
         'path' => '/module/system/example',
-        'labels' => 'LLL:EXT:examples/Resources/Private/Language/AdminModule/locallang_mod.xlf',
+        'labels' => 'examples.admin_module.mod',
         'iconIdentifier' => 'tx_examples-backend-module',
         'routes' => [
             '_default' => [

--- a/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/Index.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/ExtendingTca/Examples/Index.rst
@@ -31,16 +31,16 @@ Here is the complete code, taken from file
       [
          'tx_examples_options' => [
             'exclude' => 0,
-            'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options',
+            'label' => 'examples.db:fe_users.tx_examples_options',
             'config' => [
                'type' => 'select',
                'renderType' => 'selectSingle',
                'items' => [
                   ['',0,],
-                  ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.0',1,],
-                  ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.1',2,],
-                  ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.2','--div--',],
-                  ['LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_options.I.3',3,],
+                  ['examples.db:fe_users.tx_examples_options.I.0',1,],
+                  ['examples.db:fe_users.tx_examples_options.I.1',2,],
+                  ['examples.db:fe_users.tx_examples_options.I.2','--div--',],
+                  ['examples.db:fe_users.tx_examples_options.I.3',3,],
                ],
                'size' => 1,
                'maxitems' => 1,
@@ -48,7 +48,7 @@ Here is the complete code, taken from file
          ],
          'tx_examples_special' => [
             'exclude' => 0,
-            'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:fe_users.tx_examples_special',
+            'label' => 'examples.db:fe_users.tx_examples_special',
             'config' => [
                'type' => 'user',
                // renderType needs to be registered in ext_localconf.php
@@ -163,7 +163,7 @@ Then we add it to the :php:`$GLOBALS['TCA']` in :file:`Configuration/TCA/Overrid
       [
          'tx_examples_noprint' => [
             'exclude' => 0,
-            'label' => 'LLL:EXT:examples/Resources/Private/Language/locallang_db.xlf:tt_content.tx_examples_noprint',
+            'label' => 'examples.db:tt_content.tx_examples_noprint',
             'config' => [
                'type' => 'check',
                'renderType' => 'checkboxToggle',

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Fluid.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Fluid.rst
@@ -47,9 +47,9 @@ the text fragment prefixed by the location file can be provided.
 .. code-block:: html
    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
-   <f:translate key="LLL:EXT:my_extension/Resources/Private/Language/yourFile.xlf:yourKey" />
+   <f:translate key="my_extension.your_file:yourKey" />
    <!-- or as inline Fluid: -->
-   {f:translate(key: 'LLL:EXT:my_extension/Resources/Private/Language/yourFile.xlf:yourKey')}
+   {f:translate(key: 'my_extension.your_file:yourKey')}
 
 
 The text fragment will now be displayed in the current frontend language
@@ -67,7 +67,7 @@ avoid no text being displayed:
    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
 
    <f:translate
-       key="LLL:EXT:my_extension/Resources/Private/Language/yourFile.xlf:yourKey"
+       key="my_extension.your_file:yourKey"
        default="No translation available."
    />
 

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/_TypoScript/_locallang_fluidtemplate.typoscript
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/_TypoScript/_locallang_fluidtemplate.typoscript
@@ -6,7 +6,7 @@ page.10.template.value (
   <f:translate key="onlineDocumentation" extensionName="backend" />
 
   # infer from language key
-  <f:translate key="LLL:EXT:backend/Resources/Private/Language/locallang.xlf:onlineDocumentation" />
+  <f:translate key="backend.messages:onlineDocumentation" />
 
   # should not work because the locallang.xlf does not exist, but works right now
   <f:translate key="LLL:EXT:backend/Resources/locallang.xlf:onlineDocumentation" />

--- a/Documentation/ExtensionArchitecture/Tutorials/Tea/_Model/_image_tca.php
+++ b/Documentation/ExtensionArchitecture/Tutorials/Tea/_Model/_image_tca.php
@@ -4,7 +4,7 @@ return [
     // ...
     'columns' => [
         'image' => [
-            'label' => 'LLL:EXT:tea/Resources/Private/Language/locallang_db.xlf:tx_tea_domain_model_tea.image',
+            'label' => 'tea.db:tx_tea_domain_model_tea.image',
             'config' => [
                 'type' => 'file',
                 'maxitems' => 1,


### PR DESCRIPTION
TYPO3 v14 introduced a shorter `package.resource:key` translation
domain syntax as an alternative to the long-form `LLL:EXT:` label
reference. Convert example labels throughout the manual to it, except
where the long form is deliberately taught or demonstrated.

Also fixes a pre-existing `my-package` extension-key typo (TYPO3 keys
can't contain hyphens) and two module registrations still using the
old file-reference form.

Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf