### PR TITLE
[TASK] Add search query data to `AfterPageTreeItemsPreparedEvent`

### DIFF
--- a/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
+++ b/Documentation/ApiOverview/Events/Events/Backend/AfterPageTreeItemsPreparedEvent.rst
@@ -10,10 +10,19 @@ The PSR-14 event
 :php:`\TYPO3\CMS\Backend\Controller\Event\AfterPageTreeItemsPreparedEvent`
 allows prepared page tree items to be modified.
 
-It is dispatched in the :php:`\TYPO3\CMS\Backend\Controller\Page\TreeController`
+It is dispatched in the :php-short:`\TYPO3\CMS\Backend\Controller\Page\TreeController`
 class after the page tree items have been resolved and prepared. The event
 provides the current PSR-7 request object as well as the page tree items. All
 items contain the corresponding page record in the special :php:`_page` key.
+
+..  versionchanged:: 14.3
+    See `Important: #110233 - Search query added to AfterPageTreeItemsPreparedEvent <https://docs.typo3.org/permalink/changelog:important-110233-1787820210>`_.
+
+The event also provides the current page tree search query via
+:php:`getSearchQuery()`, returning the search phrase used to filter the page
+tree, or :php:`null` if no search is currently active. The event can be
+dispatched in contexts without a PSR-7 request, so :php:`getRequest()` - and
+therefore its return value - is nullable as well.
 
 ..  _AfterPageTreeItemsPreparedEvent-labels:
 

--- a/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_MyEventListener.php
+++ b/Documentation/ApiOverview/Events/Events/Backend/_AfterPageTreeItemsPreparedEvent/_MyEventListener.php
@@ -17,6 +17,8 @@ final readonly class MyEventListener
 {
     public function __invoke(AfterPageTreeItemsPreparedEvent $event): void
     {
+        $searchQuery = $event->getSearchQuery();
+
         $items = $event->getItems();
         foreach ($items as &$item) {
             if (($item['_page']['pid'] ?? null) === 123) {
@@ -36,6 +38,17 @@ final readonly class MyEventListener
                     severity: ContextualFeedbackSeverity::WARNING,
                     priority: 0,
                     icon: 'actions-dot',
+                    overlayIcon: '',
+                );
+            }
+
+            // Indicate which items matched an active page tree search
+            if ($searchQuery !== null) {
+                $item['statusInformation'][] = new StatusInformation(
+                    label: sprintf('Matched search "%s"', $searchQuery),
+                    severity: ContextualFeedbackSeverity::INFO,
+                    priority: 0,
+                    icon: 'actions-search',
                     overlayIcon: '',
                 );
             }

--- a/Documentation/CodeSnippets/Events/Backend/AfterPageTreeItemsPreparedEvent.rst.txt
+++ b/Documentation/CodeSnippets/Events/Backend/AfterPageTreeItemsPreparedEvent.rst.txt
@@ -6,7 +6,10 @@
     Listeners to this event will be able to modify the prepared page tree items for the page tree
 
     ..  php:method:: getRequest()
-        :returns: `\Psr\Http\Message\ServerRequestInterface`
+        :returns: `?\Psr\Http\Message\ServerRequestInterface`
+
+    ..  php:method:: getSearchQuery()
+        :returns: `?string`
 
     ..  php:method:: getItems()
         :returns: `array`


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1826
Releases: main, 14.3
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf