### PR TITLE
[TASK] Use .fluid.html extension in Fluid template examples

### DIFF
--- a/Documentation/ApiOverview/Authentication/AuthenticationService/CSRFlikeRequestTokenHandling.rst
+++ b/Documentation/ApiOverview/Authentication/AuthenticationService/CSRFlikeRequestTokenHandling.rst
@@ -67,7 +67,7 @@ The sequence looks like the following:
         :caption: EXT:my_extension/Classes/Controller/MyController.php
 
     ..  code-block:: html
-        :caption: EXT:my_extension/Resources/Private/Templates/ShowForm.html
+        :caption: EXT:my_extension/Resources/Private/Templates/ShowForm.fluid.html
 
         <!-- Assign request token object for ViewHelper -->
         <f:form action="process" requestToken="{requestToken}">

--- a/Documentation/ApiOverview/Backend/BackendLayout.rst
+++ b/Documentation/ApiOverview/Backend/BackendLayout.rst
@@ -218,7 +218,7 @@ To get the correct backend layout, the following TypoScript code can be used:
 		key.data = pagelayout
 
 		default = TEXT
-		default.value = EXT:sitepackage/Resources/Private/Templates/Home.html
+		default.value = EXT:sitepackage/Resources/Private/Templates/Home.fluid.html
 
 		3 = TEXT
 		3.value = EXT:sitepackage/Resources/Private/Templates/1-col.html

--- a/Documentation/ApiOverview/Backend/ContextualMenu.rst
+++ b/Documentation/ApiOverview/Backend/ContextualMenu.rst
@@ -191,13 +191,13 @@ of the standard backend container Fluid view helper (or backend page
 renderer view helper).
 
 Doing so in your layout is sufficient (see
-:file:`typo3/sysext/beuser/Resources/Private/Layouts/Default.html`).
+:file:`typo3/sysext/beuser/Resources/Private/Layouts/Default.fluid.html`).
 
 ..  literalinclude:: _ContextualMenu/_IncludeJS.fluid.html
 
 The second step is to activate the context menu on the icons. This kind of markup
 is required (taken from
-:file:`typo3/sysext/beuser/Resources/Private/Templates/BackendUser/Index.html`):
+:file:`typo3/sysext/beuser/Resources/Private/Templates/BackendUser/Index.fluid.html`):
 
 ..  code-block:: xml
     :emphasize-lines: 2

--- a/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
+++ b/Documentation/ApiOverview/ContentElements/AddingYourOwnContentElements.rst
@@ -191,11 +191,11 @@ The Fluid template is configured by the
 :ref:`t3tsref:cobj-fluidtemplate-properties-templatename` property as
 `NewContentElement`.
 
-This will load a :file:`BasicContent.html` template file from the path
+This will load a :file:`BasicContent.fluid.html` template file from the path
 defined at the :typoscript:`templateRootPaths`.
 
 In the example extension you can find the file at
-:file:`EXT:examples/Resources/Private/Templates/ContentElements/BasicContent.html`
+:file:`EXT:examples/Resources/Private/Templates/ContentElements/BasicContent.fluid.html`
 
 `tt_content` fields can now be used in the Fluid template by accessing them via
 the `data` variable.
@@ -376,7 +376,7 @@ parameters to be used in the data processor:
     :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
 
 You can now iterate over the variable `myTable` in the Fluid template, in this
-example :file:`Resources/Private/Templates/ContentElements/DataProcCsv.html`
+example :file:`Resources/Private/Templates/ContentElements/DataProcCsv.fluid.html`
 
 .. literalinclude:: /CodeSnippets/CustomContentElements/DataProcCsv.fluid.html
    :caption: EXT:examples/Resources/Private/Templates/ContentElements/DataProcCsv.fluid.html

--- a/Documentation/ApiOverview/ContentElements/_codesnippets/_preview.typoscript
+++ b/Documentation/ApiOverview/ContentElements/_codesnippets/_preview.typoscript
@@ -2,7 +2,7 @@ mod.web_layout {
   tt_content {
     preview {
       # Your CType
-      example_ctype = EXT:my_extension/Resources/Private/Templates/Preview/MyCType.html
+      example_ctype = EXT:my_extension/Resources/Private/Templates/Preview/MyCType.fluid.html
     }
   }
 }

--- a/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
+++ b/Documentation/ApiOverview/ContentSecurityPolicy/Index.rst
@@ -711,7 +711,7 @@ The :ref:`f:security.nonce <t3viewhelper:typo3-fluid-security-nonce>` ViewHelper
 is available, which provides the nonce in a Fluid template, for example:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <script nonce="{f:security.nonce()}">
         const inline = 'script';
@@ -726,7 +726,7 @@ or :ref:`f:asset.css <t3viewhelper:typo3-fluid-asset-css>`
 ViewHelpers with the `useNonce` attribute:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:asset.script identifier="my-inline-script" useNonce="1">
         const inline = 'script';

--- a/Documentation/ApiOverview/Fal/UsingFal/Frontend.rst
+++ b/Documentation/ApiOverview/Fal/UsingFal/Frontend.rst
@@ -116,7 +116,7 @@ This requires first a bit of TypoScript:
 
     lib.carousel = FLUIDTEMPLATE
     lib.carousel {
-      file = EXT:my_extension/Resources/Private/Templates/Carousel.html
+      file = EXT:my_extension/Resources/Private/Templates/Carousel.fluid.html
       dataProcessing.10 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
       dataProcessing.10 {
         references {
@@ -133,7 +133,7 @@ variable called :typoscript:`images`. This can then be used in the Fluid
 template:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/Carousel.html
+    :caption: EXT:my_extension/Resources/Private/Templates/Carousel.fluid.html
 
     <f:for each="{images}" as="image">
         <div class="slide">

--- a/Documentation/ApiOverview/FeatureToggleApi/Index.rst
+++ b/Documentation/ApiOverview/FeatureToggleApi/Index.rst
@@ -222,7 +222,7 @@ The :ref:`t3viewhelper:typo3-fluid-feature` can be used to check for a feature i
 template:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:feature name="unifiedPageTranslationHandling">
        This is being shown if the flag is enabled

--- a/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
+++ b/Documentation/ApiOverview/Fluid/DevelopCustomViewhelper.rst
@@ -271,14 +271,14 @@ ViewHelper. The call to render the ViewHelper was written with tag syntax, which
 seemed obvious because it itself returns a tag:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <m:gravatar emailAddress="{post.author.emailAddress}" />
 
 Alternatively, this expression can be written using the inline notation:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     {m:gravatar(emailAddress: post.author.emailAddress)}
 
@@ -286,7 +286,7 @@ One should see the Gravatar ViewHelper as a kind of post-processor for an email
 address and would allow the following syntax:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     {post.author.emailAddress -> m:gravatar()}
 

--- a/Documentation/ApiOverview/Fluid/Introduction.rst
+++ b/Documentation/ApiOverview/Fluid/Introduction.rst
@@ -95,6 +95,15 @@ Directory structure
 
 In your extension, the following directory structure should be used for Fluid files:
 
+..  versionchanged:: 14.0
+    Fluid 5 introduces a dedicated file extension for template, partial,
+    layout and component files, for example :file:`.fluid.html` instead of
+    plain :file:`.html`. A fallback mechanism keeps existing files without
+    this extension working, so renaming is entirely optional. See
+    `Feature: #108166 - Fluid File Extension and Template Resolving
+    <https://docs.typo3.org/permalink/changelog:feature-108166-1763400992>`_
+    for the resolving order and the reasoning behind the change.
+
 ..  directory-tree::
     :show-file-icons: true
 
@@ -144,8 +153,8 @@ certain action on that controller.
 
                     *   Blog
 
-                        *   List.html (for Blog->list() action)
-                        *   Show.html (for Blog->show() action)
+                        *   List.fluid.html (for Blog->list() action)
+                        *   Show.fluid.html (for Blog->show() action)
 
 
 If you don't use Extbase you can still use this convention, but it is not a
@@ -224,7 +233,7 @@ Example partial:
 Example template using the partial:
 
 ..  code-block:: html
-    :caption:  EXT:my_extension/Resources/Private/Templates/Show.html
+    :caption:  EXT:my_extension/Resources/Private/Templates/Show.fluid.html
 
     <f:render partial="Tags" arguments="{tags: post.tags}" />
 
@@ -270,18 +279,18 @@ This example was taken from a theme created by the
 
             *   Layouts
 
-                *   PageLayout.html
+                *   PageLayout.fluid.html
 
             *   Partials
 
-                *   Content.html
-                *   Footer.html
+                *   Content.fluid.html
+                *   Footer.fluid.html
                 *   ...
 
             *   Pages
 
-                *   Default.html
-                *   Subpage.html
+                *   Default.fluid.html
+                *   Subpage.fluid.html
 
 Set the Fluid base path with TypoScript using the
 `PAGEVIEW <https://docs.typo3.org/permalink/t3tsref:cobj-pageview>`_ TypoScript
@@ -290,16 +299,16 @@ object.
 ..  literalinclude:: _Introduction/_pageview.typoscript
     :caption:  packages/my_sitepackage/Configuration/Sets/SitePackage/setup.typoscript
 
-The template in file :file:`Pages/Default.html` is automatically used whenever there is
+The template in file :file:`Pages/Default.fluid.html` is automatically used whenever there is
 no specific template for the current `Backend layout <https://docs.typo3.org/permalink/t3coreapi:be-layout>`_ of the page.
 
 ..  literalinclude:: _Introduction/_Default.fluid.html
     :caption: EXT:my_sitepackage/Resources/Private/PageView/Pages/Default.fluid.html
 
-It includes the layout :file:`Layouts/PageLayout.html`. And uses partial
-:file:`Partials/Content.html` to display its content.
+It includes the layout :file:`Layouts/PageLayout.fluid.html`. And uses partial
+:file:`Partials/Content.fluid.html` to display its content.
 
-It uses the partial :file:`Partials/Content.html` to display its content.
+It uses the partial :file:`Partials/Content.fluid.html` to display its content.
 
 ..  literalinclude:: _Introduction/_Content.fluid.html
     :caption: Resources/Private/PageView/Partials/Content.fluid.html

--- a/Documentation/ApiOverview/LinkHandling/Index.rst
+++ b/Documentation/ApiOverview/LinkHandling/Index.rst
@@ -28,7 +28,7 @@ For example, in :ref:`Fluid <fluid>` all input from the RTE should be output by 
 :ref:`t3viewhelper:typo3-fluid-format-html`:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.fluid.html
 
     <f:format.html>{myContent.bodytext}</f:format.html>
 
@@ -36,7 +36,7 @@ Links provided in backend fields like the :sql:`header_link` can be used as
 input in the ViewHelper :ref:`t3viewhelper:typo3-fluid-link-typolink`:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.fluid.html
 
     <f:link.typolink parameter="{myContent.header_link}">
       {myContent.header_link}

--- a/Documentation/ApiOverview/Localization/Labels/Index.rst
+++ b/Documentation/ApiOverview/Localization/Labels/Index.rst
@@ -269,7 +269,7 @@ Use the :ref:`f:translate <t3viewhelper:typo3-fluid-translate>` ViewHelper to
 insert translated strings in Fluid templates.
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:translate key="my_extension.your_file.xlf:yourKey" />
     <!-- or as inline Fluid: -->

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -94,12 +94,12 @@ Minimal example for a Fluid-based email template
 
                     *   Email
 
-                        *   MyCustomEmail.html
+                        *   MyCustomEmail.fluid.html
 
-**`MyCustomEmail.html`:**
+**`MyCustomEmail.fluid.html`:**
 
 ..  code-block:: html
-    :caption: EXT:my_site_package/Resources/Private/Templates/Email/MyCustomEmail.html
+    :caption: EXT:my_site_package/Resources/Private/Templates/Email/MyCustomEmail.fluid.html
 
     <f:layout name="SystemEmail" />
 

--- a/Documentation/ApiOverview/Mail/Index.rst
+++ b/Documentation/ApiOverview/Mail/Index.rst
@@ -96,7 +96,7 @@ Minimal example for a Fluid-based email template
 
                         *   MyCustomEmail.fluid.html
 
-**`MyCustomEmail.fluid.html`:**
+:file:`MyCustomEmail.fluid.html`:
 
 ..  code-block:: html
     :caption: EXT:my_site_package/Resources/Private/Templates/Email/MyCustomEmail.fluid.html

--- a/Documentation/ApiOverview/Rte/RenderingInTheFrontend/Index.rst
+++ b/Documentation/ApiOverview/Rte/RenderingInTheFrontend/Index.rst
@@ -31,7 +31,7 @@ link syntax). You should therefore always render the output of a RTE field
 with the `Format.html ViewHelper <f:format.html> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-format-html>`_:
 
 ..  code-block:: html
-    :caption: packages/my_extension/Resources/Private/Templates/MyContentElement.html
+    :caption: packages/my_extension/Resources/Private/Templates/MyContentElement.fluid.html
 
     <f:format.html>{data.bodytext}</f:format.html>
 

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/FluidErrorHandler.rst
@@ -21,7 +21,7 @@ The Fluid-based error handler has the properties
 ..  option:: errorFluidTemplate
 
     :type: string
-    :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html`
+    :Example: `EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.fluid.html`
 
     The path to the Fluid template file. Path may be
 

--- a/Documentation/ApiOverview/SiteHandling/ErrorHandling/_fluid-error-handler.yaml
+++ b/Documentation/ApiOverview/SiteHandling/ErrorHandling/_fluid-error-handler.yaml
@@ -1,7 +1,7 @@
 errorHandling:
   - errorCode: 404
     errorHandler: Fluid
-    errorFluidTemplate: 'EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.html'
+    errorFluidTemplate: 'EXT:my_sitepackage/Resources/Private/Templates/Sites/Error.fluid.html'
     errorFluidTemplatesRootPath: ''
     errorFluidLayoutsRootPath: ''
     errorFluidPartialsRootPath: 'EXT:my_sitepackage/Resources/Private/Partials/Sites/'

--- a/Documentation/ApiOverview/SiteHandling/UseSiteInTypoScript.rst
+++ b/Documentation/ApiOverview/SiteHandling/UseSiteInTypoScript.rst
@@ -71,7 +71,7 @@ to fetch data from the site entity:
 
    tt_content.mycontent.20 = FLUIDTEMPLATE
    tt_content.mycontent.20 {
-       file = EXT:myextension/Resources/Private/Templates/ContentObjects/MyContent.html
+       file = EXT:myextension/Resources/Private/Templates/ContentObjects/MyContent.fluid.html
 
        dataProcessing.10 = TYPO3\CMS\Frontend\DataProcessing\SiteProcessor
        dataProcessing.10 {

--- a/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
+++ b/Documentation/ApiOverview/SiteHandling/_basics-config.yaml
@@ -36,7 +36,7 @@ errorHandling:
     errorContentSource: 't3://page?uid=8'
   - errorCode: '403'
     errorHandler: Fluid
-    errorFluidTemplate: 'EXT:my_extension/Resources/Private/Templates/ErrorPages/403.html'
+    errorFluidTemplate: 'EXT:my_extension/Resources/Private/Templates/ErrorPages/403.fluid.html'
     errorFluidTemplatesRootPath: 'EXT:my_extension/Resources/Private/Templates/ErrorPages'
     errorFluidLayoutsRootPath: 'EXT:my_extension/Resources/Private/Layouts/ErrorPages'
     errorFluidPartialsRootPath: 'EXT:my_extension/Resources/Private/Partials/ErrorPages'

--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Private/Index.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Private/Index.rst
@@ -46,7 +46,7 @@ configurable via:
 Common locations for Fluid templates in TYPO3 extensions with plugins:
 ======================================================================
 
-..  typo3:file:: [ActionName].html
+..  typo3:file:: [ActionName].fluid.html
     :scope: extension
     :path: /Resources/Private/Templates/[ControllerName]/
     :regex: /^.*\/Resources\/Private\/Templates(\/[A-Za-z0-9]+)?\/[A-Za-z0-9]+\.[a-z0-9]$/
@@ -56,14 +56,14 @@ Common locations for Fluid templates in TYPO3 extensions with plugins:
     plugins. In Extbase they are stored in a folder with the name of the controller
     class (without Controller ending), for example the `NewsController.php` has
     the template for action "view" in
-    :file:`/Resources/Private/Templates/News/View.html`. Non-Extbase controllers
+    :file:`/Resources/Private/Templates/News/View.fluid.html`. Non-Extbase controllers
     can decide on how to use this folder.
 
 ..  tip::
     Other file endings can be used for different formats, for example `.xml`
     for sitemaps or xml-feeds or `.txt` for plain text.
 
-..  typo3:file:: SomePartials.html
+..  typo3:file:: SomePartials.fluid.html
     :scope: extension
     :path: /Resources/Private/Partials/
     :regex: /^.*\/Resources\/Private\/Partials(\/[A-Za-z0-9]+)*\/[A-Za-z0-9]+\.[a-z0-9]$/
@@ -73,7 +73,7 @@ Common locations for Fluid templates in TYPO3 extensions with plugins:
     These can be included via the `Render ViewHelper <f:render> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-render>`_
     into the main Fluid template.
 
-..  typo3:file:: SomeLayout.html
+..  typo3:file:: SomeLayout.fluid.html
     :scope: extension
     :path: /Resources/Private/Layouts/
     :regex: /^.*\/Resources\/Private\/Layouts\/[A-Za-z0-9]+\.[a-z0-9]$/
@@ -93,29 +93,29 @@ TypoScript object to display the HTML page output. They have one folder, commonl
 `PageView` or `Templates` in folder `Resources/Private` with the subfolders
 `Pages`, `Partials` and `Layouts` (they cannot be renamed).
 
-..  typo3:file:: MyPageLayout.html
+..  typo3:file:: MyPageLayout.fluid.html
     :scope: extension
     :path: /Resources/Private/PageView/Pages/
-    :regex: /^.*\/Resources\/Private\/PageView\/Pages\/[A-Za-z0-9]+\.html$/
+    :regex: /^.*\/Resources\/Private\/PageView\/Pages\/[A-Za-z0-9]+(\.fluid)?\.html$/
     :shortDescription: Fluid Templates for different page layouts
 
     This folder contains one Fluid template for each page layout defined in the
     site package. See `Site package Tutorial, the page view <https://docs.typo3.org/permalink/t3sitepackage:pageview>`_.
 
-..  typo3:file:: SomePartials.html
+..  typo3:file:: SomePartials.fluid.html
     :scope: extension
     :path: /Resources/Private/PageView/Partials/
-    :regex: /^.*\/Resources\/Private\/PageView\/Partials\/[A-Za-z0-9]+\.html$/
+    :regex: /^.*\/Resources\/Private\/PageView\/Partials\/[A-Za-z0-9]+(\.fluid)?\.html$/
     :shortDescription: Fluid Partials for the page view
 
     Folder `Partials` contains the Fluid partials used by the page view.
     These can be included via the `Render ViewHelper <f:render> <https://docs.typo3.org/permalink/t3viewhelper:typo3-fluid-render>`_
     into the page view template.
 
-..  typo3:file:: SomeLayout.html
+..  typo3:file:: SomeLayout.fluid.html
     :scope: extension
     :path: /Resources/Private/PageView/Layouts/
-    :regex: /^.*\/Resources\/Private\/PageView\/Layouts\/[A-Za-z0-9]+\.html$/
+    :regex: /^.*\/Resources\/Private\/PageView\/Layouts\/[A-Za-z0-9]+(\.fluid)?\.html$/
     :shortDescription: Fluid Layouts for the page view
 
     Folder `Layouts` often contains the Fluid layout(s) used by the page view.
@@ -133,31 +133,31 @@ needs to be configured via setting
 :confval:`styles.templates.templateRootPath <typo3/cms-fluid-styled-content:fluid-styled-content-styles-templates-templaterootpath>`
 etc. to work. See also `Site Package Tutorial: Overriding the default templates of content elements <https://docs.typo3.org/permalink/t3sitepackage:content-element-rendering>`_.
 
-..  typo3:file:: SomeContentElement.html
+..  typo3:file:: SomeContentElement.fluid.html
     :scope: extension
     :path: /Resources/Private/ContentElements/Pages/
-    :regex: /^.*\/Resources\/Private\/ContentElements\/Pages\/[A-Za-z0-9]+\.html$/
+    :regex: /^.*\/Resources\/Private\/ContentElements\/Pages\/[A-Za-z0-9]+(\.fluid)?\.html$/
     :shortDescription: Fluid Templates for different content elements
 
     This folder contains one Fluid template for each content element type defined in the
     site package.
 
-..  typo3:file:: SomePartials.html
+..  typo3:file:: SomePartials.fluid.html
     :scope: extension
     :path: /Resources/Private/ContentElements/Partials/
-    :regex: /^.*\/Resources\/Private\/ContentElements\/Partials\/[A-Za-z0-9]+\.html$/
+    :regex: /^.*\/Resources\/Private\/ContentElements\/Partials\/[A-Za-z0-9]+(\.fluid)?\.html$/
     :shortDescription: Fluid Partials for content elements
 
     Typically overrides the Fluid-Styled Content partials.
 
-..  typo3:file:: Default.html
+..  typo3:file:: Default.fluid.html
     :scope: extension
     :path: /Resources/Private/ContentElements/Layouts/
-    :regex: /^.*\/Resources\/Private\/ContentElements\/Layouts\/Default\.html$/
+    :regex: /^.*\/Resources\/Private\/ContentElements\/Layouts\/Default(\.fluid)?\.html$/
     :shortDescription: Overrides the default layout for Fluid-styled content elements
 
     Overrides the default layout originally defined in
-    `vendor/typo3/cms-fluid-styled-content/Resources/Private/Layouts/Default.html`.
+    `vendor/typo3/cms-fluid-styled-content/Resources/Private/Layouts/Default.fluid.html`.
     It is possible to define additional custom layouts that can be
     included via the `Layout ViewHelper <f:layout> <https://docs.typo3.org/permalink/t3viewhelper:typo3fluid-fluid-layout>`_
     into content element templates.

--- a/Documentation/ExtensionArchitecture/FileStructure/Resources/Private/Language.rst
+++ b/Documentation/ExtensionArchitecture/FileStructure/Resources/Private/Language.rst
@@ -60,7 +60,7 @@ Any arbitrary filename ending with :file:`.xlf` can be used.
     be accessed without using the complete path:
 
     ..  code-block:: html
-        :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.html
+        :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.fluid.html
 
         <f:translate key="key1" extensionName="MyExtension"/>
 
@@ -68,7 +68,7 @@ Any arbitrary filename ending with :file:`.xlf` can be used.
     :html:`LLL:EXT` path:
 
     ..  code-block:: html
-        :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.html
+        :caption: EXT:my_extension/Resources/Private/Templates/MyTemplate.fluid.html
 
         <f:translate key="LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:key1" />
 

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/CreateModuleWithExtbase.rst
@@ -92,7 +92,7 @@ For example, here is an extract of the "Index" action template of
 the "beuser" extension:
 
 .. code-block:: html
-   :caption: typo3/sysext/beuser/Resources/Private/Templates/BackendUser/List.html
+   :caption: typo3/sysext/beuser/Resources/Private/Templates/BackendUser/List.fluid.html
 
    <html
       xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"

--- a/Documentation/ExtensionArchitecture/HowTo/BackendModule/SecurityConsiderations.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/BackendModule/SecurityConsiderations.rst
@@ -163,7 +163,7 @@ In the revised template, `POST`-based form buttons are used
 instead of `GET` links for delete actions:
 
 ..  code-block:: diff
-    :caption: **Revised** EXT:demo/Resources/Private/Templates/ExtbaseModule/List.html
+    :caption: **Revised** EXT:demo/Resources/Private/Templates/ExtbaseModule/List.fluid.html
     :linenos:
 
       <ul>
@@ -258,7 +258,7 @@ In the revised template, `POST`-based form buttons are used
 instead of `GET` action links for delete actions:
 
 ..  code-block:: diff
-    :caption: **Revised** EXT:demo/Resources/Private/Templates/ExtbaseModule/List.html
+    :caption: **Revised** EXT:demo/Resources/Private/Templates/ExtbaseModule/List.fluid.html
     :linenos:
 
       <ul>

--- a/Documentation/ExtensionArchitecture/HowTo/Localization/Fluid.rst
+++ b/Documentation/ExtensionArchitecture/HowTo/Localization/Fluid.rst
@@ -12,7 +12,7 @@ Consider you have to translate the following static texts in your Fluid
 template:
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <h3>{post.title}</h3>
    <p>By: {post.author.fullName}</p>
@@ -45,7 +45,7 @@ This ViewHelper has a property called :html:`key` where the identifier of
 the text fragment prefixed by the location file can be provided.
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <f:translate key="my_extension.your_file:yourKey" />
    <!-- or as inline Fluid: -->
@@ -64,7 +64,7 @@ You can provide a default text fragment in the property :html:`default` to
 avoid no text being displayed:
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <f:translate
        key="my_extension.your_file:yourKey"
@@ -80,7 +80,7 @@ In Extbase, the translation file can be detected automatically. It is therefore
 possible to omit the language file prefix.
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <f:translate key="commentHeader" />
    <!-- or as inline Fluid: -->
@@ -103,7 +103,7 @@ It is possible to use the translation file of another extension by supplying
 the parameter :html:`extensionName` with the UpperCamelCased extension key:
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:translate key="commentHeader" extensionName="MyOtherExtension" />
 
@@ -118,7 +118,7 @@ By replacing all static texts with translation ViewHelpers the above example
 can be replaced:
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <h3>{post.title}</h3>
    <p><f:translate key="authorPrefix"> {post.author.fullName}</p>
@@ -146,7 +146,7 @@ options on how to configure the correct language file.
     the translation file, followed by a colon and then the translation key.
 
     .. code-block:: html
-       :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+       :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
        <f:translate
            key="LLL:EXT:my_extension/Resources/Private/Language/yourFile.xlf:yourKey"
@@ -155,7 +155,7 @@ options on how to configure the correct language file.
 #.  Or provide the parameter :html:`extensionName`:
 
     .. code-block:: html
-       :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+       :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
        <f:translate
            key="yourKey"
@@ -272,7 +272,7 @@ syntax the ordering of the arguments can be made clear:
    </trans-unit>
 
 ..  code-block:: html
-    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:translate
        key="author"
@@ -300,7 +300,7 @@ Generally the date or time is formatted by the
 :html:`<f:format.date>` ViewHelper:
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <f:format.date date="{dateObject}" format="d.m.Y" />
    <!-- or -->
@@ -336,7 +336,7 @@ ViewHelper with the :html:`<f:translate>` ViewHelper to supply a localized
 date format:
 
 .. code-block:: html
-   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.html
+   :caption: EXT:my_extension/Resources/Private/Templates/SomeTemplate.fluid.html
 
    <f:format.date date="{dateObject}" format="{f:translate(key: 'dateFormat')}" />
 

--- a/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
+++ b/Documentation/Security/GuidelinesExtensionDevelopment/Index.rst
@@ -85,7 +85,7 @@ changed in our system).
 The form looks like this:
 
 ..  code-block:: html
-    :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.fluid.html
 
     <f:form name="user" object="{user}" action="update">
        <f:form.textbox property="email" />
@@ -214,7 +214,7 @@ object accessors that are used in arguments of a ViewHelper. A short
 example for this:
 
 ..  code-block:: html
-    :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.html
+    :caption: EXT:blog_example/Resources/Private/Templates/SomeTemplate.fluid.html
 
     {variable1}
     <f:format.crop append="{variable2}">a very long text</f:format.crop>


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1464
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf