### PR TITLE
[TASK] Document language and translation source indexes

### DIFF
--- a/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/ExtTablesSql.rst
@@ -255,6 +255,22 @@ auto-generated fields, if they are not manually defined in the
 :php:`['ctrl']['translationSource'] = 'my_field_name'`
     Often set to :sql:`l10n_source`.
 
+:sql:`language_identifier` and :sql:`translation_source` indexes
+    Added for every language-aware table, based on the language
+    :ref:`t3tca:ctrl` configuration alone - independent of whether the
+    fields above were added here or already declared in
+    :file:`ext_tables.sql`. The :sql:`language_identifier` index covers
+    :php:`['ctrl']['transOrigPointerField']` and
+    :php:`['ctrl']['languageField']`. If :php:`['ctrl']['translationSource']`
+    is set, the :sql:`translation_source` index additionally covers that
+    field, so that both ways of matching a translation - by translation
+    source, or by the translation origin pointer for translations saved
+    without one - resolve through a single index.
+
+    See `Important: #110454 - Translation source index covers the
+    translation lookups
+    <https://docs.typo3.org/permalink/changelog:important-110454-1786550456>`_.
+
 :sql:`l10n_state`
     Column added if :php:`['ctrl']['languageField']` and
     :php:`['ctrl']['transOrigPointerField']` are set.


### PR DESCRIPTION
TYPO3 Core now generates a `language_identifier` index for every
language-aware table and widens `translation_source` to also cover
the translation origin pointer and language fields, so both
translation lookup paths resolve through a single index. Both indexes
are now generated from the language capability alone, independent of
where the underlying columns are declared.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1820
Releases: main, 14.3, 13.4
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf