### PR TITLE
[Backport 13.4] [TASK] Add headings to confval blocks without dedicated heading

### DIFF
--- a/Documentation/Administration/Production/OPcache/Index.rst
+++ b/Documentation/Administration/Production/OPcache/Index.rst
@@ -40,6 +40,10 @@ Below is list a of OPcache features with information on how they can impact TYPO
     Setting this to 0 may improve performance but some parts of TYPO3 (including Extbase)
     rely on information stored in phpDoc comments to function correctly.
 
+
+opcache.use_cwd
+---------------
+
 ..  confval:: opcache.use_cwd
 
     :Default: 1
@@ -49,6 +53,10 @@ Below is list a of OPcache features with information on how they can impact TYPO
     that have the same name may get mixed up due to the complete path of the file not
     being stored as a key. TYPO3 works with absolute paths so this would
     return no improvements to performance.
+
+
+opcache.validate_timestamps
+---------------------------
 
 ..  confval:: opcache.validate_timestamps
 
@@ -60,6 +68,10 @@ Below is list a of OPcache features with information on how they can impact TYPO
     be updated in OPcache. This can be achieved by using a proper deployment
     pipeline. Additionally, some files can be added to the blacklist, see `opcache.blacklist_filename` for more information.
 
+
+opcache.revalidate_freq
+-----------------------
+
 ..  confval:: opcache.revalidate_freq
 
     :Default: 2
@@ -67,6 +79,10 @@ Below is list a of OPcache features with information on how they can impact TYPO
 
     Setting this to a high value can improve performance but shares the same issue
     when setting `validate_timestamps` to 0.
+
+
+opcache.revalidate_path
+-----------------------
 
 ..  confval:: opcache.revalidate_path
 
@@ -76,6 +92,10 @@ Below is list a of OPcache features with information on how they can impact TYPO
     Setting this value to 0 should be safe with TYPO3. This may be a problem if
     relative path names are used to load scripts and if the same file exists several
     times in the include path.
+
+
+opcache.max_accelerated_files
+-----------------------------
 
 ..  confval:: opcache.max_accelerated_files
 

--- a/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Backends/Index.rst
@@ -141,6 +141,10 @@ Options of database backends
     This can reduce the size of the cache data table, but incurs CPU overhead
     for compression and decompression.
 
+
+compressionLevel
+~~~~~~~~~~~~~~~~
+
 ..  confval:: compressionLevel
     :name: caching-backend-compressionLevel
     :type: integer from -1 to 9
@@ -241,6 +245,10 @@ Options for the memcached backend
         Same as above
     `unix:///path/to/memcached.sock`
         Connect to memcached server using unix sockets
+
+
+compression
+~~~~~~~~~~~
 
 ..  confval:: compression
     :name: caching-backend-memcached-compression
@@ -349,12 +357,20 @@ Options for the redis caching backend
 
     IP address or name of redis server to connect to.
 
+
+port
+~~~~
+
 ..  confval:: port
     :name: caching-backend-redis-port
     :type: integer
     :default: `6379`
 
     Port of the redis daemon.
+
+
+persistentConnection
+~~~~~~~~~~~~~~~~~~~~
 
 ..  confval:: persistentConnection
     :name: caching-backend-redis-persistentConnection
@@ -363,6 +379,10 @@ Options for the redis caching backend
 
     Activate a persistent connection to a redis server. This is a good idea
     in high load cloud setups.
+
+
+database
+~~~~~~~~
 
 ..  confval:: database
     :name: caching-backend-redis-database
@@ -373,6 +393,10 @@ Options for the redis caching backend
     otherwise caches sharing a database are all flushed if the flush operation
     is issued to one of them. Database numbers 0 and 1 are used and flushed by the Core unit tests
     and should not be used if possible.
+
+
+keyPrefix
+~~~~~~~~~
 
 ..  confval:: keyPrefix
     :name: caching-backend-redis-keyPrefix
@@ -389,6 +413,9 @@ Options for the redis caching backend
     long as the prefix is unique. If only one cache sharing the database has
     no prefix set, flushing it flushes the whole database.
 
+password
+~~~~~~~~
+
 ..  confval:: password
     :name: caching-backend-redis-password
     :type: string
@@ -399,6 +426,10 @@ Options for the redis caching backend
 
         The password is sent to the redis server as plain text.
 
+
+compression
+~~~~~~~~~~~
+
 ..  confval:: compression
     :name: caching-backend-redis-compression
     :type: boolean
@@ -407,6 +438,10 @@ Options for the redis caching backend
     Whether or not data compression with gzip should be enabled.
     This can reduce cache size, but adds some CPU overhead for the compression
     and decompression operations in PHP.
+
+
+compressionLevel
+~~~~~~~~~~~~~~~~
 
 ..  confval:: compressionLevel
     :name: caching-backend-redis-compressionLevel
@@ -589,12 +624,20 @@ Options for the PDO backend
     -   `sqlite:/path/to/sqlite.db`
     -   `sqlite::memory`
 
+
+username
+~~~~~~~~
+
 ..  confval:: username
     :name: caching-backend-pdo-username
     :type: string
 
     Username for the database connection.
 
+
+
+password
+~~~~~~~~
 
 ..  confval:: password
     :name: caching-backend-pdo-password

--- a/Documentation/ApiOverview/CachingFramework/Index.rst
+++ b/Documentation/ApiOverview/CachingFramework/Index.rst
@@ -94,6 +94,10 @@ Various configuration options exist to configure the cHash behavior via
 :ref:`$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash'] <typo3ConfVars_fe_cacheHash>`
 in the file :file:`config/system/settings.php` or :file:`config/system/additional.php`:
 
+
+cachedParametersWhiteList
+-------------------------
+
 ..  confval:: cachedParametersWhiteList
 
     **Only** the given parameters will be evaluated in the cHash calculation.
@@ -104,16 +108,28 @@ in the file :file:`config/system/settings.php` or :file:`config/system/additiona
         parameters except the ones listed here. Caching of pages will not be
         influenced by other parameters beyond the initial caching anymore.
 
+
+requireCacheHashPresenceParameters
+----------------------------------
+
 ..  confval:: requireCacheHashPresenceParameters
 
     Configure parameters that require a cHash. If no cHash is given, but one of
     the parameters are set, then TYPO3 triggers the configured cHash error
     behavior
 
+
+excludedParameters
+------------------
+
 ..  confval:: excludedParameters
 
     The given parameters will be ignored in the cHash calculation.
     Example: `L,tx_search_pi1[query]`
+
+
+excludedParametersIfEmpty
+-------------------------
 
 ..  confval:: excludedParametersIfEmpty
 
@@ -121,10 +137,18 @@ in the file :file:`config/system/settings.php` or :file:`config/system/additiona
     associated value available. Set excludeAllEmptyParameters to true to skip
     all empty parameters.
 
+
+excludeAllEmptyParameters
+-------------------------
+
 ..  confval:: excludeAllEmptyParameters
 
     If true, all parameters relevant to cHash are only considered when they are
     not empty.
+
+
+enforceValidation
+-----------------
 
 ..  confval:: enforceValidation
 

--- a/Documentation/ApiOverview/CodeEditor/Index.rst
+++ b/Documentation/ApiOverview/CodeEditor/Index.rst
@@ -126,6 +126,10 @@ The following configuration options are available:
     Represents the unique identifier of the module (:php:`my/addon` in this
     example).
 
+
+module
+~~~~~~
+
 ..  confval:: module
     :name: code-editor-register-addon-module
     :type: string
@@ -133,17 +137,29 @@ The following configuration options are available:
 
     Holds the JavaScriptModuleInstruction of the CodeMirror module.
 
+
+cssFiles
+~~~~~~~~
+
 ..  confval:: cssFiles
     :name: code-editor-register-addon-cssFiles
     :type: array
 
     Holds all CSS files that must be loaded for the module.
 
+
+options
+~~~~~~~
+
 ..  confval:: options
     :name: code-editor-register-addon-options
     :type: array
 
     Options that are used by the addon.
+
+
+modes
+~~~~~
 
 ..  confval:: modes
     :name: code-editor-register-addon-modes
@@ -180,6 +196,10 @@ The following configuration options are available:
 
         $GLOBALS['TCA']['tt_content']['types']['css']['columnsOverrides']['bodytext']['config']['format'] = 'css';
 
+
+module
+~~~~~~
+
 ..  confval:: module
     :name: code-editor-register-mode-module
     :type: string
@@ -187,12 +207,20 @@ The following configuration options are available:
 
     Holds the JavaScriptModuleInstruction of the CodeMirror module.
 
+
+extensions
+~~~~~~~~~~
+
 ..  confval:: extensions
     :name: code-editor-register-mode-extensions
     :type: array
 
     Binds the mode to specific file extensions. This is important for using
     the code editor in the module :guilabel:`File > Filelist`.
+
+
+default
+~~~~~~~
 
 ..  confval:: default
     :name: code-editor-register-mode-default

--- a/Documentation/ApiOverview/Context/Index.rst
+++ b/Documentation/ApiOverview/Context/Index.rst
@@ -53,11 +53,19 @@ the following properties:
 
     Returns the Unix timestamp as an integer value.
 
+
+timezone
+~~~~~~~~
+
 ..  confval:: timezone
     :name: datetime-aspect-timezone
     :Call: :php:`$this->context->getPropertyFromAspect('date', 'timezone');`
 
     Returns the timezone name, for example, "Germany/Berlin".
+
+
+iso
+~~~
 
 ..  confval:: iso
     :name: datetime-aspect-iso
@@ -66,6 +74,10 @@ the following properties:
     Returns the datetime as string in
     `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601>`__ format, for example,
     "2004-02-12T15:19:21+00:00".
+
+
+full
+~~~~
 
 ..  confval:: full
     :name: datetime-aspect-full
@@ -105,6 +117,10 @@ following properties:
 
     Returns the requested language of the current page as integer (uid).
 
+
+contentId
+~~~~~~~~~
+
 ..  confval:: contentId
     :name: language-aspect-contentId
     :Call: :php:`$this->context->getPropertyFromAspect('language', 'contentId');`
@@ -112,11 +128,19 @@ following properties:
     Returns the language ID of records to be fetched in translation scenarios as
     integer (uid).
 
+
+fallbackChain
+~~~~~~~~~~~~~
+
 ..  confval:: fallbackChain
     :name: language-aspect-fallbackChain
     :Call: :php:`$this->context->getPropertyFromAspect('language', 'fallbackChain');`
 
     Returns the fallback steps as array.
+
+
+overlayType
+~~~~~~~~~~~
 
 ..  confval:: overlayType
     :name: language-aspect-overlayType
@@ -131,6 +155,10 @@ following properties:
 
     See :ref:`context_api_aspects_language_overlay-types` for more details.
 
+
+legacyLanguageMode
+~~~~~~~~~~~~~~~~~~
+
 ..  confval:: legacyLanguageMode
     :name: language-aspect-legacyLanguageMode
     :Call: :php:`$this->context->getPropertyFromAspect('language', 'legacyLanguageMode');`
@@ -143,6 +171,10 @@ following properties:
 
     This property is kept for compatibility reasons. Do not use, if not really
     necessary, the option will be removed rather sooner than later.
+
+
+legacyOverlayType
+~~~~~~~~~~~~~~~~~
 
 ..  confval:: legacyOverlayType
     :name: language-aspect-legacyOverlayType
@@ -235,6 +267,10 @@ following properties:
     Returns the uid of the currently logged in user, `0` if no user is logged
     in.
 
+
+username
+~~~~~~~~
+
 ..  confval:: username
     :name: user-aspect-username
     :Call: :php:`$this->context->getPropertyFromAspect('frontend.user', 'username');` or :php:`$this->context->getPropertyFromAspect('backend.user', 'username');`
@@ -242,11 +278,19 @@ following properties:
     Returns the username of the currently authenticated user. Empty string, if
     no user is logged in.
 
+
+isLoggedIn
+~~~~~~~~~~
+
 ..  confval:: isLoggedIn
     :name: user-aspect-isLoggedIn
     :Call: :php:`$this->context->getPropertyFromAspect('frontend.user', 'isLoggedIn');` or :php:`$this->context->getPropertyFromAspect('backend.user', 'isLoggedIn');`
 
     Returns, whether a user is logged in, as boolean.
+
+
+isAdmin
+~~~~~~~
 
 ..  confval:: isAdmin
     :name: user-aspect-isAdmin
@@ -255,11 +299,19 @@ following properties:
     Returns, whether the user is an administrator, as boolean. It is only useful
     for backend users.
 
+
+groupIds
+~~~~~~~~
+
 ..  confval:: groupIds
     :name: user-aspect-groupIds
     :Call: :php:`$this->context->getPropertyFromAspect('frontend.user', 'groupIds');` or :php:`$this->context->getPropertyFromAspect('backend.user', 'groupIds');`
 
     Returns the groups the user is a member of, as array.
+
+
+groupNames
+~~~~~~~~~~
 
 ..  confval:: groupNames
     :name: user-aspect-groupNames
@@ -297,11 +349,19 @@ the following properties:
 
     Returns, whether hidden pages should be displayed, as boolean.
 
+
+includeHiddenContent
+~~~~~~~~~~~~~~~~~~~~
+
 ..  confval:: includeHiddenContent
     :name: visibility-aspect-includeHiddenContent
     :Call: :php:`$this->context->getPropertyFromAspect('visibility', 'includeHiddenContent');`
 
     Returns, whether hidden content should be displayed, as boolean.
+
+
+includeDeletedRecords
+~~~~~~~~~~~~~~~~~~~~~
 
 ..  confval:: includeDeletedRecords
     :name: visibility-aspect-includeDeletedRecords
@@ -339,12 +399,20 @@ the following properties:
 
     Returns the UID of the currently accessed workspace, as integer.
 
+
+isLive
+~~~~~~
+
 ..  confval:: isLive
     :name: workspace-aspect-isLive
     :Call: :php:`$this->context->getPropertyFromAspect('workspace', 'isLive');`
 
     Returns whether the current workspace is live, or a custom offline
     workspace, as boolean.
+
+
+isOffline
+~~~~~~~~~
 
 ..  confval:: isOffline
     :name: workspace-aspect-isOffline

--- a/Documentation/ApiOverview/DataHandler/Database/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/Database/Index.rst
@@ -84,11 +84,19 @@ Description of keywords in syntax:
     Name of the database table. It must be configured in the
     :php:`$GLOBALS['TCA']` array, otherwise it cannot be processed.
 
+
+uid
+---
+
 ..  confval:: uid
     :name: datahandler-cmd-uid
     :Data type: integer
 
     The UID of the record that is manipulated. This is always an integer.
+
+
+command
+-------
 
 ..  confval:: command
     :name: datahandler-cmd-command
@@ -101,6 +109,10 @@ Description of keywords in syntax:
         record! The first command in the array will be taken.
 
     See :ref:`command keywords and values <datahandler-command-keywords>`
+
+
+value
+-----
 
 ..  confval:: value
     :name: datahandler-cmd-value
@@ -154,6 +166,10 @@ Command keywords and values
             ]
 
 
+
+move
+~~~~
+
 ..  confval:: move
     :name: datahandler-cmd-move
     :DataType: integer
@@ -161,6 +177,10 @@ Command keywords and values
     Works like :confval:`datahandler-cmd-copy` but moves the record instead of
     making a copy.
 
+
+
+delete
+~~~~~~
 
 ..  confval:: delete
     :name: datahandler-cmd-delete
@@ -173,6 +193,10 @@ Command keywords and values
     :ref:`$GLOBALS['TCA'][$table]['ctrl']['delete'] <t3tca:ctrl-reference-delete>`).
 
 
+
+undelete
+~~~~~~~~
+
 ..  confval:: undelete
     :name: datahandler-cmd-undelete
     :Data Type: integer (1)
@@ -181,6 +205,10 @@ Command keywords and values
 
     This action will set the "deleted" flag back to 0.
 
+
+
+localize
+~~~~~~~~
 
 ..  confval:: localize
     :name: datahandler-cmd-localize
@@ -218,6 +246,10 @@ Command keywords and values
     translation wizard.
 
 
+
+copyToLanguage
+~~~~~~~~~~~~~~
+
 ..  confval:: copyToLanguage
     :name: datahandler-cmd-copyToLanguage
     :Data type: integer
@@ -232,6 +264,10 @@ Command keywords and values
     command is used when localizing content elements using translation wizard's
     "Copy" strategy.
 
+
+
+inlineLocalizeSynchronize
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  confval:: inlineLocalizeSynchronize
     :name: datahandler-cmd-inlineLocalizeSynchronize
@@ -250,6 +286,10 @@ Command keywords and values
             'ids' =>  [1, 2, 3],         // array of child IDs to be localized
         ];
 
+
+
+version
+~~~~~~~
 
 ..  confval:: version
     :name: datahandler-cmd-version
@@ -411,6 +451,10 @@ Description of keywords in syntax:
     :php:`$GLOBALS['TCA']` array, otherwise it cannot be processed.
 
 
+
+uid
+---
+
 ..  confval:: uid
     :name: datahandler-data-uid
     :Data type: string|int
@@ -429,6 +473,10 @@ Description of keywords in syntax:
     The occurance of an underscore implies a reference to a record in a table.
 
 
+
+fieldname
+---------
+
 ..  confval:: fieldname
     :name: datahandler-data-fieldname
     :Data type: string
@@ -437,6 +485,10 @@ Description of keywords in syntax:
     table must be configured in
     :ref:`$GLOBALS['TCA'][$table]['columns'] <t3tca:columns>`.
 
+
+
+value
+-----
 
 ..  confval:: value
     :name: datahandler-data-value
@@ -570,6 +622,10 @@ Values for the :php:`$cacheCmd` argument:
     Clear the cache for the page ID given.
 
 
+
+"all"
+-----
+
 ..  confval:: "all"
     :name: datahandler-clear-cachecmd-all
 
@@ -579,6 +635,10 @@ Values for the :php:`$cacheCmd` argument:
     Only available for admin-users unless explicitly allowed by User
     TSconfig "options.clearCache.all".
 
+
+
+"pages"
+-------
 
 ..  confval:: "pages"
     :name: datahandler-clear-cachecmd-pages
@@ -680,6 +740,10 @@ commands or data submission. These are the most significant:
 
     And so on.
 
+
+
+->reverseOrder
+--------------
 
 ..  confval:: ->reverseOrder
     :name: datahandler-flags-reverseOrder

--- a/Documentation/ApiOverview/DataHandler/TceDb/Index.rst
+++ b/Documentation/ApiOverview/DataHandler/TceDb/Index.rst
@@ -26,6 +26,10 @@ takes precedence. The variable names you can use are:
     headline">`.
 
 
+
+cmd
+---
+
 ..  confval:: cmd
     :name: datahandler-commit-cmd
     :Data type: array
@@ -39,12 +43,20 @@ takes precedence. The variable names you can use are:
     element with UID 123.
 
 
+
+cacheCmd
+--------
+
 ..  confval:: cacheCmd
     :name: datahandler-commit-cacheCmd
     :Data type: string
 
     Cache command sent to :php:`DataHandler->clear_cacheCmd()`.
 
+
+
+redirect
+--------
 
 ..  confval:: redirect
     :name: datahandler-commit-redirect
@@ -54,6 +66,10 @@ takes precedence. The variable names you can use are:
     operations (unless errors has occurred).
 
 
+
+flags
+-----
+
 ..  confval:: flags
     :name: datahandler-commit-flags
     :Data type: array
@@ -61,6 +77,10 @@ takes precedence. The variable names you can use are:
     Accepts options to be set in DataHandler object. Currently, it supports
     "reverseOrder" (boolean).
 
+
+
+mirror
+------
 
 ..  confval:: mirror
     :name: datahandler-commit-mirror
@@ -71,12 +91,20 @@ takes precedence. The variable names you can use are:
     `[data][table][33]`.
 
 
+
+CB
+--
+
 ..  confval:: CB
     :name: datahandler-commit-cb
     :Data type: array
 
     Clipboard command array. May trigger changes in "cmd".
 
+
+
+vC
+--
 
 ..  confval:: vC
     :name: datahandler-commit-vc

--- a/Documentation/ApiOverview/Database/DoctrineDbal/Middleware/Index.rst
+++ b/Documentation/ApiOverview/Database/DoctrineDbal/Middleware/Index.rst
@@ -143,6 +143,10 @@ structure for a middleware configuration is:
 
     The fully-qualified class name of the driver middleware.
 
+
+before
+------
+
 ..  confval:: before
 
     :Data type: list of strings
@@ -151,6 +155,10 @@ structure for a middleware configuration is:
 
     A list of middleware identifiers the current middleware should be registered
     before.
+
+
+after
+-----
 
 ..  confval:: after
 
@@ -166,6 +174,10 @@ structure for a middleware configuration is:
         placed after the `'typo3/core/custom-platform-driver-middleware'` and
         `'typo3/core/custom-pdo-driver-result-middleware'` driver middlewares to
         ensure essential Core driver middlewares have been processed first.
+
+
+disabled
+--------
 
 ..  confval:: disabled
 

--- a/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
+++ b/Documentation/ApiOverview/FlexForms/T3datastructure/Elements/Index.rst
@@ -35,12 +35,20 @@ must be arrays.)
     This is the root element of a T3DataStructure. It may contain tags
     `<meta>` and `<ROOT>` or `<sheets>`
 
+
+<meta>
+------
+
 ..  confval:: <meta>
     :name: t3datastructure-meta
     :type: array
 
     Can contain application specific meta settings. Interpretation depends on
     the application using the T3DataStructure. Each setting goes to a XML tag.
+
+
+<ROOT>
+------
 
 ..  confval:: <ROOT>
     :name: t3datastructure-root
@@ -55,6 +63,10 @@ must be arrays.)
     Can have the following child tags: `<type>`, `<section>`, `<el>`
     `<[application tag]>`.
 
+
+<[field name]>
+--------------
+
 ..  confval:: <[field name]>
     :name: t3datastructure-field-name
     :type: array
@@ -63,6 +75,10 @@ must be arrays.)
     objects name.
 
     Can have the same child tags like `<ROOT>`.
+
+
+<sheets>
+--------
 
 ..  confval:: <sheets>
     :name: t3datastructure-sheets
@@ -73,6 +89,10 @@ must be arrays.)
 
     Contains `<[sheet name]>` tags for the actual sheets.
 
+
+<sheetTitle>
+------------
+
 ..  confval:: <sheetTitle>
     :name: t3datastructure-sheet-title
     :type: string or LLL reference
@@ -81,6 +101,10 @@ must be arrays.)
     gets "General" in this case). Can be a plain string or a reference to
     a language file using standard LLL syntax. Ignored if sheets are not
     defined for the FlexForm.
+
+
+<displayCond>
+-------------
 
 ..  confval:: <displayCond>
     :name: t3datastructure-display-cond
@@ -92,6 +116,10 @@ must be arrays.)
     For more details refer to the description of the "displayCond" property
     in the :ref:`TCA Reference <t3tca:columns>`.
 
+
+<[sheet ident]>
+---------------
+
 ..  confval:: <[sheet ident]>
     :name: t3datastructure-sheet-ident
     :type: array
@@ -100,6 +128,10 @@ must be arrays.)
 
     Alternatively, it can be a plain value referring to another
     XML file which contains the <ROOT> structure. See example later.
+
+
+<el>
+----
 
 ..  confval:: <el>
     :name: t3datastructure-el
@@ -145,6 +177,10 @@ must be strings or integers.)
         data structure. For FlexForms this object would draw a form element.
 
     If the parent is `<ROOT>` this tag must have the value `"array"`.
+
+
+<section>
+---------
 
 ..  confval:: <section>
     :name: t3datastructure-section

--- a/Documentation/ApiOverview/Logging/Logger/Index.rst
+++ b/Documentation/ApiOverview/Logging/Logger/Index.rst
@@ -56,11 +56,19 @@ which takes three parameters:
     One of the defined log levels, see the section
     :ref:`logging-logger-shortcuts`.
 
+
+$message
+--------
+
 ..  confval:: $message
     :name: logger-log-message
     :Type: string | :php:`\Stringable`
 
     The log message itself.
+
+
+$data
+-----
 
 ..  confval:: $data
     :name: logger-log-data
@@ -113,6 +121,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     development of PHP code.
 
 ..  _label-Informational:
+
+Informational
+-------------
+
 ..  confval:: Informational
     :name: logger-info
     :Class constant: :php:`\Psr\Log\LogLevel::INFO`
@@ -125,6 +137,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   Logging of SQL statements.
 
 ..  _label-notice:
+
+Notice
+------
+
 ..  confval:: Notice
     :name: logger-notice
     :Class constant: :php:`\Psr\Log\LogLevel::NOTICE`
@@ -137,6 +153,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   Logging of SQL statements.
 
 ..  _label-warning:
+
+Warning
+-------
+
 ..  confval:: Warning
     :name: logger-warning
     :Class constant: :php:`\Psr\Log\LogLevel::WARNING`
@@ -148,6 +168,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   Undesirable events that are not necessarily wrong.
 
 ..  _label-error:
+
+Error
+-----
+
 ..  confval:: Error
     :name: logger-error
     :Class constant: :php:`\Psr\Log\LogLevel::ERROR`
@@ -160,6 +184,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   A white screen is shown.
 
 ..  _label-critical:
+
+Critical
+--------
+
 ..  confval:: Critical
     :name: logger-critical
     :Class constant: :php:`\Psr\Log\LogLevel::CRITICAL`
@@ -172,6 +200,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   Data is corrupt or outdated.
 
 ..  _label-alert:
+
+Alert
+-----
+
 ..  confval:: Alert
     :name: logger-alert
     :Class constant: :php:`\Psr\Log\LogLevel::ALERT`
@@ -183,6 +215,10 @@ For each of the severity levels mentioned below, a shorthand method exists in
     *   The database is unavailable.
 
 .. _label-emergency:
+
+Emergency
+---------
+
 ..  confval:: Emergency
     :name: logger-emergency
     :Class constant: :php:`\Psr\Log\LogLevel::EMERGENCY`

--- a/Documentation/ApiOverview/Logging/Processors/Index.rst
+++ b/Documentation/ApiOverview/Logging/Processors/Index.rst
@@ -66,6 +66,10 @@ Options
 
     Adds a full backtrace stack to the log.
 
+
+shiftBackTraceLevel
+```````````````````
+
 ..  confval:: shiftBackTraceLevel
     :name: logging-processors-introspection-shiftBackTraceLevel
     :Mandatory: no
@@ -98,6 +102,10 @@ Options
     Use the `real size of memory <https://www.php.net/manual/en/function.memory-get-usage.php#refsect1-function.memory-get-usage-parameters>`__
     allocated from system instead of :php:`emalloc()` value.
 
+
+formatSize
+``````````
+
 ..  confval:: formatSize
     :name: logging-processors-memory-formatSize
     :Mandatory: no
@@ -129,6 +137,10 @@ Options
 
     Use the `real size of memory <https://www.php.net/manual/en/function.memory-get-peak-usage.php#refsect1-function.memory-get-peak-usage-parameters>`__
     allocated from system instead of :php:`emalloc()` value.
+
+
+formatSize
+``````````
 
 ..  confval:: formatSize
     :name: logging-processors-memory-peak-formatSize

--- a/Documentation/ApiOverview/Logging/Writers/Index.rst
+++ b/Documentation/ApiOverview/Logging/Writers/Index.rst
@@ -108,6 +108,10 @@ set, TYPO3 will use a filename containing a random hash, like
 
 The following options are available:
 
+
+logFile
+~~~~~~~
+
 ..  confval:: logFile
     :name: file-writer-logFile
     :type: string
@@ -116,6 +120,10 @@ The following options are available:
               (for example, like :file:`typo3temp/logs/typo3_7ac500bce5.log`)
 
     The path to the log file.
+
+
+logFileInfix
+~~~~~~~~~~~~
 
 ..  confval:: logFileInfix
     :name: file-writer-logFileInfix
@@ -173,6 +181,10 @@ The file writer :php:`\TYPO3\CMS\Core\Log\Writer\RotatingFileWriter` extends the
 :ref:`FileWriter <logging-writers-FileWriter>` class. The :php:`RotatingFileWriter`
 accepts all options of :php:`FileWriter` in addition of the following:
 
+
+interval
+~~~~~~~~
+
 ..  confval:: interval
     :name: rotating-file-writer-interval
     :type: :php:`\TYPO3\CMS\Core\Log\Writer\Enum\Interval`, string
@@ -186,6 +198,10 @@ accepts all options of :php:`FileWriter` in addition of the following:
     *   :php:`\TYPO3\CMS\Core\Log\Writer\Enum\Interval::WEEKLY` or :php:`weekly`
     *   :php:`\TYPO3\CMS\Core\Log\Writer\Enum\Interval::MONTHLY` or :php:`monthly`
     *   :php:`\TYPO3\CMS\Core\Log\Writer\Enum\Interval::YEARLY` or :php:`yearly`
+
+
+maxFiles
+~~~~~~~~
 
 ..  confval:: maxFiles
     :name: rotating-file-writer-maxFiles

--- a/Documentation/ApiOverview/Rte/Transformations/Overview.rst
+++ b/Documentation/ApiOverview/Rte/Transformations/Overview.rst
@@ -55,6 +55,10 @@ Transformation filters
    nowadays outdated markup like :code:`<font>` tag style rendering in the
    frontend.
 
+
+ts_links
+--------
+
 .. confval:: ts_links
 
    :Scope: RTE Transformation filter

--- a/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
+++ b/Documentation/ApiOverview/SiteHandling/AddLanguages.rst
@@ -55,6 +55,10 @@ Configuration properties
     Defines, if the language is visible on the frontend. Editors in the TYPO3
     backend will still be able to translate content for the language.
 
+
+languageId
+----------
+
 ..  confval:: languageId
     :name: sitehandling-addingLanguages-languageId
     :type: integer
@@ -68,6 +72,10 @@ Configuration properties
         Once pages, content or records are created in a specific language, the
         :yaml:`languageId` must not be changed anymore.
 
+
+title
+-----
+
 ..  confval:: title
     :name: sitehandling-addingLanguages-title
     :type: string
@@ -75,12 +83,20 @@ Configuration properties
 
     The internal human-readable name for this language.
 
+
+websiteTitle
+------------
+
 ..  confval:: websiteTitle
     :name: sitehandling-addingLanguages-websiteTitle
     :type: string
     :Example: :yaml:`My custom very British title`
 
     Overrides the global website title for this language.
+
+
+navigationTitle
+---------------
 
 ..  confval:: navigationTitle
     :name: sitehandling-addingLanguages-navigationTitle
@@ -90,12 +106,20 @@ Configuration properties
     Optional navigation title which is used in
     :typoscript:`HMENU.special = language`.
 
+
+base
+----
+
 ..  confval:: base
     :name: sitehandling-addingLanguages-base
     :type: string / URL
     :Example: :yaml:`/uk/`
 
     The language base accepts either a URL or a path segment like :yaml:`/en/`.
+
+
+baseVariants
+------------
 
 ..  confval:: baseVariants
     :name: sitehandling-addingLanguages-baseVariants
@@ -134,6 +158,10 @@ Configuration properties
     iterate through the locales from left to right until it finds a locale that
     is installed on the server.
 
+
+hreflang
+~~~~~~~~
+
 ..  confval:: hreflang
     :name: sitehandling-addingLanguages-hreflang
     :type: string
@@ -154,6 +182,10 @@ Configuration properties
     *   You want to explicitly set :yaml:`x-default` for a specific language,
         which is clearly not a valid language key.
 
+
+typo3Language
+~~~~~~~~~~~~~
+
 ..  confval:: typo3Language
     :name: sitehandling-addingLanguages-typo3Language
     :type: string
@@ -167,6 +199,10 @@ Configuration properties
 
     Language identifier to use in TYPO3 :ref:`XLIFF files <xliff_api>`.
 
+
+flag
+~~~~
+
 ..  confval:: flag
     :name: sitehandling-addingLanguages-flag
     :type: string
@@ -174,6 +210,10 @@ Configuration properties
 
     The flag identifier. For example, the flag is displayed in the backend page
     module.
+
+
+fallbackType
+~~~~~~~~~~~~
 
 ..  confval:: fallbackType
     :name: sitehandling-addingLanguages-fallbackType
@@ -204,6 +244,10 @@ Configuration properties
         (available) language.
 
         It behaves like old :typoscript:`config.sys_language_overlay = 0`.
+
+
+fallbacks
+~~~~~~~~~
 
 ..  confval:: fallbacks
     :name: sitehandling-addingLanguages-fallbacks

--- a/Documentation/ApiOverview/SystemRegistry/Index.rst
+++ b/Documentation/ApiOverview/SystemRegistry/Index.rst
@@ -103,6 +103,10 @@ table:
 
     Primary key, needed for replication and also useful as an index.
 
+
+entry_namespace
+---------------
+
 ..  confval:: entry_namespace
     :name: sys-registry-entry-namespace
     :type: varchar(128)
@@ -114,6 +118,10 @@ table:
     The purpose of namespaces is that entries with the same key can exist
     within different namespaces.
 
+
+entry_key
+---------
+
 ..  confval:: entry_key
     :name: sys-registry-entry-key
     :type: varchar(128)
@@ -122,6 +130,10 @@ table:
     whole table. The key can be any string to identify the entry. It is
     recommended to use dots as dividers, if necessary. In this way, the
     naming is similar to the syntax already known in TypoScript.
+
+
+entry_value
+-----------
 
 ..  confval:: entry_value
     :name: sys-registry-entry-value

--- a/Documentation/Configuration/GlobalVariables.rst
+++ b/Documentation/Configuration/GlobalVariables.rst
@@ -27,6 +27,10 @@ $GLOBALS
     :guilabel:`Admin Tools > Settings > Configure Installation-Wide Options`.
 
 
+
+TCA
+---
+
 ..  confval:: TCA
     :name: globals-tca
     :Path: $GLOBALS
@@ -37,6 +41,10 @@ $GLOBALS
     See :ref:`TCA Reference <t3tca:start>`
 
 
+
+T3_SERVICES
+-----------
+
 ..  confval:: T3_SERVICES
     :name: globals-t3-services
     :Path: $GLOBALS
@@ -46,6 +54,10 @@ $GLOBALS
 
     Global registration of :ref:`services <services-introduction>`.
 
+
+TYPO3_USER_SETTINGS
+-------------------
+
 ..  confval:: TYPO3_USER_SETTINGS
     :name: globals-typo3-user-settings
     :Path: $GLOBALS
@@ -53,6 +65,10 @@ $GLOBALS
     :Defined: :file:`typo3/sysext/setup/ext_tables.php`
 
     Defines the form in the :guilabel:`User Settings`.
+
+
+BE_USER
+-------
 
 ..  confval:: BE_USER
     :name: globals-be-users
@@ -63,6 +79,10 @@ $GLOBALS
 
     Backend user object. See :ref:`be-user`.
 
+
+
+EXEC_TIME
+---------
 
 ..  confval:: EXEC_TIME
     :name: globals-exec-time
@@ -80,6 +100,10 @@ $GLOBALS
         :ref:`DateTime Aspect <context_api_aspects_datetime>`.
 
 
+
+SIM_EXEC_TIME
+-------------
+
 ..  confval:: SIM_EXEC_TIME
     :name: globals-sim-exec-time
     :Path: $GLOBALS
@@ -95,6 +119,10 @@ $GLOBALS
 
         Should not be used anymore, rather use the
         :ref:`DateTime Aspect <context_api_aspects_datetime>`.
+
+
+LANG
+----
 
 ..  confval:: LANG
     :name: globals-lang

--- a/Documentation/Configuration/Typo3ConfVars/BE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/BE.rst
@@ -26,6 +26,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_fileadminDir:
 
+
+fileadminDir
+------------
+
 ..  confval:: fileadminDir
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['fileadminDir']
     :name: globals-typo3-conf-vars-be-fileadminDir
@@ -38,6 +42,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     :php:`\TYPO3\CMS\Core\Resource\ResourceFactory::getDefaultStorage()`.
 
 ..  _typo3ConfVars_be_lockBackendFile:
+
+
+lockBackendFile
+---------------
 
 ..  confval:: lockBackendFile
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockBackendFile']
@@ -52,6 +60,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     changes or during critical updates.
 
 ..  _typo3ConfVars_be_lockRootPath:
+
+
+lockRootPath
+------------
 
 ..  confval:: lockRootPath
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockRootPath']
@@ -74,6 +86,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_userHomePath:
 
+
+userHomePath
+------------
+
 ..  confval:: userHomePath
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['userHomePath']
     :name: globals-typo3-conf-vars-be-userHomePath
@@ -86,6 +102,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     The home directory identifier of backend user 2 would be: :php:`2:users/2/`. End slash required!
 
 ..  _typo3ConfVars_be_groupHomePath:
+
+
+groupHomePath
+-------------
 
 ..  confval:: groupHomePath
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['groupHomePath']
@@ -100,6 +120,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_userUploadDir:
 
+
+userUploadDir
+-------------
+
 ..  confval:: userUploadDir
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['userUploadDir']
     :name: globals-typo3-conf-vars-be-userUploadDir
@@ -111,6 +135,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     is :file:`/upload`  then :file:`../123_user/upload` will be mounted.
 
 ..  _typo3ConfVars_be_warning_email_addr:
+
+
+warning_email_addr
+------------------
 
 ..  confval:: warning_email_addr
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_email_addr']
@@ -127,6 +155,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     <security-global-typo3-options-warning-email-addr>`.
 
 ..  _typo3ConfVars_be_warning_mode:
+
+
+warning_mode
+------------
 
 ..  confval:: warning_mode
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['warning_mode']
@@ -148,6 +180,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_passwordReset:
 
+
+passwordReset
+-------------
+
 ..  confval:: passwordReset
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordReset']
     :name: globals-typo3-conf-vars-be-passwordReset
@@ -161,6 +197,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_passwordResetForAdmins:
 
+
+passwordResetForAdmins
+----------------------
+
 ..  confval:: passwordResetForAdmins
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordResetForAdmins']
     :name: globals-typo3-conf-vars-be-passwordResetForAdmins
@@ -172,6 +212,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     increased security.
 
 ..  _typo3ConfVars_be_requireMfa:
+
+
+requireMfa
+----------
 
 ..  confval:: requireMfa
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['requireMfa']
@@ -196,6 +240,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_recommendedMfaProvider:
 
+
+recommendedMfaProvider
+----------------------
+
 ..  confval:: recommendedMfaProvider
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['recommendedMfaProvider']
     :name: globals-typo3-conf-vars-be-recommendedMfaProvider
@@ -207,6 +255,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     Recommended for all users.
 
 ..  _typo3ConfVars_be_loginRateLimit:
+
+
+loginRateLimit
+--------------
 
 ..  confval:: loginRateLimit
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimit']
@@ -220,6 +272,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     :php:`"0"` will disable login rate limiting.
 
 ..  _typo3ConfVars_be_loginRateLimitInterval:
+
+
+loginRateLimitInterval
+----------------------
 
 ..  confval:: loginRateLimitInterval
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitInterval']
@@ -235,6 +291,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_loginRateLimitIpExcludeList:
 
+
+loginRateLimitIpExcludeList
+---------------------------
+
 ..  confval:: loginRateLimitIpExcludeList
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['loginRateLimitIpExcludeList']
     :name: globals-typo3-conf-vars-be-loginRateLimitIpExcludeList
@@ -246,6 +306,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     An empty value disables the exclude list check.
 
 ..  _typo3ConfVars_be_lockIP:
+
+
+lockIP
+------
 
 ..  confval:: lockIP
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIP']
@@ -271,6 +335,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     <security-global-typo3-options-lockIP>`.
 
 ..  _typo3ConfVars_be_lockIPv6:
+
+
+lockIPv6
+--------
 
 ..  confval:: lockIPv6
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockIPv6']
@@ -302,6 +370,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_sessionTimeout:
 
+
+sessionTimeout
+--------------
+
 ..  confval:: sessionTimeout
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['sessionTimeout']
     :name: globals-typo3-conf-vars-be-sessionTimeout
@@ -312,6 +384,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     180 to avoid side effects. The default is 28800 seconds = 8 hours.
 
 ..  _typo3ConfVars_be_IPmaskList:
+
+
+IPmaskList
+----------
 
 ..  confval:: IPmaskList
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['IPmaskList']
@@ -332,6 +408,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_lockSSL:
 
+
+lockSSL
+-------
+
 ..  confval:: lockSSL
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL']
     :name: globals-typo3-conf-vars-be-lockSSL
@@ -347,6 +427,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_lockSSLPort:
 
+
+lockSSLPort
+-----------
+
 ..  confval:: lockSSLPort
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSLPort']
     :name: globals-typo3-conf-vars-be-lockSSLPort
@@ -357,6 +441,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     lockSSL and the HTTPS port of your webserver is not 443.
 
 ..  _typo3ConfVars_be_cookieDomain:
+
+
+cookieDomain
+------------
 
 ..  confval:: cookieDomain
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieDomain']
@@ -370,6 +458,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_cookieName:
 
+
+cookieName
+----------
+
 ..  confval:: cookieName
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieName']
     :name: globals-typo3-conf-vars-be-cookieName
@@ -379,6 +471,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     Set the cookie name for the back-end user session.
 
 ..  _typo3ConfVars_be_cookieSameSite:
+
+
+cookieSameSite
+--------------
 
 ..  confval:: cookieSameSite
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['cookieSameSite']
@@ -403,6 +499,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_showRefreshLoginPopup:
 
+
+showRefreshLoginPopup
+---------------------
+
 ..  confval:: showRefreshLoginPopup
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['showRefreshLoginPopup']
     :name: globals-typo3-conf-vars-be-showRefreshLoginPopup
@@ -415,6 +515,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     relogin window.
 
 ..  _typo3ConfVars_be_adminOnly:
+
+
+adminOnly
+---------
 
 ..  confval:: adminOnly
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['adminOnly']
@@ -437,6 +541,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_disable_exec_function:
 
+
+disable_exec_function
+---------------------
+
 ..  confval:: disable_exec_function
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['disable_exec_function']
     :name: globals-typo3-conf-vars-be-disable_exec_function
@@ -449,6 +557,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     system commands using exec() can be used, unless this is disabled.
 
 ..  _typo3ConfVars_be_compressionLevel:
+
+
+compressionLevel
+----------------
 
 ..  confval:: compressionLevel
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['compressionLevel']
@@ -471,6 +583,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     recommended and most optimal value is `5`.
 
 ..  _typo3ConfVars_be_installToolPassword:
+
+
+installToolPassword
+-------------------
 
 ..  confval:: installToolPassword
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['installToolPassword']
@@ -537,6 +653,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_defaultPermissions:
 
+
+defaultPermissions
+------------------
+
 ..  confval:: defaultPermissions
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultPermissions']
     :name: globals-typo3-conf-vars-be-defaultPermissions
@@ -573,6 +693,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_defaultUC:
 
+
+defaultUC
+---------
+
 ..  confval:: defaultUC
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['defaultUC']
     :name: globals-typo3-conf-vars-be-defaultUC
@@ -602,6 +726,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_customPermOptions:
 
+
+customPermOptions
+-----------------
+
 ..  confval:: customPermOptions
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']
     :name: globals-typo3-conf-vars-be-customPermOptions
@@ -624,6 +752,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     Keys cannot contain any of the following characters: :php:`:|,`.
 
 ..  _typo3ConfVars_be_fileDenyPattern:
+
+
+fileDenyPattern
+---------------
 
 ..  confval:: fileDenyPattern
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['fileDenyPattern']
@@ -657,6 +789,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_versionNumberInFilename:
 
+
+versionNumberInFilename
+-----------------------
+
 ..  confval:: versionNumberInFilename
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['versionNumberInFilename']
     :name: globals-typo3-conf-vars-be-versionNumberInFilename
@@ -677,6 +813,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_debug:
 
+
+debug
+-----
+
 ..  confval:: debug
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['debug']
     :name: globals-typo3-conf-vars-be-debug
@@ -692,6 +832,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     setting.
 
 ..  _typo3ConfVars_be_HTTP:
+
+
+HTTP
+----
 
 ..  confval:: HTTP
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['HTTP']
@@ -721,6 +865,10 @@ The following configuration variables can be used to configure the TYPO3 backend
         :ref:`$GLOBALS[TYPO3_CONF_VARS][BE][lockSSL] <typo3ConfVars_be_lockSSL>`
         is enabled.
 
+
+
+passwordHashing
+---------------
 
 ..  confval:: passwordHashing
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordHashing']
@@ -760,6 +908,10 @@ The following configuration variables can be used to configure the TYPO3 backend
 
 ..  _typo3ConfVars_be_passwordPolicy:
 
+
+passwordPolicy
+--------------
+
 ..  confval:: passwordPolicy
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['passwordPolicy']
     :name: globals-typo3-conf-vars-be-passwordPolicy
@@ -769,6 +921,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     Defines the :ref:`password policy <password-policies>` in the backend context.
 
 ..  _typo3ConfVars_be_stylesheets:
+
+
+stylesheets
+-----------
 
 ..  confval:: stylesheets
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets']
@@ -796,6 +952,10 @@ The following configuration variables can be used to configure the TYPO3 backend
             = 'EXT:my_extension/Resources/Public/Css/';
 
 ..  _typo3ConfVars_be_contentSecurityPolicyReportingUrl:
+
+
+contentSecurityPolicyReportingUrl
+---------------------------------
 
 ..  confval:: contentSecurityPolicyReportingUrl
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['contentSecurityPolicyReportingUrl']
@@ -831,6 +991,10 @@ The following configuration variables can be used to configure the TYPO3 backend
     to configure Content Security Policy reporting for the frontend.
 
 ..  _typo3ConfVars_be_entryPoint:
+
+
+entryPoint
+----------
 
 ..  confval:: entryPoint
     :Path: $GLOBALS['TYPO3_CONF_VARS']['BE']['entryPoint']

--- a/Documentation/Configuration/Typo3ConfVars/DB.rst
+++ b/Documentation/Configuration/Typo3ConfVars/DB.rst
@@ -28,6 +28,10 @@ the connection to the database:
 
 ..  _typo3ConfVars_db_additionalQueryRestrictions:
 
+
+additionalQueryRestrictions
+---------------------------
+
 ..  confval:: additionalQueryRestrictions
     :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']['additionalQueryRestrictions']
     :name: typo3-conf-vars-db-additionalQueryRestrictions
@@ -39,6 +43,10 @@ the connection to the database:
     Have a look into the chapter :ref:`database-custom-restrictions` for details.
 
 ..  _typo3ConfVars_db_connections:
+
+
+Connections
+-----------
 
 ..  confval:: Connections
     :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']
@@ -288,6 +296,10 @@ the connection to the database:
         For example, database session options.
 
 ..  _typo3ConfVars_db_tablemapping:
+
+
+TableMapping
+------------
 
 ..  confval:: TableMapping
     :Path: $GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']

--- a/Documentation/Configuration/Typo3ConfVars/EXT.rst
+++ b/Documentation/Configuration/Typo3ConfVars/EXT.rst
@@ -34,6 +34,10 @@ the Extension manager:
     TYPO3_CONF_VARS SYS; excludeForPackaging
 ..  _typo3ConfVars_ext_excludeForPackaging:
 
+
+excludeForPackaging
+-------------------
+
 ..  confval:: excludeForPackaging
     :name: globals-typo3-conf-vars-excludeForPackaging
     :Path: $GLOBALS['TYPO3_CONF_VARS']['EXT']['excludeForPackaging']

--- a/Documentation/Configuration/Typo3ConfVars/FE.rst
+++ b/Documentation/Configuration/Typo3ConfVars/FE.rst
@@ -27,6 +27,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_addAllowedPaths:
 
+
+addAllowedPaths
+---------------
+
 ..  confval:: addAllowedPaths
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['addAllowedPaths']
     :name: typo3-conf-vars-fe-addAllowedPaths
@@ -45,6 +49,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_debug:
 
+
+debug
+-----
+
 ..  confval:: debug
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['debug']
     :name: typo3-conf-vars-fe-debug
@@ -56,6 +64,10 @@ the TYPO3 frontend:
     TypoScript option :php:`config.debug = 0`.
 
 ..  _typo3ConfVars_fe_compressionLevel:
+
+
+compressionLevel
+----------------
 
 ..  confval:: compressionLevel
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']
@@ -78,6 +90,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_pageNotFoundOnCHashError:
 
+
+pageNotFoundOnCHashError
+------------------------
+
 ..  confval:: pageNotFoundOnCHashError
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['pageNotFoundOnCHashError']
     :name: typo3-conf-vars-fe-pageNotFoundOnCHashError
@@ -88,6 +104,10 @@ the TYPO3 frontend:
     otherwise caching is disabled and page output is displayed.
 
 ..  _typo3ConfVars_fe_pageUnavailable_force:
+
+
+pageUnavailable_force
+---------------------
 
 ..  confval:: pageUnavailable_force
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['pageUnavailable_force']
@@ -114,6 +134,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_checkFeUserPid:
 
+
+checkFeUserPid
+--------------
+
 ..  confval:: checkFeUserPid
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['checkFeUserPid']
     :name: typo3-conf-vars-fe-checkFeUserPid
@@ -128,6 +152,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_loginRateLimit:
 
+
+loginRateLimit
+--------------
+
 ..  confval:: loginRateLimit
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimit']
     :name: typo3-conf-vars-fe-loginRateLimit
@@ -140,6 +168,10 @@ the TYPO3 frontend:
     :php:`"0"` will disable login rate limiting.
 
 ..  _typo3ConfVars_fe_loginRateLimitInterval:
+
+
+loginRateLimitInterval
+----------------------
 
 ..  confval:: loginRateLimitInterval
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitInterval']
@@ -155,6 +187,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_loginRateLimitIpExcludeList:
 
+
+loginRateLimitIpExcludeList
+---------------------------
+
 ..  confval:: loginRateLimitIpExcludeList
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['loginRateLimitIpExcludeList']
     :name: typo3-conf-vars-fe-loginRateLimitIpExcludeList
@@ -167,6 +203,10 @@ the TYPO3 frontend:
     An empty value disables the exclude list check.
 
 ..  _typo3ConfVars_fe_lockIP:
+
+
+lockIP
+------
 
 ..  confval:: lockIP
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIP']
@@ -199,6 +239,10 @@ the TYPO3 frontend:
     <security-global-typo3-options-lockIP>`.
 
 ..  _typo3ConfVars_fe_lockIPv6:
+
+
+lockIPv6
+--------
 
 ..  confval:: lockIPv6
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['lockIPv6']
@@ -246,6 +290,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_lifetime:
 
+
+lifetime
+--------
+
 ..  confval:: lifetime
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['lifetime']
     :name: typo3-conf-vars-fe-lifetime
@@ -261,6 +309,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_sessionTimeout:
 
+
+sessionTimeout
+--------------
+
 ..  confval:: sessionTimeout
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionTimeout']
     :name: typo3-conf-vars-fe-sessionTimeout
@@ -271,6 +323,10 @@ the TYPO3 frontend:
     be overwritten by the lifetime property if the lifetime is longer.
 
 ..  _typo3ConfVars_fe_sessionDataLifetime:
+
+
+sessionDataLifetime
+-------------------
 
 ..  confval:: sessionDataLifetime
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['sessionDataLifetime']
@@ -283,6 +339,10 @@ the TYPO3 frontend:
     (86400 seconds represents 24 hours).
 
 ..  _typo3ConfVars_fe_permalogin:
+
+
+permalogin
+----------
 
 ..  confval:: permalogin
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['permalogin']
@@ -309,6 +369,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_cookieDomain:
 
+
+cookieDomain
+------------
+
 ..  confval:: cookieDomain
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieDomain']
     :name: typo3-conf-vars-fe-cookieDomain
@@ -321,6 +385,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_cookieName:
 
+
+cookieName
+----------
+
 ..  confval:: cookieName
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieName']
     :name: typo3-conf-vars-fe-cookieName
@@ -330,6 +398,10 @@ the TYPO3 frontend:
     Sets the name for the cookie used for the front-end user session
 
 ..  _typo3ConfVars_fe_cookieSameSite:
+
+
+cookieSameSite
+--------------
 
 ..  confval:: cookieSameSite
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['cookieSameSite']
@@ -352,6 +424,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_defaultTypoScript_constants:
 
+
+defaultTypoScript_constants
+---------------------------
+
 ..  confval:: defaultTypoScript_constants
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_constants']
     :name: typo3-conf-vars-fe-defaultTypoScript-constants
@@ -361,6 +437,10 @@ the TYPO3 frontend:
     Enter lines of default TypoScript, constants-field.
 
 ..  _typo3ConfVars_fe_defaultTypoScript_setup:
+
+
+defaultTypoScript_setup
+-----------------------
 
 ..  confval:: defaultTypoScript_setup
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_setup']
@@ -388,6 +468,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_enable_mount_pids:
 
+
+enable_mount_pids
+-----------------
+
 ..  confval:: enable_mount_pids
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['enable_mount_pids']
     :name: typo3-conf-vars-fe-enable-mount-pids
@@ -398,6 +482,10 @@ the TYPO3 frontend:
     (for frontend operation) is allowed.
 
 ..  _typo3ConfVars_fe_hidePagesIfNotTranslatedByDefault:
+
+
+hidePagesIfNotTranslatedByDefault
+---------------------------------
 
 ..  confval:: hidePagesIfNotTranslatedByDefault
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['hidePagesIfNotTranslatedByDefault']
@@ -411,6 +499,10 @@ the TYPO3 frontend:
     "Show page even if no translation exists"
 
 ..  _typo3ConfVars_fe_eID_include:
+
+
+eID_include
+-----------
 
 ..  confval:: eID_include
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']
@@ -428,6 +520,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_disableNoCacheParameter:
 
+
+disableNoCacheParameter
+-----------------------
+
 ..  confval:: disableNoCacheParameter
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['disableNoCacheParameter']
     :name: typo3-conf-vars-fe-disableNoCacheParameter
@@ -443,6 +539,10 @@ the TYPO3 frontend:
 
 ..  _typo3ConfVars_fe_additionalCanonicalizedUrlParameters:
 
+
+additionalCanonicalizedUrlParameters
+------------------------------------
+
 ..  confval:: additionalCanonicalizedUrlParameters
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalCanonicalizedUrlParameters']
     :name: typo3-conf-vars-fe-additionalCanonicalizedUrlParameters
@@ -453,6 +553,10 @@ the TYPO3 frontend:
     See :ref:`canonicalapi-additionalparameters` for details.
 
 ..  _typo3ConfVars_fe_cacheHash:
+
+
+cacheHash
+---------
 
 ..  confval:: cacheHash
     :name: typo3-conf-vars-fe-cacheHash
@@ -564,6 +668,10 @@ the TYPO3 frontend:
     TYPO3_CONF_VARS FE; workspacePreviewLogoutTemplate
 ..  _typo3ConfVars_fe_workspacePreviewLogoutTemplate:
 
+
+workspacePreviewLogoutTemplate
+------------------------------
+
 ..  confval:: workspacePreviewLogoutTemplate
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['workspacePreviewLogoutTemplate']
     :name: typo3-conf-vars-fe-workspacePreviewLogoutTemplate
@@ -580,6 +688,10 @@ the TYPO3 frontend:
 ..  index::
     TYPO3_CONF_VARS FE; versionNumberInFilename
 ..  _typo3ConfVars_fe_versionNumberInFilename:
+
+
+versionNumberInFilename
+-----------------------
 
 ..  confval:: versionNumberInFilename
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename']
@@ -605,6 +717,10 @@ the TYPO3 frontend:
     TYPO3_CONF_VARS FE; contentRenderingTemplates
 ..  _typo3ConfVars_fe_contentRenderingTemplates:
 
+
+contentRenderingTemplates
+-------------------------
+
 ..  confval:: contentRenderingTemplates
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates']
     :name: typo3-conf-vars-fe-contentRenderingTemplates
@@ -624,6 +740,10 @@ the TYPO3 frontend:
 ..  index::
     TYPO3_CONF_VARS FE; typolinkBuilder
 ..  _typo3ConfVars_fe_typolinkBuilder:
+
+
+typolinkBuilder
+---------------
 
 ..  confval:: typolinkBuilder
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['typolinkBuilder']
@@ -653,12 +773,20 @@ the TYPO3 frontend:
     TYPO3_CONF_VARS FE; passwordHashing
 ..  _typo3ConfVars_fe_passwordHashing:
 
+
+passwordHashing
+---------------
+
 ..  confval:: passwordHashing
 
 
 ..  index::
     TYPO3_CONF_VARS FE; passwordHashing className
 ..  _typo3ConfVars_fe_passwordHashing_className:
+
+
+className
+---------
 
 ..  confval:: className
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['className']
@@ -682,6 +810,10 @@ the TYPO3 frontend:
     TYPO3_CONF_VARS FE; passwordHashing options
 ..  _typo3ConfVars_fe_passwordHashing_options:
 
+
+options
+-------
+
 ..  confval:: options
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordHashing']['options']
     :name: typo3-conf-vars-fe-options
@@ -694,6 +826,10 @@ the TYPO3 frontend:
 ..  index::
     TYPO3_CONF_VARS FE; passwordPolicy
 ..  _typo3ConfVars_fe_passwordPolicy:
+
+
+passwordPolicy
+--------------
 
 ..  confval:: passwordPolicy
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['passwordPolicy']
@@ -708,6 +844,10 @@ the TYPO3 frontend:
     TYPO3_CONF_VARS FE; exposeRedirectInformation
 ..  _typo3ConfVars_fe_exposeRedirectInformation:
 
+
+exposeRedirectInformation
+-------------------------
+
 ..  confval:: exposeRedirectInformation
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['exposeRedirectInformation']
     :name: typo3-conf-vars-fe-exposeRedirectInformation
@@ -721,6 +861,10 @@ the TYPO3 frontend:
 ..  index::
     TYPO3_CONF_VARS FE; contentSecurityPolicyReportingUrl
 ..  _typo3ConfVars_fe_contentSecurityPolicyReportingUrl:
+
+
+contentSecurityPolicyReportingUrl
+---------------------------------
 
 ..  confval:: contentSecurityPolicyReportingUrl
     :Path: $GLOBALS['TYPO3_CONF_VARS']['FE']['contentSecurityPolicyReportingUrl']

--- a/Documentation/Configuration/Typo3ConfVars/GFX.rst
+++ b/Documentation/Configuration/Typo3ConfVars/GFX.rst
@@ -31,6 +31,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_thumbnails:
 
+
+thumbnails
+----------
+
 ..  confval:: thumbnails
     :name: globals-typo3-conf-vars-sys-gfx-thumbnails
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['thumbnails']
@@ -42,6 +46,10 @@ This variable can be set in one of the following files:
 ..  index::
     TYPO3_CONF_VARS GFX; imagefile_ext
 ..  _typo3ConfVars_gfx_imagefile_ext:
+
+
+imagefile_ext
+-------------
 
 ..  confval:: imagefile_ext
     :name: globals-typo3-conf-vars-sys-gfx-imagefile_ext
@@ -66,6 +74,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_enabled:
 
+
+processor_enabled
+-----------------
+
 ..  confval:: processor_enabled
     :name: globals-typo3-conf-vars-sys-gfx-processor_enabled
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_enabled']
@@ -76,6 +88,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_path:
 
+
+processor_path
+--------------
+
 ..  confval:: processor_path
     :name: globals-typo3-conf-vars-sys-gfx-processor_path
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_path']
@@ -85,6 +101,10 @@ This variable can be set in one of the following files:
     Path to the IM tools convert, combine, identify.
 
 ..  _typo3ConfVars_gfx_processor:
+
+
+processor
+---------
 
 ..  confval:: processor
     :name: globals-typo3-conf-vars-sys-gfx-processor
@@ -102,6 +122,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_effects:
 
+
+processor_effects
+-----------------
+
 ..  confval:: processor_effects
     :name: globals-typo3-conf-vars-sys-gfx-processor_effects
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_effects']
@@ -111,6 +135,10 @@ This variable can be set in one of the following files:
     If enabled, apply blur and sharpening in ImageMagick/GraphicsMagick functions
 
 ..  _typo3ConfVars_gfx_processor_allowUpscaling:
+
+
+processor_allowUpscaling
+------------------------
 
 ..  confval:: processor_allowUpscaling
     :name: globals-typo3-conf-vars-sys-gfx-processor_allowUpscaling
@@ -122,6 +150,10 @@ This variable can be set in one of the following files:
     :php:`\TYPO3\CMS\Core\Imaging\GraphicalFunctions`)
 
 ..  _typo3ConfVars_gfx_processor_allowFrameSelection:
+
+
+processor_allowFrameSelection
+-----------------------------
 
 ..  confval:: processor_allowFrameSelection
     :name: globals-typo3-conf-vars-sys-gfx-processor_allowFrameSelection
@@ -136,6 +168,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_stripColorProfileByDefault:
 
+
+processor_stripColorProfileByDefault
+------------------------------------
+
 ..  confval:: processor_stripColorProfileByDefault
     :name: globals-typo3-conf-vars-sys-gfx-processor_stripColorProfileByDefault
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileByDefault']
@@ -147,6 +183,10 @@ This variable can be set in one of the following files:
     for IMAGE generation.
 
 ..  _typo3ConfVars_gfx_processor_stripColorProfileCommand:
+
+
+processor_stripColorProfileCommand
+----------------------------------
 
 ..  confval:: processor_stripColorProfileCommand
     :name: globals-typo3-conf-vars-sys-gfx-processor_stripColorProfileCommand
@@ -180,6 +220,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_stripColorProfileParameters:
 
+
+processor_stripColorProfileParameters
+-------------------------------------
+
 ..  confval:: processor_stripColorProfileParameters
     :name: globals-typo3-conf-vars-sys-gfx-processor_stripColorProfileParameters
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_stripColorProfileParameters']
@@ -193,6 +237,10 @@ This variable can be set in one of the following files:
     for details.
 
 ..  _typo3ConfVars_gfx_processor_colorspace:
+
+
+processor_colorspace
+--------------------
 
 ..  confval:: processor_colorspace
     :name: globals-typo3-conf-vars-sys-gfx-processor_colorspace
@@ -219,6 +267,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_processor_interlace:
 
+
+processor_interlace
+-------------------
+
 ..  confval:: processor_interlace
     :name: globals-typo3-conf-vars-sys-gfx-processor_interlace
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['processor_interlace']
@@ -233,6 +285,10 @@ This variable can be set in one of the following files:
 
 ..  _typo3ConfVars_gfx_jpg_quality:
 
+
+jpg_quality
+-----------
+
 ..  confval:: jpg_quality
     :name: globals-typo3-conf-vars-sys-gfx-jpg_quality
     :Path: $GLOBALS['TYPO3_CONF_VARS']['GFX']['jpg_quality']
@@ -246,6 +302,10 @@ This variable can be set in one of the following files:
     Default JPEG generation quality
 
 ..  _typo3ConfVars_gfx_webp_quality:
+
+
+webp_quality
+------------
 
 ..  confval:: webp_quality
     :name: globals-typo3-conf-vars-sys-gfx-webp_quality

--- a/Documentation/Configuration/Typo3ConfVars/HTTP.rst
+++ b/Documentation/Configuration/Typo3ConfVars/HTTP.rst
@@ -29,6 +29,10 @@ for more background information on many of those settings.
 
 ..  _typo3ConfVars_http_allow_redirects:
 
+
+allow_redirects
+---------------
+
 ..  confval:: allow_redirects
     :name: globals-typo3-conf-vars-sys-http-allow_redirects
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']
@@ -68,6 +72,10 @@ for more background information on many of those settings.
 ..  _typo3ConfVars_http_allowed_hosts:
 
 
+
+allowed_hosts
+-------------
+
 ..  confval:: allowed_hosts
     :name: globals-typo3-conf-vars-sys-http-allowed_hosts
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']
@@ -103,6 +111,10 @@ for more background information on many of those settings.
 
 ..  _typo3ConfVars_http_cert:
 
+
+cert
+----
+
 ..  confval:: cert
     :name: globals-typo3-conf-vars-sys-http-cert
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['cert']
@@ -115,6 +127,10 @@ for more background information on many of those settings.
 
 ..  _typo3ConfVars_http_connect_timeout:
 
+
+connect_timeout
+---------------
+
 ..  confval:: connect_timeout
     :name: globals-typo3-conf-vars-sys-http-connect_timeout
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout']
@@ -125,6 +141,10 @@ for more background information on many of those settings.
     connecting to a remote host
 
 ..  _typo3ConfVars_http_proxy:
+
+
+proxy
+-----
 
 ..  confval:: proxy
     :name: globals-typo3-conf-vars-sys-http-proxy
@@ -145,6 +165,10 @@ for more background information on many of those settings.
 
 ..  _typo3ConfVars_http_ssl_key:
 
+
+ssl_key
+-------
+
 ..  confval:: ssl_key
     :name: globals-typo3-conf-vars-sys-http-ssl_key
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['ssl_key']
@@ -155,6 +179,10 @@ for more background information on many of those settings.
     `Guzzle option ssl-key <https://docs.guzzlephp.org/en/latest/request-options.html#ssl-key>`__
 
 ..  _typo3ConfVars_http_timeout:
+
+
+timeout
+-------
 
 ..  confval:: timeout
     :name: globals-typo3-conf-vars-sys-http-timeout
@@ -171,6 +199,10 @@ for more background information on many of those settings.
 
 ..  _typo3ConfVars_http_verify:
 
+
+verify
+------
+
 ..  confval:: verify
     :name: globals-typo3-conf-vars-sys-http-verify
     :Path: $GLOBALS['TYPO3_CONF_VARS']['HTTP']['verify']
@@ -181,6 +213,10 @@ for more background information on many of those settings.
     `Guzzle option verify <https://docs.guzzlephp.org/en/latest/request-options.html#verify>`__
 
 ..  _typo3ConfVars_http_version:
+
+
+version
+-------
 
 ..  confval:: version
     :name: globals-typo3-conf-vars-sys-http-version

--- a/Documentation/Configuration/Typo3ConfVars/SYS.rst
+++ b/Documentation/Configuration/Typo3ConfVars/SYS.rst
@@ -26,6 +26,10 @@ configuration.
     :display: tree
     :type:
 
+
+caching
+-------
+
 ..  confval:: caching
     :name: globals-typo3-conf-vars-sys-caching
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']
@@ -47,6 +51,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_fileCreateMask:
 
+
+fileCreateMask
+--------------
+
 ..  confval:: fileCreateMask
     :name: globals-typo3-conf-vars-sys-fileCreateMask
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['fileCreateMask']
@@ -57,6 +65,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_folderCreateMask:
 
+
+folderCreateMask
+----------------
+
 ..  confval:: folderCreateMask
     :name: globals-typo3-conf-vars-sys-folderCreateMask
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask']
@@ -66,6 +78,10 @@ configuration.
     As above, but for folders.
 
 ..  _typo3ConfVars_sys_createGroup:
+
+
+createGroup
+-----------
 
 ..  confval:: createGroup
     :name: globals-typo3-conf-vars-sys-createGroup
@@ -86,6 +102,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_sitename:
 
+
+sitename
+--------
+
 ..  confval:: sitename
     :name: globals-typo3-conf-vars-sys-sitename
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['sitename']
@@ -95,6 +115,10 @@ configuration.
     Name of the base site.
 
 ..  _typo3ConfVars_sys_defaultScheme:
+
+
+defaultScheme
+-------------
 
 ..  confval:: defaultScheme
     :name: globals-typo3-conf-vars-sys-defaultScheme
@@ -107,6 +131,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_encryptionKey:
 
+
+encryptionKey
+-------------
+
 ..  confval:: encryptionKey
     :name: globals-typo3-conf-vars-sys-encryptionKey
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']
@@ -115,13 +143,17 @@ configuration.
 
     This is a "salt" used for encryption, CRC checksums and
     validations. You can enter any string here but try to keep it
-    secret. 
-    
+    secret.
+
   **When changing this value, flush all the caches:** A change to this value might invalidate
     temporary information, such as URLs mappings.
-    
+
 
 ..  _typo3ConfVars_sys_cookieDomain:
+
+
+cookieDomain
+------------
 
 ..  confval:: cookieDomain
     :name: globals-typo3-conf-vars-sys-cookieDomain
@@ -145,6 +177,10 @@ configuration.
     respectively.
 
 ..  _typo3ConfVars_sys_trustedHostsPattern:
+
+
+trustedHostsPattern
+-------------------
 
 ..  confval:: trustedHostsPattern
     :name: globals-typo3-conf-vars-sys-trustedHostsPattern
@@ -182,6 +218,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_devIPmask:
 
+
+devIPmask
+---------
+
 ..  confval:: devIPmask
     :name: globals-typo3-conf-vars-sys-devIPmask
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']
@@ -199,6 +239,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_ddmmyy:
 
+
+ddmmyy
+------
+
 ..  versionchanged:: 12.4.14/13.1.0
     The default value has been changed from 'd-m-y' to 'Y-m-d' (ISO 8601) to
     avoid unclear dates.
@@ -214,6 +258,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_hhmm:
 
+
+hhmm
+----
+
 ..  confval:: hhmm
     :name: globals-typo3-conf-vars-sys-hhmm
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['hhmm']
@@ -223,6 +271,10 @@ configuration.
     Format of Hours-Minutes - see PHP-function `date() <https://www.php.net/manual/en/function.date.php>`__
 
 ..  _typo3ConfVars_sys_loginCopyrightWarrantyProvider:
+
+
+loginCopyrightWarrantyProvider
+------------------------------
 
 ..  confval:: loginCopyrightWarrantyProvider
     :name: globals-typo3-conf-vars-sys-loginCopyrightWarrantyProvider
@@ -235,6 +287,10 @@ configuration.
     (You must also set URL below).
 
 ..  _typo3ConfVars_sys_loginCopyrightWarrantyURL:
+
+
+loginCopyrightWarrantyURL
+-------------------------
 
 ..  confval:: loginCopyrightWarrantyURL
     :name: globals-typo3-conf-vars-sys-loginCopyrightWarrantyURL
@@ -251,6 +307,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_textfile_ext:
 
+
+textfile_ext
+------------
+
 ..  confval:: textfile_ext
     :name: globals-typo3-conf-vars-sys-textfile_ext
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['textfile_ext']
@@ -262,6 +322,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_mediafile_ext:
 
+
+mediafile_ext
+-------------
+
 ..  confval:: mediafile_ext
     :name: globals-typo3-conf-vars-sys-mediafile_ext
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
@@ -272,6 +336,10 @@ configuration.
     Must be in lowercase with no spaces in between.
 
 ..  _typo3ConfVars_sys_miscfile_ext:
+
+
+miscfile_ext
+------------
 
 ..  confval:: miscfile_ext
     :name: globals-typo3-conf-vars-sys-miscfile-ext
@@ -289,6 +357,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_binPath:
 
+
+binPath
+-------
+
 ..  confval:: binPath
     :name: globals-typo3-conf-vars-sys-binPath
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['binPath']
@@ -302,6 +374,10 @@ configuration.
 ..  index::
     TYPO3_CONF_VARS SYS; binSetup
 ..  _typo3ConfVars_sys_binSetup:
+
+
+binSetup
+--------
 
 ..  confval:: binSetup
     :name: globals-typo3-conf-vars-sys-binSetup
@@ -318,6 +394,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_setMemoryLimit:
 
+
+setMemoryLimit
+--------------
+
 ..  confval:: setMemoryLimit
     :name: globals-typo3-conf-vars-sys-setMemoryLimit
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['setMemoryLimit']
@@ -329,6 +409,10 @@ configuration.
     :php:`ini_set()` is not disabled by your sysadmin.
 
 ..  _typo3ConfVars_sys_phpTimeZone:
+
+
+phpTimeZone
+-----------
 
 ..  confval:: phpTimeZone
     :name: globals-typo3-conf-vars-sys-phpTimeZone
@@ -346,6 +430,10 @@ configuration.
     "UTC" is used instead.
 
 ..  _typo3ConfVars_sys_UTF8filesystem:
+
+
+UTF8filesystem
+--------------
 
 ..  confval:: UTF8filesystem
     :name: globals-typo3-conf-vars-sys-UTF8filesystem
@@ -369,6 +457,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_systemLocale:
 
+
+systemLocale
+------------
+
 ..  confval:: systemLocale
     :name: globals-typo3-conf-vars-sys-systemLocale
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']
@@ -381,6 +473,10 @@ configuration.
     `php function setlocale() <https://www.php.net/manual/en/function.setlocale.php>`__.
 
 ..  _typo3ConfVars_sys_reverseProxyIP:
+
+
+reverseProxyIP
+--------------
 
 ..  confval:: reverseProxyIP
     :name: globals-typo3-conf-vars-sys-reverseProxyIP
@@ -408,6 +504,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_reverseProxyHeaderMultiValue:
 
+
+reverseProxyHeaderMultiValue
+----------------------------
+
 ..  confval:: reverseProxyHeaderMultiValue
     :name: globals-typo3-conf-vars-sys-reverseProxyHeaderMultiValue
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyHeaderMultiValue']
@@ -430,6 +530,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_reverseProxyPrefix:
 
+
+reverseProxyPrefix
+------------------
+
 ..  confval:: reverseProxyPrefix
     :name: globals-typo3-conf-vars-sys-reverseProxyPrefix
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefix']
@@ -443,6 +547,10 @@ configuration.
     be set to :php:`prefix`
 
 ..  _typo3ConfVars_sys_reverseProxySSL:
+
+
+reverseProxySSL
+---------------
 
 ..  confval:: reverseProxySSL
     :name: globals-typo3-conf-vars-sys-reverseProxySSL
@@ -469,6 +577,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_reverseProxyPrefixSSL:
 
+
+reverseProxyPrefixSSL
+---------------------
+
 ..  confval:: reverseProxyPrefixSSL
     :name: globals-typo3-conf-vars-sys-reverseProxyPrefixSSL
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['reverseProxyPrefixSSL']
@@ -480,6 +592,10 @@ configuration.
     :ref:`[SYS][reverseProxyPrefix]<typo3ConfVars_sys_reverseProxyPrefix>`.
 
 ..  _typo3ConfVars_sys_displayErrors:
+
+
+displayErrors
+-------------
 
 ..  confval:: displayErrors
     :name: globals-typo3-conf-vars-sys-displayErrors
@@ -521,6 +637,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_productionExceptionHandler:
 
+
+productionExceptionHandler
+--------------------------
+
 ..  confval:: productionExceptionHandler
     :name: globals-typo3-conf-vars-sys-productionExceptionHandler
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['productionExceptionHandler']
@@ -538,6 +658,10 @@ configuration.
     :ref:`[SYS][devIPmask]<typo3ConfVars_sys_devIPmask>` does not match the user's IP.
 
 ..  _typo3ConfVars_sys_debugExceptionHandler:
+
+
+debugExceptionHandler
+---------------------
 
 ..  confval:: debugExceptionHandler
     :name: globals-typo3-conf-vars-sys-debugExceptionHandler
@@ -557,6 +681,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_errorHandler:
 
+
+errorHandler
+------------
+
 ..  confval:: errorHandler
     :name: globals-typo3-conf-vars-sys-errorHandler
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandler']
@@ -575,6 +703,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_errorHandlerErrors:
 
+
+errorHandlerErrors
+------------------
+
 ..  confval:: errorHandlerErrors
     :name: globals-typo3-conf-vars-sys-errorHandlerErrors
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['errorHandlerErrors']
@@ -592,6 +724,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_exceptionalErrors:
 
+
+exceptionalErrors
+-----------------
+
 ..  confval:: exceptionalErrors
     :name: globals-typo3-conf-vars-sys-exceptionalErrors
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['exceptionalErrors']
@@ -607,6 +743,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_belogErrorReporting:
 
+
+belogErrorReporting
+-------------------
+
 ..  confval:: belogErrorReporting
     :name: globals-typo3-conf-vars-sys-belogErrorReporting
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['belogErrorReporting']
@@ -620,6 +760,10 @@ configuration.
     (see `PHP documentation <https://www.php.net/manual/en/errorfunc.constants.php>`__).
 
 ..  _typo3ConfVars_sys_generateApacheHtaccess:
+
+
+generateApacheHtaccess
+----------------------
 
 ..  confval:: generateApacheHtaccess
     :name: globals-typo3-conf-vars-sys-generateApacheHtaccess
@@ -635,6 +779,10 @@ configuration.
     want to use your own rule sets.
 
 ..  _typo3ConfVars_sys_ipAnonymization:
+
+
+ipAnonymization
+---------------
 
 ..  confval:: ipAnonymization
     :name: globals-typo3-conf-vars-sys-ipAnonymization
@@ -657,6 +805,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_systemMaintainers:
 
+
+systemMaintainers
+-----------------
+
 ..  confval:: systemMaintainers
     :name: globals-typo3-conf-vars-sys-systemMaintainers
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']
@@ -666,6 +818,10 @@ configuration.
     A list of backend user IDs that are allowed to access the Install Tool
 
 ..  _typo3ConfVars_sys_features:
+
+
+features
+--------
 
 ..  confval:: features
    :name: globals-typo3-conf-vars-sys-features
@@ -804,6 +960,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_availablePasswordHashAlgorithms:
 
+
+availablePasswordHashAlgorithms
+-------------------------------
+
 ..  confval:: availablePasswordHashAlgorithms
    :name: globals-typo3-conf-vars-sys-availablePasswordHashAlgorithms
    :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['availablePasswordHashAlgorithms']
@@ -814,6 +974,10 @@ configuration.
    additional mechanisms here.
 
 ..  _typo3ConfVars_sys_linkHandler:
+
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['linkHandler']
+-------------------------------------------------
 
 ..  confval:: $GLOBALS['TYPO3_CONF_VARS']['SYS']['linkHandler']
     :name: globals-typo3-conf-vars-sys-linkHandler
@@ -879,6 +1043,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_passwordPolicies:
 
+
+passwordPolicies
+----------------
+
 ..  confval::passwordPolicies
     :name: globals-typo3-conf-vars-sys-passwordPolicies
     :Path: $GLOBALS['TYPO3_CONF_VARS']['SYS']['passwordPolicies']
@@ -915,6 +1083,10 @@ configuration.
 
 ..  _typo3ConfVars_sys_messenger:
 
+
+messenger
+---------
+
 ..  confval:: messenger
     :name: globals-typo3-conf-vars-sys-messenger
 
@@ -946,6 +1118,10 @@ configuration.
             :ref:`message-bus-routing`
 
 ..  _typo3ConfVars_sys_localization:
+
+
+localization
+------------
 
 ..  confval:: localization
     :name: globals-typo3-conf-vars-sys-localization
@@ -986,9 +1162,13 @@ configuration.
                 ];
 
     ..  seealso::
-    
+
         *   `Adding custom languages <https://docs.typo3.org/permalink/t3coreapi:xliff-translating-languages>`_
         *   `Feature: #86913 - Automatic support for language files of languages with region suffix <https://docs.typo3.org/permalink/changelog:feature-86913-1673955088>`_
+
+
+FileInfo
+--------
 
 ..  confval:: FileInfo
     :name: globals-typo3-conf-vars-sys-FileInfo
@@ -1049,6 +1229,10 @@ configuration.
 
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['FileInfo']['mimeTypeCompatibility']['text/plain']['foo'] =
                 'text/x-foo';
+
+
+allowedPhpDisableFunctions
+--------------------------
 
 ..  confval:: allowedPhpDisableFunctions
     :name: globals-typo3-conf-vars-sys-allowedPhpDisableFunctions


### PR DESCRIPTION
# Description
Backport of #6765 to `13.4`.

Manual cherry-pick — automatic backport failed on several conflicts.
Resolved as follows:

*   Two files (`PasswordPolicies/Validator/Index.rst`,
    `Typo3ConfVars/LANG.rst`) don't exist on `13.4` at all (main/14.3-only
    additions) - removed them from the resulting tree.
*   Several confvals the PR adds headings for don't exist on `13.4` yet,
    either because they're `versionadded:: 14.0` (e.g. `username` in the
    Redis backend options, `installToolSessionHandler`,
    `imageFileConversionFormats`) or because they're a separate,
    apparently never-completed backport gap unrelated to this heading-only
    PR (`rateLimiter`, and a confval-description block on
    `ModifyClearCacheActionsEvent.rst`) - dropped the corresponding
    heading/section in each case, since there's nothing to attach a
    heading to.
*   `SiteHandling/AddLanguages.rst`: `13.4` still has the (deprecated but
    not yet removed) `typo3Language` confval, which no longer exists on
    `main`. Added a heading for it too, consistent with the rest of this
    PR's pattern.
*   `Typo3ConfVars/SYS.rst`: kept a pre-existing `13.4`-specific
    `versionchanged:: 12.4.14/13.1.0` note (about the `ddmmyy` default
    format) that no longer exists on `main`, and added the new `ddmmyy`
    heading around it. Also kept `13.4`'s own "Admin Tools > Settings"
    wording where it read "System > Settings" upstream - unrelated
    pre-existing divergence, not part of this PR.

Everything else applied cleanly.