### PR TITLE
[BUGFIX] Fix broken PHP namespace rendering in Extbase model docs

### DIFF
--- a/Documentation/ExtensionArchitecture/Extbase/Domain/Model.rst
+++ b/Documentation/ExtensionArchitecture/Extbase/Domain/Model.rst
@@ -157,7 +157,7 @@ The four possible attributes on model properties are:
         :php:`#[Validate]` is repeatable — apply multiple validators to one
         property.
 
-Import from the :php:`\TYPO3\CMS\Extbase\Attribute\ORM\` namespace:
+Import from the :php:`\TYPO3\CMS\Extbase\Attribute\ORM` namespace:
 
 ..  code-block:: php
     :caption: EXT:my_extension/Classes/Domain/Model/Conference.php


### PR DESCRIPTION
A namespace ending directly in `\` right before the closing backtick of
`:php:`...`` escapes the backtick instead of closing the role, so the role
never parses and the raw text is rendered with every backslash stripped
(`TYPO3CMSExtbaseAttributeORM`). Drop the redundant trailing separator.

Resolves: #6768
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf <lwolf@w-commerce.de>