### PR TITLE
[BUGFIX] Fix broken backslash rendering in mail spool path notes

### DIFF
--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -308,7 +308,7 @@ Additional notes about the mail spool path:
 *   If the path is relative, the public web path is prepended to the path
 *   The path must not contain symlinks (important for environments with auto
     deployment)
-*   The path must not contain `//`, `..` or `\`
+*   The path must not contain `//`, `..` or `\\`
 
 ..  _mail-spooling-sending-spooled-mails:
 


### PR DESCRIPTION
A lone `\` right before the closing backtick of a default-role span
(`` `\` ``) is consumed by reST's backslash escaping instead of closing
the role, so it rendered as an empty tag. Doubling it (`\\`) lets the
delimiter be recognized while the escaped content still collapses to a
single literal backslash in the output.

Releases: main, 14.3, 13.4
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf <lwolf@w-commerce.de>